### PR TITLE
OBS-03: Instrument installed app loading performance

### DIFF
--- a/core/apps/AGENTS.md
+++ b/core/apps/AGENTS.md
@@ -64,9 +64,9 @@ list-driven requests or `lifecycle_start` for foreground refreshes. `UsageStatsR
 `usage_stats_load` for lifecycle refreshes. Single-package detail queries are outside both bulk
 traces.
 
-Keep trace, metric, and attribute names private beside the emitting repository. Scope every trace
-with `use`, record one terminal outcome, preserve cancellation, and aggregate bulk counts and
-durations rather than creating per-app traces.
+Keep operation-specific trace, metric, and attribute names private beside the emitting repository.
+Scope every trace with `startCancellableTrace`, record one terminal outcome, preserve cancellation,
+and aggregate bulk counts and durations rather than creating per-app traces.
 
 ## Signing Semantics
 

--- a/core/apps/AGENTS.md
+++ b/core/apps/AGENTS.md
@@ -54,6 +54,20 @@ Attach a throwable only for unexpected recoverable degradation or terminal failu
 layer that owns that outcome. Let coroutine cancellation propagate without logging it. Package names
 and APK file paths are valid diagnostic context.
 
+## Performance Traces
+
+`InstalledAppsRepositoryImpl` owns `installed_apps_load` around package querying and basic
+`InstalledApp` mapping only. Storage and usage enrichment must not extend this trace.
+
+`StorageStatsRepositoryImpl` owns `storage_stats_load`; its bounded trigger is `installed_apps` for
+list-driven requests or `lifecycle_start` for foreground refreshes. `UsageStatsRepositoryImpl` owns
+`usage_stats_load` for lifecycle refreshes. Single-package detail queries are outside both bulk
+traces.
+
+Keep trace, metric, and attribute names private beside the emitting repository. Scope every trace
+with `use`, record one terminal outcome, preserve cancellation, and aggregate bulk counts and
+durations rather than creating per-app traces.
+
 ## Signing Semantics
 
 * `apkContentsSigners` is the current signer set. Multiple current signers form one package identity

--- a/core/apps/AGENTS.md
+++ b/core/apps/AGENTS.md
@@ -54,20 +54,6 @@ Attach a throwable only for unexpected recoverable degradation or terminal failu
 layer that owns that outcome. Let coroutine cancellation propagate without logging it. Package names
 and APK file paths are valid diagnostic context.
 
-## Performance Traces
-
-`InstalledAppsRepositoryImpl` owns `installed_apps_load` around package querying and basic
-`InstalledApp` mapping only. Storage and usage enrichment must not extend this trace.
-
-`StorageStatsRepositoryImpl` owns `storage_stats_load`; its bounded trigger is `installed_apps` for
-list-driven requests or `lifecycle_start` for foreground refreshes. `UsageStatsRepositoryImpl` owns
-`usage_stats_load` for lifecycle refreshes. Single-package detail queries are outside both bulk
-traces.
-
-Keep operation-specific trace, metric, and attribute names private beside the emitting repository.
-Scope every trace with `startCancellableTrace`, record one terminal outcome, preserve cancellation,
-and aggregate bulk counts and durations rather than creating per-app traces.
-
 ## Signing Semantics
 
 * `apkContentsSigners` is the current signer set. Multiple current signers form one package identity

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
@@ -22,13 +23,16 @@ import sk.styk.martin.apkanalyzer.core.apps.model.resolveAppCategory
 import sk.styk.martin.apkanalyzer.core.apps.storagestats.StorageStatsRepository
 import sk.styk.martin.apkanalyzer.core.apps.usagestats.UsageStatsRepository
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
+import sk.styk.martin.apkanalyzer.core.common.coroutines.runCatchingCancellable
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.model.bytes
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
 import java.io.File
 import java.time.Instant
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.measureTimedValue
 
 internal const val INSTALLED_APPS = "InstalledApps"
 
@@ -40,23 +44,15 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
     storageStatsRepository: StorageStatsRepository,
     usageStatsRepository: UsageStatsRepository,
     appScope: CoroutineScope,
+    private val performanceTracker: PerformanceTracker,
 ) : InstalledAppsRepository {
 
-    @Suppress("TooGenericExceptionCaught")
     private val cachedApps = packageChangesObserver.observe()
-        .onStart { emit(Unit) }
-        .mapLatest {
+        .map { InstalledAppsLoadTrigger.PackageChange }
+        .onStart { emit(InstalledAppsLoadTrigger.Initial) }
+        .mapLatest { trigger ->
             Logger.d(INSTALLED_APPS, "Installed apps loading started")
-            try {
-                val apps = loadAllApps()
-                Logger.i(INSTALLED_APPS, "Installed apps loading finished: ${apps.size} apps loaded")
-                apps
-            } catch (failure: Throwable) {
-                if (failure !is CancellationException) {
-                    Logger.e(INSTALLED_APPS, failure, "Installed apps loading failed")
-                }
-                throw failure
-            }
+            loadAllApps(trigger)
         }
         .onEach { apps -> storageStatsRepository.requestTotalSizes(apps.map { it.packageName }) }
         .flatMapLatest { apps ->
@@ -82,16 +78,54 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
     override fun apps(): Flow<List<InstalledApp>> = cachedApps
 
     @SuppressLint("QueryPermissionsNeeded")
-    private fun loadAllApps(): List<InstalledApp> {
-        Logger.d(INSTALLED_APPS, "Installed apps package query started")
-        val packages = packageManager.getInstalledPackages(PackageManager.GET_PERMISSIONS)
-        Logger.d(INSTALLED_APPS, "Installed apps package query finished: ${packages.size} packages found")
+    private suspend fun loadAllApps(trigger: InstalledAppsLoadTrigger): List<InstalledApp> =
+        performanceTracker.startTrace(TRACE_INSTALLED_APPS_LOAD).use { trace ->
+            trace.putAttribute(ATTRIBUTE_TRIGGER, trigger.attributeValue)
+            val result = try {
+                runCatchingCancellable {
+                    Logger.d(INSTALLED_APPS, "Installed apps package query started")
+                    val packageQuery = measureTimedValue {
+                        packageManager.getInstalledPackages(PackageManager.GET_PERMISSIONS)
+                    }
+                    trace.putMetric(METRIC_PACKAGE_QUERY_US, packageQuery.duration.inWholeMicroseconds)
+                    Logger.d(
+                        INSTALLED_APPS,
+                        "Installed apps package query finished: ${packageQuery.value.size} packages found",
+                    )
 
-        Logger.d(INSTALLED_APPS, "Installed apps mapping started")
-        val apps = packages.mapNotNull { packageInfo -> packageInfo.applicationInfo?.let { packageInfo.toInstalledApp() } }
-        Logger.d(INSTALLED_APPS, "Installed apps mapping finished: ${apps.size} apps mapped")
-        return apps
-    }
+                    Logger.d(INSTALLED_APPS, "Installed apps mapping started")
+                    val appMapping = measureTimedValue {
+                        packageQuery.value.mapNotNull { packageInfo ->
+                            packageInfo.applicationInfo?.let { packageInfo.toInstalledApp() }
+                        }
+                    }
+                    trace.putMetric(METRIC_APP_MAPPING_US, appMapping.duration.inWholeMicroseconds)
+                    trace.putMetric(METRIC_APP_COUNT, appMapping.value.size.toLong())
+                    trace.putAttribute(ATTRIBUTE_APP_COUNT_BUCKET, appCountBucket(appMapping.value.size))
+                    Logger.d(
+                        INSTALLED_APPS,
+                        "Installed apps mapping finished: ${appMapping.value.size} apps mapped",
+                    )
+                    appMapping.value
+                }
+            } catch (cancellation: CancellationException) {
+                trace.putAttribute(ATTRIBUTE_OUTCOME, OUTCOME_CANCELLED)
+                throw cancellation
+            }
+
+            result.fold(
+                onSuccess = { apps ->
+                    trace.putAttribute(ATTRIBUTE_OUTCOME, OUTCOME_SUCCESS)
+                    Logger.i(INSTALLED_APPS, "Installed apps loading finished: ${apps.size} apps loaded")
+                    apps
+                },
+                onFailure = { failure ->
+                    trace.putAttribute(ATTRIBUTE_OUTCOME, OUTCOME_ERROR)
+                    Logger.e(INSTALLED_APPS, failure, "Installed apps loading failed")
+                    throw failure
+                },
+            )
+        }
 
     private fun PackageInfo.toInstalledApp(): InstalledApp {
         val appInfo = applicationInfo
@@ -116,3 +150,36 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
         )
     }
 }
+
+private enum class InstalledAppsLoadTrigger(val attributeValue: String) {
+    Initial(TRIGGER_INITIAL),
+    PackageChange(TRIGGER_PACKAGE_CHANGE),
+}
+
+private fun appCountBucket(appCount: Int): String = when (appCount) {
+    in 0..APP_COUNT_SMALL_MAX -> "0_49"
+    in APP_COUNT_MEDIUM_MIN..APP_COUNT_MEDIUM_MAX -> "50_99"
+    in APP_COUNT_LARGE_MIN..APP_COUNT_LARGE_MAX -> "100_199"
+    in APP_COUNT_VERY_LARGE_MIN..APP_COUNT_VERY_LARGE_MAX -> "200_399"
+    else -> "400_plus"
+}
+
+private const val TRACE_INSTALLED_APPS_LOAD = "installed_apps_load"
+private const val METRIC_PACKAGE_QUERY_US = "package_query_us"
+private const val METRIC_APP_MAPPING_US = "app_mapping_us"
+private const val METRIC_APP_COUNT = "app_count"
+private const val ATTRIBUTE_OUTCOME = "outcome"
+private const val ATTRIBUTE_TRIGGER = "trigger"
+private const val ATTRIBUTE_APP_COUNT_BUCKET = "app_count_bucket"
+private const val OUTCOME_SUCCESS = "success"
+private const val OUTCOME_ERROR = "error"
+private const val OUTCOME_CANCELLED = "cancelled"
+private const val TRIGGER_INITIAL = "initial"
+private const val TRIGGER_PACKAGE_CHANGE = "package_change"
+private const val APP_COUNT_SMALL_MAX = 49
+private const val APP_COUNT_MEDIUM_MIN = 50
+private const val APP_COUNT_MEDIUM_MAX = 99
+private const val APP_COUNT_LARGE_MIN = 100
+private const val APP_COUNT_LARGE_MAX = 199
+private const val APP_COUNT_VERY_LARGE_MIN = 200
+private const val APP_COUNT_VERY_LARGE_MAX = 399

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
@@ -27,6 +27,7 @@ import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.model.bytes
 import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
+import sk.styk.martin.apkanalyzer.core.common.performance.TraceOutcome
 import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
 import java.io.File
 import java.time.Instant
@@ -92,12 +93,12 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
             apps
         }.fold(
             onSuccess = { apps ->
-                trace["outcome"] = "success"
+                trace.setOutcome(TraceOutcome.Success)
                 Logger.i(INSTALLED_APPS, "Installed apps loading finished: ${apps.size} apps loaded")
                 apps
             },
             onFailure = { failure ->
-                trace["outcome"] = "error"
+                trace.setOutcome(TraceOutcome.Error)
                 Logger.e(INSTALLED_APPS, failure, "Installed apps loading failed")
                 throw failure
             },

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
@@ -28,10 +28,10 @@ import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.model.bytes
 import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
+import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
 import java.io.File
 import java.time.Instant
 import javax.inject.Inject
-import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.measureTimedValue
 
 internal const val INSTALLED_APPS = "InstalledApps"
@@ -79,48 +79,43 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
 
     @SuppressLint("QueryPermissionsNeeded")
     private suspend fun loadAllApps(trigger: InstalledAppsLoadTrigger): List<InstalledApp> =
-        performanceTracker.startTrace(TRACE_INSTALLED_APPS_LOAD).use { trace ->
-            trace.putAttribute(ATTRIBUTE_TRIGGER, trigger.attributeValue)
-            val result = try {
-                runCatchingCancellable {
-                    Logger.d(INSTALLED_APPS, "Installed apps package query started")
-                    val packageQuery = measureTimedValue {
-                        packageManager.getInstalledPackages(PackageManager.GET_PERMISSIONS)
-                    }
-                    trace.putMetric(METRIC_PACKAGE_QUERY_US, packageQuery.duration.inWholeMicroseconds)
-                    Logger.d(
-                        INSTALLED_APPS,
-                        "Installed apps package query finished: ${packageQuery.value.size} packages found",
-                    )
-
-                    Logger.d(INSTALLED_APPS, "Installed apps mapping started")
-                    val appMapping = measureTimedValue {
-                        packageQuery.value.mapNotNull { packageInfo ->
-                            packageInfo.applicationInfo?.let { packageInfo.toInstalledApp() }
-                        }
-                    }
-                    trace.putMetric(METRIC_APP_MAPPING_US, appMapping.duration.inWholeMicroseconds)
-                    trace.putMetric(METRIC_APP_COUNT, appMapping.value.size.toLong())
-                    trace.putAttribute(ATTRIBUTE_APP_COUNT_BUCKET, appCountBucket(appMapping.value.size))
-                    Logger.d(
-                        INSTALLED_APPS,
-                        "Installed apps mapping finished: ${appMapping.value.size} apps mapped",
-                    )
-                    appMapping.value
+        performanceTracker.startCancellableTrace(TRACE_INSTALLED_APPS_LOAD) { trace ->
+            trace[ATTRIBUTE_TRIGGER] = trigger.attributeValue
+            val result = runCatchingCancellable {
+                Logger.d(INSTALLED_APPS, "Installed apps package query started")
+                val packageQuery = measureTimedValue {
+                    packageManager.getInstalledPackages(PackageManager.GET_PERMISSIONS)
                 }
-            } catch (cancellation: CancellationException) {
-                trace.putAttribute(ATTRIBUTE_OUTCOME, OUTCOME_CANCELLED)
-                throw cancellation
+                trace[METRIC_PACKAGE_QUERY_US] = packageQuery.duration.inWholeMicroseconds
+                Logger.d(
+                    INSTALLED_APPS,
+                    "Installed apps package query finished: ${packageQuery.value.size} packages found",
+                )
+
+                Logger.d(INSTALLED_APPS, "Installed apps mapping started")
+                val appMapping = measureTimedValue {
+                    packageQuery.value.mapNotNull { packageInfo ->
+                        packageInfo.applicationInfo?.let { packageInfo.toInstalledApp() }
+                    }
+                }
+                trace[METRIC_APP_MAPPING_US] = appMapping.duration.inWholeMicroseconds
+                trace[METRIC_APP_COUNT] = appMapping.value.size.toLong()
+                trace[ATTRIBUTE_APP_COUNT_BUCKET] = appCountBucket(appMapping.value.size)
+                Logger.d(
+                    INSTALLED_APPS,
+                    "Installed apps mapping finished: ${appMapping.value.size} apps mapped",
+                )
+                appMapping.value
             }
 
             result.fold(
                 onSuccess = { apps ->
-                    trace.putAttribute(ATTRIBUTE_OUTCOME, OUTCOME_SUCCESS)
+                    trace[ATTRIBUTE_OUTCOME] = OUTCOME_SUCCESS
                     Logger.i(INSTALLED_APPS, "Installed apps loading finished: ${apps.size} apps loaded")
                     apps
                 },
                 onFailure = { failure ->
-                    trace.putAttribute(ATTRIBUTE_OUTCOME, OUTCOME_ERROR)
+                    trace[ATTRIBUTE_OUTCOME] = OUTCOME_ERROR
                     Logger.e(INSTALLED_APPS, failure, "Installed apps loading failed")
                     throw failure
                 },
@@ -173,7 +168,6 @@ private const val ATTRIBUTE_TRIGGER = "trigger"
 private const val ATTRIBUTE_APP_COUNT_BUCKET = "app_count_bucket"
 private const val OUTCOME_SUCCESS = "success"
 private const val OUTCOME_ERROR = "error"
-private const val OUTCOME_CANCELLED = "cancelled"
 private const val TRIGGER_INITIAL = "initial"
 private const val TRIGGER_PACKAGE_CHANGE = "package_change"
 private const val APP_COUNT_SMALL_MAX = 49

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
@@ -46,14 +45,9 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
     appScope: CoroutineScope,
     private val performanceTracker: PerformanceTracker,
 ) : InstalledAppsRepository {
-
     private val cachedApps = packageChangesObserver.observe()
-        .map { InstalledAppsLoadTrigger.PackageChange }
-        .onStart { emit(InstalledAppsLoadTrigger.Initial) }
-        .mapLatest { trigger ->
-            Logger.d(INSTALLED_APPS, "Installed apps loading started")
-            loadAllApps(trigger)
-        }
+        .onStart { emit(Unit) }
+        .mapLatest { loadAllApps() }
         .onEach { apps -> storageStatsRepository.requestTotalSizes(apps.map { it.packageName }) }
         .flatMapLatest { apps ->
             combine(
@@ -78,49 +72,37 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
     override fun apps(): Flow<List<InstalledApp>> = cachedApps
 
     @SuppressLint("QueryPermissionsNeeded")
-    private suspend fun loadAllApps(trigger: InstalledAppsLoadTrigger): List<InstalledApp> =
-        performanceTracker.startCancellableTrace(TRACE_INSTALLED_APPS_LOAD) { trace ->
-            trace[ATTRIBUTE_TRIGGER] = trigger.attributeValue
-            val result = runCatchingCancellable {
-                Logger.d(INSTALLED_APPS, "Installed apps package query started")
-                val packageQuery = measureTimedValue {
-                    packageManager.getInstalledPackages(PackageManager.GET_PERMISSIONS)
-                }
-                trace[METRIC_PACKAGE_QUERY_US] = packageQuery.duration.inWholeMicroseconds
-                Logger.d(
-                    INSTALLED_APPS,
-                    "Installed apps package query finished: ${packageQuery.value.size} packages found",
-                )
-
-                Logger.d(INSTALLED_APPS, "Installed apps mapping started")
-                val appMapping = measureTimedValue {
-                    packageQuery.value.mapNotNull { packageInfo ->
-                        packageInfo.applicationInfo?.let { packageInfo.toInstalledApp() }
-                    }
-                }
-                trace[METRIC_APP_MAPPING_US] = appMapping.duration.inWholeMicroseconds
-                trace[METRIC_APP_COUNT] = appMapping.value.size.toLong()
-                trace[ATTRIBUTE_APP_COUNT_BUCKET] = appCountBucket(appMapping.value.size)
-                Logger.d(
-                    INSTALLED_APPS,
-                    "Installed apps mapping finished: ${appMapping.value.size} apps mapped",
-                )
-                appMapping.value
+    private suspend fun loadAllApps(): List<InstalledApp> = performanceTracker.startCancellableTrace("installed_apps_load") { trace ->
+        Logger.d(INSTALLED_APPS, "Installed apps loading started")
+        runCatchingCancellable {
+            Logger.d(INSTALLED_APPS, "Installed apps package query started")
+            val packageQuery = measureTimedValue {
+                packageManager.getInstalledPackages(PackageManager.GET_PERMISSIONS)
             }
+            val packages = packageQuery.value
+            trace["package_query_ms"] = packageQuery.duration.inWholeMilliseconds
+            Logger.d(INSTALLED_APPS, "Installed apps package query finished: ${packages.size} packages found")
 
-            result.fold(
-                onSuccess = { apps ->
-                    trace[ATTRIBUTE_OUTCOME] = OUTCOME_SUCCESS
-                    Logger.i(INSTALLED_APPS, "Installed apps loading finished: ${apps.size} apps loaded")
-                    apps
-                },
-                onFailure = { failure ->
-                    trace[ATTRIBUTE_OUTCOME] = OUTCOME_ERROR
-                    Logger.e(INSTALLED_APPS, failure, "Installed apps loading failed")
-                    throw failure
-                },
-            )
-        }
+            Logger.d(INSTALLED_APPS, "Installed apps mapping started")
+            val apps = packages.mapNotNull { packageInfo ->
+                packageInfo.applicationInfo?.let { packageInfo.toInstalledApp() }
+            }
+            trace["app_count"] = apps.size.toLong()
+            Logger.d(INSTALLED_APPS, "Installed apps mapping finished: ${apps.size} apps mapped")
+            apps
+        }.fold(
+            onSuccess = { apps ->
+                trace["outcome"] = "success"
+                Logger.i(INSTALLED_APPS, "Installed apps loading finished: ${apps.size} apps loaded")
+                apps
+            },
+            onFailure = { failure ->
+                trace["outcome"] = "error"
+                Logger.e(INSTALLED_APPS, failure, "Installed apps loading failed")
+                throw failure
+            },
+        )
+    }
 
     private fun PackageInfo.toInstalledApp(): InstalledApp {
         val appInfo = applicationInfo
@@ -145,35 +127,3 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
         )
     }
 }
-
-private enum class InstalledAppsLoadTrigger(val attributeValue: String) {
-    Initial(TRIGGER_INITIAL),
-    PackageChange(TRIGGER_PACKAGE_CHANGE),
-}
-
-private fun appCountBucket(appCount: Int): String = when (appCount) {
-    in 0..APP_COUNT_SMALL_MAX -> "0_49"
-    in APP_COUNT_MEDIUM_MIN..APP_COUNT_MEDIUM_MAX -> "50_99"
-    in APP_COUNT_LARGE_MIN..APP_COUNT_LARGE_MAX -> "100_199"
-    in APP_COUNT_VERY_LARGE_MIN..APP_COUNT_VERY_LARGE_MAX -> "200_399"
-    else -> "400_plus"
-}
-
-private const val TRACE_INSTALLED_APPS_LOAD = "installed_apps_load"
-private const val METRIC_PACKAGE_QUERY_US = "package_query_us"
-private const val METRIC_APP_MAPPING_US = "app_mapping_us"
-private const val METRIC_APP_COUNT = "app_count"
-private const val ATTRIBUTE_OUTCOME = "outcome"
-private const val ATTRIBUTE_TRIGGER = "trigger"
-private const val ATTRIBUTE_APP_COUNT_BUCKET = "app_count_bucket"
-private const val OUTCOME_SUCCESS = "success"
-private const val OUTCOME_ERROR = "error"
-private const val TRIGGER_INITIAL = "initial"
-private const val TRIGGER_PACKAGE_CHANGE = "package_change"
-private const val APP_COUNT_SMALL_MAX = 49
-private const val APP_COUNT_MEDIUM_MIN = 50
-private const val APP_COUNT_MEDIUM_MAX = 99
-private const val APP_COUNT_LARGE_MIN = 100
-private const val APP_COUNT_LARGE_MAX = 199
-private const val APP_COUNT_VERY_LARGE_MIN = 200
-private const val APP_COUNT_VERY_LARGE_MAX = 399

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
@@ -25,7 +25,6 @@ import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.time.measureTimedValue
 
 private const val TAG = "StorageStatsRepositoryImpl"
 
@@ -50,7 +49,7 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
 
     override fun onStart(owner: LifecycleOwner) {
         applicationScope.launch(dispatcherProvider.io()) {
-            fetchTotalSizes(packageNames, TRIGGER_LIFECYCLE_START)
+            fetchTotalSizes(packageNames, "lifecycle_start")
         }
     }
 
@@ -66,7 +65,7 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
     override fun requestTotalSizes(packageNames: List<PackageName>) {
         this.packageNames = packageNames
         applicationScope.launch(dispatcherProvider.io()) {
-            fetchTotalSizes(packageNames, TRIGGER_INSTALLED_APPS)
+            fetchTotalSizes(packageNames, "installed_apps")
         }
     }
 
@@ -88,19 +87,16 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
     }
 
     private suspend fun fetchTotalSizes(packageNames: List<PackageName>, trigger: String) {
-        performanceTracker.startCancellableTrace(TRACE_STORAGE_STATS_LOAD) { trace ->
-            trace[ATTRIBUTE_TRIGGER] = trigger
-            trace[METRIC_REQUESTED_COUNT] = packageNames.size.toLong()
-            val result = runCatchingCancellable {
-                val permissionCheck = measureTimedValue { checkPermission() }
-                trace[METRIC_PERMISSION_CHECK_US] = permissionCheck.duration.inWholeMicroseconds
-                trace[ATTRIBUTE_PERMISSION] = if (permissionCheck.value) PERMISSION_GRANTED else PERMISSION_DENIED
-                isPermissionGranted.value = permissionCheck.value
+        performanceTracker.startCancellableTrace("storage_stats_load") { trace ->
+            trace["trigger"] = trigger
+            runCatchingCancellable {
+                val hasPermission = checkPermission()
+                trace["permission"] = if (hasPermission) "granted" else "denied"
+                isPermissionGranted.value = hasPermission
 
-                if (!permissionCheck.value) {
-                    trace[METRIC_LOADED_COUNT] = 0L
+                if (!hasPermission) {
                     Logger.w(TAG, "Storage stats loading degraded: permission missing")
-                    OUTCOME_DEGRADED
+                    "degraded"
                 } else {
                     Logger.d(TAG, "Storage stats loading started: ${packageNames.size} apps requested")
                     val user = UserHandle.getUserHandleForUid(Process.myUid())
@@ -108,32 +104,28 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
                     var permissionRaceCount = 0
                     var queryFailureCount = 0
                     var lastQueryFailure: IOException? = null
-                    val statsQuery = measureTimedValue {
-                        packageNames.mapNotNull { packageName ->
-                            when (val queryResult = queryPackageSize(user, packageName)) {
-                                is SizeQueryResult.Success -> packageName to queryResult.size
+                    val sizes = packageNames.mapNotNull { packageName ->
+                        when (val queryResult = queryPackageSize(user, packageName)) {
+                            is SizeQueryResult.Success -> packageName to queryResult.size
 
-                                SizeQueryResult.UninstallRace -> {
-                                    uninstallRaceCount++
-                                    null
-                                }
-
-                                SizeQueryResult.PermissionRace -> {
-                                    permissionRaceCount++
-                                    null
-                                }
-
-                                is SizeQueryResult.Failure -> {
-                                    queryFailureCount++
-                                    lastQueryFailure = queryResult.error
-                                    null
-                                }
+                            SizeQueryResult.UninstallRace -> {
+                                uninstallRaceCount++
+                                null
                             }
-                        }.toMap()
-                    }
-                    trace[METRIC_STATS_QUERY_US] = statsQuery.duration.inWholeMicroseconds
-                    trace[METRIC_LOADED_COUNT] = statsQuery.value.size.toLong()
-                    totalSizes.value = statsQuery.value
+
+                            SizeQueryResult.PermissionRace -> {
+                                permissionRaceCount++
+                                null
+                            }
+
+                            is SizeQueryResult.Failure -> {
+                                queryFailureCount++
+                                lastQueryFailure = queryResult.error
+                                null
+                            }
+                        }
+                    }.toMap()
+                    totalSizes.value = sizes
 
                     if (uninstallRaceCount > 0) {
                         Logger.w(TAG, "Storage stats loading degraded: $uninstallRaceCount uninstalled apps skipped")
@@ -147,19 +139,17 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
                     lastQueryFailure?.let {
                         Logger.w(TAG, it, "Storage stats loading degraded: $queryFailureCount app queries failed")
                     }
-                    Logger.i(TAG, "Storage stats loading finished: ${statsQuery.value.size} apps loaded")
+                    Logger.i(TAG, "Storage stats loading finished: ${sizes.size} apps loaded")
                     if (uninstallRaceCount > 0 || permissionRaceCount > 0 || queryFailureCount > 0) {
-                        OUTCOME_DEGRADED
+                        "degraded"
                     } else {
-                        OUTCOME_SUCCESS
+                        "success"
                     }
                 }
-            }
-
-            result.fold(
-                onSuccess = { outcome -> trace[ATTRIBUTE_OUTCOME] = outcome },
+            }.fold(
+                onSuccess = { outcome -> trace["outcome"] = outcome },
                 onFailure = { failure ->
-                    trace[ATTRIBUTE_OUTCOME] = OUTCOME_ERROR
+                    trace["outcome"] = "error"
                     Logger.e(TAG, failure, "Storage stats loading failed")
                     throw failure
                 },
@@ -185,19 +175,3 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
         data class Failure(val error: IOException) : SizeQueryResult
     }
 }
-
-private const val TRACE_STORAGE_STATS_LOAD = "storage_stats_load"
-private const val METRIC_PERMISSION_CHECK_US = "permission_check_us"
-private const val METRIC_STATS_QUERY_US = "stats_query_us"
-private const val METRIC_REQUESTED_COUNT = "requested_count"
-private const val METRIC_LOADED_COUNT = "loaded_count"
-private const val ATTRIBUTE_OUTCOME = "outcome"
-private const val ATTRIBUTE_PERMISSION = "permission"
-private const val ATTRIBUTE_TRIGGER = "trigger"
-private const val OUTCOME_SUCCESS = "success"
-private const val OUTCOME_DEGRADED = "degraded"
-private const val OUTCOME_ERROR = "error"
-private const val PERMISSION_GRANTED = "granted"
-private const val PERMISSION_DENIED = "denied"
-private const val TRIGGER_LIFECYCLE_START = "lifecycle_start"
-private const val TRIGGER_INSTALLED_APPS = "installed_apps"

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
@@ -15,13 +15,17 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
+import sk.styk.martin.apkanalyzer.core.common.coroutines.runCatchingCancellable
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.model.AppSize
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.model.bytes
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.measureTimedValue
 
 private const val TAG = "StorageStatsRepositoryImpl"
 
@@ -32,6 +36,7 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
     private val appOpsManager: AppOpsManager,
     private val dispatcherProvider: DispatcherProvider,
     private val applicationScope: CoroutineScope,
+    private val performanceTracker: PerformanceTracker,
 ) : StorageStatsRepository,
     DefaultLifecycleObserver {
 
@@ -45,7 +50,7 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
 
     override fun onStart(owner: LifecycleOwner) {
         applicationScope.launch(dispatcherProvider.io()) {
-            fetchTotalSizes(packageNames)
+            fetchTotalSizes(packageNames, TRIGGER_LIFECYCLE_START)
         }
     }
 
@@ -61,7 +66,7 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
     override fun requestTotalSizes(packageNames: List<PackageName>) {
         this.packageNames = packageNames
         applicationScope.launch(dispatcherProvider.io()) {
-            fetchTotalSizes(packageNames)
+            fetchTotalSizes(packageNames, TRIGGER_INSTALLED_APPS)
         }
     }
 
@@ -82,53 +87,92 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
         null
     }
 
-    private fun fetchTotalSizes(packageNames: List<PackageName>) {
-        val hasPermission = checkPermission()
-        isPermissionGranted.value = hasPermission
-        if (!hasPermission) {
-            Logger.w(TAG, "Storage stats loading degraded: permission missing")
-            return
-        }
+    private suspend fun fetchTotalSizes(packageNames: List<PackageName>, trigger: String) {
+        performanceTracker.startTrace(TRACE_STORAGE_STATS_LOAD).use { trace ->
+            trace.putAttribute(ATTRIBUTE_TRIGGER, trigger)
+            trace.putMetric(METRIC_REQUESTED_COUNT, packageNames.size.toLong())
+            val result = try {
+                runCatchingCancellable {
+                    val permissionCheck = measureTimedValue { checkPermission() }
+                    trace.putMetric(METRIC_PERMISSION_CHECK_US, permissionCheck.duration.inWholeMicroseconds)
+                    trace.putAttribute(
+                        ATTRIBUTE_PERMISSION,
+                        if (permissionCheck.value) PERMISSION_GRANTED else PERMISSION_DENIED,
+                    )
+                    isPermissionGranted.value = permissionCheck.value
 
-        Logger.d(TAG, "Storage stats loading started: ${packageNames.size} apps requested")
-        val user = UserHandle.getUserHandleForUid(Process.myUid())
-        var uninstallRaceCount = 0
-        var permissionRaceCount = 0
-        var queryFailureCount = 0
-        var lastQueryFailure: IOException? = null
-        val sizes = packageNames.mapNotNull { packageName ->
-            when (val result = queryPackageSize(user, packageName)) {
-                is SizeQueryResult.Success -> packageName to result.size
+                    if (!permissionCheck.value) {
+                        trace.putMetric(METRIC_LOADED_COUNT, 0)
+                        Logger.w(TAG, "Storage stats loading degraded: permission missing")
+                        OUTCOME_DEGRADED
+                    } else {
+                        Logger.d(TAG, "Storage stats loading started: ${packageNames.size} apps requested")
+                        val user = UserHandle.getUserHandleForUid(Process.myUid())
+                        var uninstallRaceCount = 0
+                        var permissionRaceCount = 0
+                        var queryFailureCount = 0
+                        var lastQueryFailure: IOException? = null
+                        val statsQuery = measureTimedValue {
+                            packageNames.mapNotNull { packageName ->
+                                when (val queryResult = queryPackageSize(user, packageName)) {
+                                    is SizeQueryResult.Success -> packageName to queryResult.size
 
-                SizeQueryResult.UninstallRace -> {
-                    uninstallRaceCount++
-                    null
+                                    SizeQueryResult.UninstallRace -> {
+                                        uninstallRaceCount++
+                                        null
+                                    }
+
+                                    SizeQueryResult.PermissionRace -> {
+                                        permissionRaceCount++
+                                        null
+                                    }
+
+                                    is SizeQueryResult.Failure -> {
+                                        queryFailureCount++
+                                        lastQueryFailure = queryResult.error
+                                        null
+                                    }
+                                }
+                            }.toMap()
+                        }
+                        trace.putMetric(METRIC_STATS_QUERY_US, statsQuery.duration.inWholeMicroseconds)
+                        trace.putMetric(METRIC_LOADED_COUNT, statsQuery.value.size.toLong())
+                        totalSizes.value = statsQuery.value
+
+                        if (uninstallRaceCount > 0) {
+                            Logger.w(TAG, "Storage stats loading degraded: $uninstallRaceCount uninstalled apps skipped")
+                        }
+                        if (permissionRaceCount > 0) {
+                            Logger.w(
+                                TAG,
+                                "Storage stats loading degraded: $permissionRaceCount apps skipped after permission changed",
+                            )
+                        }
+                        lastQueryFailure?.let {
+                            Logger.w(TAG, it, "Storage stats loading degraded: $queryFailureCount app queries failed")
+                        }
+                        Logger.i(TAG, "Storage stats loading finished: ${statsQuery.value.size} apps loaded")
+                        if (uninstallRaceCount > 0 || permissionRaceCount > 0 || queryFailureCount > 0) {
+                            OUTCOME_DEGRADED
+                        } else {
+                            OUTCOME_SUCCESS
+                        }
+                    }
                 }
-
-                SizeQueryResult.PermissionRace -> {
-                    permissionRaceCount++
-                    null
-                }
-
-                is SizeQueryResult.Failure -> {
-                    queryFailureCount++
-                    lastQueryFailure = result.error
-                    null
-                }
+            } catch (cancellation: CancellationException) {
+                trace.putAttribute(ATTRIBUTE_OUTCOME, OUTCOME_CANCELLED)
+                throw cancellation
             }
-        }.toMap()
-        totalSizes.value = sizes
 
-        if (uninstallRaceCount > 0) {
-            Logger.w(TAG, "Storage stats loading degraded: $uninstallRaceCount uninstalled apps skipped")
+            result.fold(
+                onSuccess = { outcome -> trace.putAttribute(ATTRIBUTE_OUTCOME, outcome) },
+                onFailure = { failure ->
+                    trace.putAttribute(ATTRIBUTE_OUTCOME, OUTCOME_ERROR)
+                    Logger.e(TAG, failure, "Storage stats loading failed")
+                    throw failure
+                },
+            )
         }
-        if (permissionRaceCount > 0) {
-            Logger.w(TAG, "Storage stats loading degraded: $permissionRaceCount apps skipped after permission changed")
-        }
-        lastQueryFailure?.let {
-            Logger.w(TAG, it, "Storage stats loading degraded: $queryFailureCount app queries failed")
-        }
-        Logger.i(TAG, "Storage stats loading finished: ${sizes.size} apps loaded")
     }
 
     private fun queryPackageSize(user: UserHandle, packageName: PackageName): SizeQueryResult = try {
@@ -149,3 +193,20 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
         data class Failure(val error: IOException) : SizeQueryResult
     }
 }
+
+private const val TRACE_STORAGE_STATS_LOAD = "storage_stats_load"
+private const val METRIC_PERMISSION_CHECK_US = "permission_check_us"
+private const val METRIC_STATS_QUERY_US = "stats_query_us"
+private const val METRIC_REQUESTED_COUNT = "requested_count"
+private const val METRIC_LOADED_COUNT = "loaded_count"
+private const val ATTRIBUTE_OUTCOME = "outcome"
+private const val ATTRIBUTE_PERMISSION = "permission"
+private const val ATTRIBUTE_TRIGGER = "trigger"
+private const val OUTCOME_SUCCESS = "success"
+private const val OUTCOME_DEGRADED = "degraded"
+private const val OUTCOME_ERROR = "error"
+private const val OUTCOME_CANCELLED = "cancelled"
+private const val PERMISSION_GRANTED = "granted"
+private const val PERMISSION_DENIED = "denied"
+private const val TRIGGER_LIFECYCLE_START = "lifecycle_start"
+private const val TRIGGER_INSTALLED_APPS = "installed_apps"

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
@@ -21,6 +21,8 @@ import sk.styk.martin.apkanalyzer.core.common.model.AppSize
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.model.bytes
 import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
+import sk.styk.martin.apkanalyzer.core.common.performance.TraceOutcome
+import sk.styk.martin.apkanalyzer.core.common.performance.TracePermission
 import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
 import java.io.IOException
 import javax.inject.Inject
@@ -91,12 +93,12 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
             trace["trigger"] = trigger
             runCatchingCancellable {
                 val hasPermission = checkPermission()
-                trace["permission"] = if (hasPermission) "granted" else "denied"
+                trace.setPermission(if (hasPermission) TracePermission.Granted else TracePermission.Denied)
                 isPermissionGranted.value = hasPermission
 
                 if (!hasPermission) {
                     Logger.w(TAG, "Storage stats loading degraded: permission missing")
-                    "degraded"
+                    TraceOutcome.Degraded
                 } else {
                     Logger.d(TAG, "Storage stats loading started: ${packageNames.size} apps requested")
                     val user = UserHandle.getUserHandleForUid(Process.myUid())
@@ -141,15 +143,15 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
                     }
                     Logger.i(TAG, "Storage stats loading finished: ${sizes.size} apps loaded")
                     if (uninstallRaceCount > 0 || permissionRaceCount > 0 || queryFailureCount > 0) {
-                        "degraded"
+                        TraceOutcome.Degraded
                     } else {
-                        "success"
+                        TraceOutcome.Success
                     }
                 }
             }.fold(
-                onSuccess = { outcome -> trace["outcome"] = outcome },
+                onSuccess = trace::setOutcome,
                 onFailure = { failure ->
-                    trace["outcome"] = "error"
+                    trace.setOutcome(TraceOutcome.Error)
                     Logger.e(TAG, failure, "Storage stats loading failed")
                     throw failure
                 },

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
@@ -21,10 +21,10 @@ import sk.styk.martin.apkanalyzer.core.common.model.AppSize
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.model.bytes
 import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
+import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.measureTimedValue
 
 private const val TAG = "StorageStatsRepositoryImpl"
@@ -88,86 +88,78 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
     }
 
     private suspend fun fetchTotalSizes(packageNames: List<PackageName>, trigger: String) {
-        performanceTracker.startTrace(TRACE_STORAGE_STATS_LOAD).use { trace ->
-            trace.putAttribute(ATTRIBUTE_TRIGGER, trigger)
-            trace.putMetric(METRIC_REQUESTED_COUNT, packageNames.size.toLong())
-            val result = try {
-                runCatchingCancellable {
-                    val permissionCheck = measureTimedValue { checkPermission() }
-                    trace.putMetric(METRIC_PERMISSION_CHECK_US, permissionCheck.duration.inWholeMicroseconds)
-                    trace.putAttribute(
-                        ATTRIBUTE_PERMISSION,
-                        if (permissionCheck.value) PERMISSION_GRANTED else PERMISSION_DENIED,
-                    )
-                    isPermissionGranted.value = permissionCheck.value
+        performanceTracker.startCancellableTrace(TRACE_STORAGE_STATS_LOAD) { trace ->
+            trace[ATTRIBUTE_TRIGGER] = trigger
+            trace[METRIC_REQUESTED_COUNT] = packageNames.size.toLong()
+            val result = runCatchingCancellable {
+                val permissionCheck = measureTimedValue { checkPermission() }
+                trace[METRIC_PERMISSION_CHECK_US] = permissionCheck.duration.inWholeMicroseconds
+                trace[ATTRIBUTE_PERMISSION] = if (permissionCheck.value) PERMISSION_GRANTED else PERMISSION_DENIED
+                isPermissionGranted.value = permissionCheck.value
 
-                    if (!permissionCheck.value) {
-                        trace.putMetric(METRIC_LOADED_COUNT, 0)
-                        Logger.w(TAG, "Storage stats loading degraded: permission missing")
+                if (!permissionCheck.value) {
+                    trace[METRIC_LOADED_COUNT] = 0L
+                    Logger.w(TAG, "Storage stats loading degraded: permission missing")
+                    OUTCOME_DEGRADED
+                } else {
+                    Logger.d(TAG, "Storage stats loading started: ${packageNames.size} apps requested")
+                    val user = UserHandle.getUserHandleForUid(Process.myUid())
+                    var uninstallRaceCount = 0
+                    var permissionRaceCount = 0
+                    var queryFailureCount = 0
+                    var lastQueryFailure: IOException? = null
+                    val statsQuery = measureTimedValue {
+                        packageNames.mapNotNull { packageName ->
+                            when (val queryResult = queryPackageSize(user, packageName)) {
+                                is SizeQueryResult.Success -> packageName to queryResult.size
+
+                                SizeQueryResult.UninstallRace -> {
+                                    uninstallRaceCount++
+                                    null
+                                }
+
+                                SizeQueryResult.PermissionRace -> {
+                                    permissionRaceCount++
+                                    null
+                                }
+
+                                is SizeQueryResult.Failure -> {
+                                    queryFailureCount++
+                                    lastQueryFailure = queryResult.error
+                                    null
+                                }
+                            }
+                        }.toMap()
+                    }
+                    trace[METRIC_STATS_QUERY_US] = statsQuery.duration.inWholeMicroseconds
+                    trace[METRIC_LOADED_COUNT] = statsQuery.value.size.toLong()
+                    totalSizes.value = statsQuery.value
+
+                    if (uninstallRaceCount > 0) {
+                        Logger.w(TAG, "Storage stats loading degraded: $uninstallRaceCount uninstalled apps skipped")
+                    }
+                    if (permissionRaceCount > 0) {
+                        Logger.w(
+                            TAG,
+                            "Storage stats loading degraded: $permissionRaceCount apps skipped after permission changed",
+                        )
+                    }
+                    lastQueryFailure?.let {
+                        Logger.w(TAG, it, "Storage stats loading degraded: $queryFailureCount app queries failed")
+                    }
+                    Logger.i(TAG, "Storage stats loading finished: ${statsQuery.value.size} apps loaded")
+                    if (uninstallRaceCount > 0 || permissionRaceCount > 0 || queryFailureCount > 0) {
                         OUTCOME_DEGRADED
                     } else {
-                        Logger.d(TAG, "Storage stats loading started: ${packageNames.size} apps requested")
-                        val user = UserHandle.getUserHandleForUid(Process.myUid())
-                        var uninstallRaceCount = 0
-                        var permissionRaceCount = 0
-                        var queryFailureCount = 0
-                        var lastQueryFailure: IOException? = null
-                        val statsQuery = measureTimedValue {
-                            packageNames.mapNotNull { packageName ->
-                                when (val queryResult = queryPackageSize(user, packageName)) {
-                                    is SizeQueryResult.Success -> packageName to queryResult.size
-
-                                    SizeQueryResult.UninstallRace -> {
-                                        uninstallRaceCount++
-                                        null
-                                    }
-
-                                    SizeQueryResult.PermissionRace -> {
-                                        permissionRaceCount++
-                                        null
-                                    }
-
-                                    is SizeQueryResult.Failure -> {
-                                        queryFailureCount++
-                                        lastQueryFailure = queryResult.error
-                                        null
-                                    }
-                                }
-                            }.toMap()
-                        }
-                        trace.putMetric(METRIC_STATS_QUERY_US, statsQuery.duration.inWholeMicroseconds)
-                        trace.putMetric(METRIC_LOADED_COUNT, statsQuery.value.size.toLong())
-                        totalSizes.value = statsQuery.value
-
-                        if (uninstallRaceCount > 0) {
-                            Logger.w(TAG, "Storage stats loading degraded: $uninstallRaceCount uninstalled apps skipped")
-                        }
-                        if (permissionRaceCount > 0) {
-                            Logger.w(
-                                TAG,
-                                "Storage stats loading degraded: $permissionRaceCount apps skipped after permission changed",
-                            )
-                        }
-                        lastQueryFailure?.let {
-                            Logger.w(TAG, it, "Storage stats loading degraded: $queryFailureCount app queries failed")
-                        }
-                        Logger.i(TAG, "Storage stats loading finished: ${statsQuery.value.size} apps loaded")
-                        if (uninstallRaceCount > 0 || permissionRaceCount > 0 || queryFailureCount > 0) {
-                            OUTCOME_DEGRADED
-                        } else {
-                            OUTCOME_SUCCESS
-                        }
+                        OUTCOME_SUCCESS
                     }
                 }
-            } catch (cancellation: CancellationException) {
-                trace.putAttribute(ATTRIBUTE_OUTCOME, OUTCOME_CANCELLED)
-                throw cancellation
             }
 
             result.fold(
-                onSuccess = { outcome -> trace.putAttribute(ATTRIBUTE_OUTCOME, outcome) },
+                onSuccess = { outcome -> trace[ATTRIBUTE_OUTCOME] = outcome },
                 onFailure = { failure ->
-                    trace.putAttribute(ATTRIBUTE_OUTCOME, OUTCOME_ERROR)
+                    trace[ATTRIBUTE_OUTCOME] = OUTCOME_ERROR
                     Logger.e(TAG, failure, "Storage stats loading failed")
                     throw failure
                 },
@@ -205,7 +197,6 @@ private const val ATTRIBUTE_TRIGGER = "trigger"
 private const val OUTCOME_SUCCESS = "success"
 private const val OUTCOME_DEGRADED = "degraded"
 private const val OUTCOME_ERROR = "error"
-private const val OUTCOME_CANCELLED = "cancelled"
 private const val PERMISSION_GRANTED = "granted"
 private const val PERMISSION_DENIED = "denied"
 private const val TRIGGER_LIFECYCLE_START = "lifecycle_start"

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/usagestats/UsageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/usagestats/UsageStatsRepositoryImpl.kt
@@ -17,10 +17,10 @@ import sk.styk.martin.apkanalyzer.core.common.coroutines.runCatchingCancellable
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
+import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration.Companion.days
 import kotlin.time.measureTimedValue
 import kotlin.time.toJavaDuration
@@ -60,52 +60,44 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
     }
 
     private suspend fun fetchUsageTimes() {
-        performanceTracker.startTrace(TRACE_USAGE_STATS_LOAD).use { trace ->
-            trace.putAttribute(ATTRIBUTE_TRIGGER, TRIGGER_LIFECYCLE_START)
-            val result = try {
-                runCatchingCancellable {
-                    val permissionCheck = measureTimedValue { checkPermission() }
-                    trace.putMetric(METRIC_PERMISSION_CHECK_US, permissionCheck.duration.inWholeMicroseconds)
-                    trace.putAttribute(
-                        ATTRIBUTE_PERMISSION,
-                        if (permissionCheck.value) PERMISSION_GRANTED else PERMISSION_DENIED,
-                    )
-                    isPermissionGranted.value = permissionCheck.value
+        performanceTracker.startCancellableTrace(TRACE_USAGE_STATS_LOAD) { trace ->
+            trace[ATTRIBUTE_TRIGGER] = TRIGGER_LIFECYCLE_START
+            val result = runCatchingCancellable {
+                val permissionCheck = measureTimedValue { checkPermission() }
+                trace[METRIC_PERMISSION_CHECK_US] = permissionCheck.duration.inWholeMicroseconds
+                trace[ATTRIBUTE_PERMISSION] = if (permissionCheck.value) PERMISSION_GRANTED else PERMISSION_DENIED
+                isPermissionGranted.value = permissionCheck.value
 
-                    if (!permissionCheck.value) {
-                        trace.putMetric(METRIC_LOADED_COUNT, 0)
-                        Logger.w(TAG, "Usage stats loading degraded: permission missing")
-                        OUTCOME_DEGRADED
-                    } else {
-                        Logger.d(TAG, "Usage stats loading started")
-                        val usageQuery = measureTimedValue {
-                            queryRawUsageStats(detectPermissionRace = true)
-                        }
-                        trace.putMetric(METRIC_USAGE_QUERY_US, usageQuery.duration.inWholeMicroseconds)
-                        val usageMapping = measureTimedValue {
-                            usageQuery.value.usages
-                                .groupBy { PackageName(it.packageName) }
-                                .mapValues { (_, usages) -> Instant.ofEpochMilli(usages.maxOf { it.lastTimeUsed }) }
-                        }
-                        trace.putMetric(METRIC_USAGE_MAPPING_US, usageMapping.duration.inWholeMicroseconds)
-                        trace.putMetric(METRIC_LOADED_COUNT, usageMapping.value.size.toLong())
-                        lastUsedTimes.value = usageMapping.value
-                        if (usageQuery.value.permissionRace) {
-                            trace.putAttribute(ATTRIBUTE_PERMISSION, PERMISSION_DENIED)
-                        }
-                        Logger.i(TAG, "Usage stats loading finished: ${usageMapping.value.size} apps loaded")
-                        if (usageQuery.value.permissionRace) OUTCOME_DEGRADED else OUTCOME_SUCCESS
+                if (!permissionCheck.value) {
+                    trace[METRIC_LOADED_COUNT] = 0L
+                    Logger.w(TAG, "Usage stats loading degraded: permission missing")
+                    OUTCOME_DEGRADED
+                } else {
+                    Logger.d(TAG, "Usage stats loading started")
+                    val usageQuery = measureTimedValue {
+                        queryRawUsageStats(detectPermissionRace = true)
                     }
+                    trace[METRIC_USAGE_QUERY_US] = usageQuery.duration.inWholeMicroseconds
+                    val usageMapping = measureTimedValue {
+                        usageQuery.value.usages
+                            .groupBy { PackageName(it.packageName) }
+                            .mapValues { (_, usages) -> Instant.ofEpochMilli(usages.maxOf { it.lastTimeUsed }) }
+                    }
+                    trace[METRIC_USAGE_MAPPING_US] = usageMapping.duration.inWholeMicroseconds
+                    trace[METRIC_LOADED_COUNT] = usageMapping.value.size.toLong()
+                    lastUsedTimes.value = usageMapping.value
+                    if (usageQuery.value.permissionRace) {
+                        trace[ATTRIBUTE_PERMISSION] = PERMISSION_DENIED
+                    }
+                    Logger.i(TAG, "Usage stats loading finished: ${usageMapping.value.size} apps loaded")
+                    if (usageQuery.value.permissionRace) OUTCOME_DEGRADED else OUTCOME_SUCCESS
                 }
-            } catch (cancellation: CancellationException) {
-                trace.putAttribute(ATTRIBUTE_OUTCOME, OUTCOME_CANCELLED)
-                throw cancellation
             }
 
             result.fold(
-                onSuccess = { outcome -> trace.putAttribute(ATTRIBUTE_OUTCOME, outcome) },
+                onSuccess = { outcome -> trace[ATTRIBUTE_OUTCOME] = outcome },
                 onFailure = { failure ->
-                    trace.putAttribute(ATTRIBUTE_OUTCOME, OUTCOME_ERROR)
+                    trace[ATTRIBUTE_OUTCOME] = OUTCOME_ERROR
                     Logger.e(TAG, failure, "Usage stats loading failed")
                     throw failure
                 },
@@ -150,7 +142,6 @@ private const val ATTRIBUTE_TRIGGER = "trigger"
 private const val OUTCOME_SUCCESS = "success"
 private const val OUTCOME_DEGRADED = "degraded"
 private const val OUTCOME_ERROR = "error"
-private const val OUTCOME_CANCELLED = "cancelled"
 private const val PERMISSION_GRANTED = "granted"
 private const val PERMISSION_DENIED = "denied"
 private const val TRIGGER_LIFECYCLE_START = "lifecycle_start"

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/usagestats/UsageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/usagestats/UsageStatsRepositoryImpl.kt
@@ -22,7 +22,6 @@ import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Duration.Companion.days
-import kotlin.time.measureTimedValue
 import kotlin.time.toJavaDuration
 
 private const val TAG = "UsageStatsRepositoryImpl"
@@ -51,7 +50,7 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun queryLastUsedTime(packageName: PackageName): Instant? = lastUsedTimes.value[packageName] ?: if (checkPermission()) {
-        queryRawUsageStats().usages
+        queryRawUsageStats()
             .filter { it.packageName == packageName.value }
             .maxOfOrNull { it.lastTimeUsed }
             ?.let { Instant.ofEpochMilli(it) }
@@ -60,44 +59,28 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
     }
 
     private suspend fun fetchUsageTimes() {
-        performanceTracker.startCancellableTrace(TRACE_USAGE_STATS_LOAD) { trace ->
-            trace[ATTRIBUTE_TRIGGER] = TRIGGER_LIFECYCLE_START
-            val result = runCatchingCancellable {
-                val permissionCheck = measureTimedValue { checkPermission() }
-                trace[METRIC_PERMISSION_CHECK_US] = permissionCheck.duration.inWholeMicroseconds
-                trace[ATTRIBUTE_PERMISSION] = if (permissionCheck.value) PERMISSION_GRANTED else PERMISSION_DENIED
-                isPermissionGranted.value = permissionCheck.value
+        performanceTracker.startCancellableTrace("usage_stats_load") { trace ->
+            runCatchingCancellable {
+                val hasPermission = checkPermission()
+                trace["permission"] = if (hasPermission) "granted" else "denied"
+                isPermissionGranted.value = hasPermission
 
-                if (!permissionCheck.value) {
-                    trace[METRIC_LOADED_COUNT] = 0L
+                if (!hasPermission) {
                     Logger.w(TAG, "Usage stats loading degraded: permission missing")
-                    OUTCOME_DEGRADED
+                    "degraded"
                 } else {
                     Logger.d(TAG, "Usage stats loading started")
-                    val usageQuery = measureTimedValue {
-                        queryRawUsageStats(detectPermissionRace = true)
-                    }
-                    trace[METRIC_USAGE_QUERY_US] = usageQuery.duration.inWholeMicroseconds
-                    val usageMapping = measureTimedValue {
-                        usageQuery.value.usages
-                            .groupBy { PackageName(it.packageName) }
-                            .mapValues { (_, usages) -> Instant.ofEpochMilli(usages.maxOf { it.lastTimeUsed }) }
-                    }
-                    trace[METRIC_USAGE_MAPPING_US] = usageMapping.duration.inWholeMicroseconds
-                    trace[METRIC_LOADED_COUNT] = usageMapping.value.size.toLong()
-                    lastUsedTimes.value = usageMapping.value
-                    if (usageQuery.value.permissionRace) {
-                        trace[ATTRIBUTE_PERMISSION] = PERMISSION_DENIED
-                    }
-                    Logger.i(TAG, "Usage stats loading finished: ${usageMapping.value.size} apps loaded")
-                    if (usageQuery.value.permissionRace) OUTCOME_DEGRADED else OUTCOME_SUCCESS
+                    val usages = queryRawUsageStats()
+                        .groupBy { PackageName(it.packageName) }
+                        .mapValues { (_, usages) -> Instant.ofEpochMilli(usages.maxOf { it.lastTimeUsed }) }
+                    lastUsedTimes.value = usages
+                    Logger.i(TAG, "Usage stats loading finished: ${usages.size} apps loaded")
+                    "success"
                 }
-            }
-
-            result.fold(
-                onSuccess = { outcome -> trace[ATTRIBUTE_OUTCOME] = outcome },
+            }.fold(
+                onSuccess = { outcome -> trace["outcome"] = outcome },
                 onFailure = { failure ->
-                    trace[ATTRIBUTE_OUTCOME] = OUTCOME_ERROR
+                    trace["outcome"] = "error"
                     Logger.e(TAG, failure, "Usage stats loading failed")
                     throw failure
                 },
@@ -106,16 +89,12 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
     }
 
     @SuppressLint("MissingPermission")
-    private fun queryRawUsageStats(detectPermissionRace: Boolean = false): UsageStatsQueryResult = try {
+    private fun queryRawUsageStats() = try {
         val now = Instant.now()
         val yearAgo = now - 365.days.toJavaDuration()
-        val usages = usageStatsManager.queryUsageStats(UsageStatsManager.INTERVAL_BEST, yearAgo.toEpochMilli(), now.toEpochMilli())
-        UsageStatsQueryResult(
-            usages = usages,
-            permissionRace = detectPermissionRace && usages.isEmpty() && !checkPermission(),
-        )
+        usageStatsManager.queryUsageStats(UsageStatsManager.INTERVAL_BEST, yearAgo.toEpochMilli(), now.toEpochMilli())
     } catch (_: SecurityException) {
-        UsageStatsQueryResult(usages = emptyList(), permissionRace = true)
+        emptyList()
     }
 
     private fun checkPermission(): Boolean {
@@ -127,21 +106,4 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
 
         return mode == AppOpsManager.MODE_ALLOWED
     }
-
-    private data class UsageStatsQueryResult(val usages: List<android.app.usage.UsageStats>, val permissionRace: Boolean)
 }
-
-private const val TRACE_USAGE_STATS_LOAD = "usage_stats_load"
-private const val METRIC_PERMISSION_CHECK_US = "permission_check_us"
-private const val METRIC_USAGE_QUERY_US = "usage_query_us"
-private const val METRIC_USAGE_MAPPING_US = "usage_mapping_us"
-private const val METRIC_LOADED_COUNT = "loaded_count"
-private const val ATTRIBUTE_OUTCOME = "outcome"
-private const val ATTRIBUTE_PERMISSION = "permission"
-private const val ATTRIBUTE_TRIGGER = "trigger"
-private const val OUTCOME_SUCCESS = "success"
-private const val OUTCOME_DEGRADED = "degraded"
-private const val OUTCOME_ERROR = "error"
-private const val PERMISSION_GRANTED = "granted"
-private const val PERMISSION_DENIED = "denied"
-private const val TRIGGER_LIFECYCLE_START = "lifecycle_start"

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/usagestats/UsageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/usagestats/UsageStatsRepositoryImpl.kt
@@ -17,6 +17,8 @@ import sk.styk.martin.apkanalyzer.core.common.coroutines.runCatchingCancellable
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
+import sk.styk.martin.apkanalyzer.core.common.performance.TraceOutcome
+import sk.styk.martin.apkanalyzer.core.common.performance.TracePermission
 import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
 import java.time.Instant
 import javax.inject.Inject
@@ -62,12 +64,12 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
         performanceTracker.startCancellableTrace("usage_stats_load") { trace ->
             runCatchingCancellable {
                 val hasPermission = checkPermission()
-                trace["permission"] = if (hasPermission) "granted" else "denied"
+                trace.setPermission(if (hasPermission) TracePermission.Granted else TracePermission.Denied)
                 isPermissionGranted.value = hasPermission
 
                 if (!hasPermission) {
                     Logger.w(TAG, "Usage stats loading degraded: permission missing")
-                    "degraded"
+                    TraceOutcome.Degraded
                 } else {
                     Logger.d(TAG, "Usage stats loading started")
                     val usages = queryRawUsageStats()
@@ -75,12 +77,12 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
                         .mapValues { (_, usages) -> Instant.ofEpochMilli(usages.maxOf { it.lastTimeUsed }) }
                     lastUsedTimes.value = usages
                     Logger.i(TAG, "Usage stats loading finished: ${usages.size} apps loaded")
-                    "success"
+                    TraceOutcome.Success
                 }
             }.fold(
-                onSuccess = { outcome -> trace["outcome"] = outcome },
+                onSuccess = trace::setOutcome,
                 onFailure = { failure ->
-                    trace["outcome"] = "error"
+                    trace.setOutcome(TraceOutcome.Error)
                     Logger.e(TAG, failure, "Usage stats loading failed")
                     throw failure
                 },

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/usagestats/UsageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/usagestats/UsageStatsRepositoryImpl.kt
@@ -13,12 +13,16 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
+import sk.styk.martin.apkanalyzer.core.common.coroutines.runCatchingCancellable
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration.Companion.days
+import kotlin.time.measureTimedValue
 import kotlin.time.toJavaDuration
 
 private const val TAG = "UsageStatsRepositoryImpl"
@@ -30,6 +34,7 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
     private val appOpsManager: AppOpsManager,
     private val dispatcherProvider: DispatcherProvider,
     private val applicationScope: CoroutineScope,
+    private val performanceTracker: PerformanceTracker,
 ) : UsageStatsRepository,
     DefaultLifecycleObserver {
 
@@ -46,7 +51,7 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun queryLastUsedTime(packageName: PackageName): Instant? = lastUsedTimes.value[packageName] ?: if (checkPermission()) {
-        queryRawUsageStats()
+        queryRawUsageStats().usages
             .filter { it.packageName == packageName.value }
             .maxOfOrNull { it.lastTimeUsed }
             ?.let { Instant.ofEpochMilli(it) }
@@ -54,29 +59,71 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
         null
     }
 
-    private fun fetchUsageTimes() {
-        val hasPermission = checkPermission()
-        isPermissionGranted.value = hasPermission
-        if (!hasPermission) {
-            Logger.w(TAG, "Usage stats loading degraded: permission missing")
-            return
-        }
+    private suspend fun fetchUsageTimes() {
+        performanceTracker.startTrace(TRACE_USAGE_STATS_LOAD).use { trace ->
+            trace.putAttribute(ATTRIBUTE_TRIGGER, TRIGGER_LIFECYCLE_START)
+            val result = try {
+                runCatchingCancellable {
+                    val permissionCheck = measureTimedValue { checkPermission() }
+                    trace.putMetric(METRIC_PERMISSION_CHECK_US, permissionCheck.duration.inWholeMicroseconds)
+                    trace.putAttribute(
+                        ATTRIBUTE_PERMISSION,
+                        if (permissionCheck.value) PERMISSION_GRANTED else PERMISSION_DENIED,
+                    )
+                    isPermissionGranted.value = permissionCheck.value
 
-        Logger.d(TAG, "Usage stats loading started")
-        val usages = queryRawUsageStats()
-            .groupBy { PackageName(it.packageName) }
-            .mapValues { (_, usages) -> Instant.ofEpochMilli(usages.maxOf { it.lastTimeUsed }) }
-        lastUsedTimes.value = usages
-        Logger.i(TAG, "Usage stats loading finished: ${usages.size} apps loaded")
+                    if (!permissionCheck.value) {
+                        trace.putMetric(METRIC_LOADED_COUNT, 0)
+                        Logger.w(TAG, "Usage stats loading degraded: permission missing")
+                        OUTCOME_DEGRADED
+                    } else {
+                        Logger.d(TAG, "Usage stats loading started")
+                        val usageQuery = measureTimedValue {
+                            queryRawUsageStats(detectPermissionRace = true)
+                        }
+                        trace.putMetric(METRIC_USAGE_QUERY_US, usageQuery.duration.inWholeMicroseconds)
+                        val usageMapping = measureTimedValue {
+                            usageQuery.value.usages
+                                .groupBy { PackageName(it.packageName) }
+                                .mapValues { (_, usages) -> Instant.ofEpochMilli(usages.maxOf { it.lastTimeUsed }) }
+                        }
+                        trace.putMetric(METRIC_USAGE_MAPPING_US, usageMapping.duration.inWholeMicroseconds)
+                        trace.putMetric(METRIC_LOADED_COUNT, usageMapping.value.size.toLong())
+                        lastUsedTimes.value = usageMapping.value
+                        if (usageQuery.value.permissionRace) {
+                            trace.putAttribute(ATTRIBUTE_PERMISSION, PERMISSION_DENIED)
+                        }
+                        Logger.i(TAG, "Usage stats loading finished: ${usageMapping.value.size} apps loaded")
+                        if (usageQuery.value.permissionRace) OUTCOME_DEGRADED else OUTCOME_SUCCESS
+                    }
+                }
+            } catch (cancellation: CancellationException) {
+                trace.putAttribute(ATTRIBUTE_OUTCOME, OUTCOME_CANCELLED)
+                throw cancellation
+            }
+
+            result.fold(
+                onSuccess = { outcome -> trace.putAttribute(ATTRIBUTE_OUTCOME, outcome) },
+                onFailure = { failure ->
+                    trace.putAttribute(ATTRIBUTE_OUTCOME, OUTCOME_ERROR)
+                    Logger.e(TAG, failure, "Usage stats loading failed")
+                    throw failure
+                },
+            )
+        }
     }
 
     @SuppressLint("MissingPermission")
-    private fun queryRawUsageStats() = try {
+    private fun queryRawUsageStats(detectPermissionRace: Boolean = false): UsageStatsQueryResult = try {
         val now = Instant.now()
         val yearAgo = now - 365.days.toJavaDuration()
-        usageStatsManager.queryUsageStats(UsageStatsManager.INTERVAL_BEST, yearAgo.toEpochMilli(), now.toEpochMilli())
+        val usages = usageStatsManager.queryUsageStats(UsageStatsManager.INTERVAL_BEST, yearAgo.toEpochMilli(), now.toEpochMilli())
+        UsageStatsQueryResult(
+            usages = usages,
+            permissionRace = detectPermissionRace && usages.isEmpty() && !checkPermission(),
+        )
     } catch (_: SecurityException) {
-        emptyList()
+        UsageStatsQueryResult(usages = emptyList(), permissionRace = true)
     }
 
     private fun checkPermission(): Boolean {
@@ -88,4 +135,22 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
 
         return mode == AppOpsManager.MODE_ALLOWED
     }
+
+    private data class UsageStatsQueryResult(val usages: List<android.app.usage.UsageStats>, val permissionRace: Boolean)
 }
+
+private const val TRACE_USAGE_STATS_LOAD = "usage_stats_load"
+private const val METRIC_PERMISSION_CHECK_US = "permission_check_us"
+private const val METRIC_USAGE_QUERY_US = "usage_query_us"
+private const val METRIC_USAGE_MAPPING_US = "usage_mapping_us"
+private const val METRIC_LOADED_COUNT = "loaded_count"
+private const val ATTRIBUTE_OUTCOME = "outcome"
+private const val ATTRIBUTE_PERMISSION = "permission"
+private const val ATTRIBUTE_TRIGGER = "trigger"
+private const val OUTCOME_SUCCESS = "success"
+private const val OUTCOME_DEGRADED = "degraded"
+private const val OUTCOME_ERROR = "error"
+private const val OUTCOME_CANCELLED = "cancelled"
+private const val PERMISSION_GRANTED = "granted"
+private const val PERMISSION_DENIED = "denied"
+private const val TRIGGER_LIFECYCLE_START = "lifecycle_start"

--- a/core/common/AGENTS.md
+++ b/core/common/AGENTS.md
@@ -28,11 +28,6 @@ logic do not belong here.
   events, formatter helpers, or logging-only wrapper functions.
 * Throwable-bearing WARN and ERROR logs record Crashlytics non-fatals. Attach the throwable once at
   the boundary that owns the degraded result or terminal failure.
-* `PerformanceTracker.startTrace(name)` returns an `AutoCloseable` `PerformanceTrace`. Scope traced
-  suspend work with `startCancellableTrace(name) { trace -> ... }`; it records the standard
-  `outcome=cancelled` attribute and closes on every exit.
-* Keep operation-specific trace, metric, and attribute names private beside the repository that emits
-  them. Suffix duration metric names with `_us` because Firebase custom metrics do not carry a unit.
 * Firebase Performance imports stay inside the internal adapter in this infrastructure module.
   Domain core modules and feature modules depend only on `PerformanceTracker` and
   `PerformanceTrace`. This module already owns the Firebase-backed logging facade, while the app

--- a/core/common/AGENTS.md
+++ b/core/common/AGENTS.md
@@ -28,10 +28,11 @@ logic do not belong here.
   events, formatter helpers, or logging-only wrapper functions.
 * Throwable-bearing WARN and ERROR logs record Crashlytics non-fatals. Attach the throwable once at
   the boundary that owns the degraded result or terminal failure.
-* `PerformanceTracker.startTrace(name)` returns an `AutoCloseable` `PerformanceTrace`. Always scope
-  it with `use` so it closes on success, failure, and cancellation.
-* Keep trace, metric, and attribute names private beside the repository that emits them. Suffix
-  duration metric names with `_us` because Firebase custom metrics do not carry a unit.
+* `PerformanceTracker.startTrace(name)` returns an `AutoCloseable` `PerformanceTrace`. Scope traced
+  suspend work with `startCancellableTrace(name) { trace -> ... }`; it records the standard
+  `outcome=cancelled` attribute and closes on every exit.
+* Keep operation-specific trace, metric, and attribute names private beside the repository that emits
+  them. Suffix duration metric names with `_us` because Firebase custom metrics do not carry a unit.
 * Firebase Performance imports stay inside the internal adapter in this infrastructure module.
   Domain core modules and feature modules depend only on `PerformanceTracker` and
   `PerformanceTrace`. This module already owns the Firebase-backed logging facade, while the app

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/FirebasePerformanceTrace.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/FirebasePerformanceTrace.kt
@@ -3,11 +3,11 @@ package sk.styk.martin.apkanalyzer.core.common.performance
 import com.google.firebase.perf.metrics.Trace
 
 internal class FirebasePerformanceTrace(private val trace: Trace) : PerformanceTrace {
-    override fun putMetric(name: String, value: Long) {
+    override fun set(name: String, value: Long) {
         trace.putMetric(name, value)
     }
 
-    override fun putAttribute(name: String, value: String) {
+    override fun set(name: String, value: String) {
         trace.putAttribute(name, value)
     }
 

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTrace.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTrace.kt
@@ -4,4 +4,24 @@ interface PerformanceTrace : AutoCloseable {
     operator fun set(name: String, value: Long)
 
     operator fun set(name: String, value: String)
+
+    fun setOutcome(outcome: TraceOutcome) {
+        this["outcome"] = outcome.attributeValue
+    }
+
+    fun setPermission(permission: TracePermission) {
+        this["permission"] = permission.attributeValue
+    }
+}
+
+enum class TraceOutcome(internal val attributeValue: String) {
+    Success("success"),
+    Degraded("degraded"),
+    Error("error"),
+    Cancelled("cancelled"),
+}
+
+enum class TracePermission(internal val attributeValue: String) {
+    Granted("granted"),
+    Denied("denied"),
 }

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTrace.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTrace.kt
@@ -1,7 +1,7 @@
 package sk.styk.martin.apkanalyzer.core.common.performance
 
 interface PerformanceTrace : AutoCloseable {
-    fun putMetric(name: String, value: Long)
+    operator fun set(name: String, value: Long)
 
-    fun putAttribute(name: String, value: String)
+    operator fun set(name: String, value: String)
 }

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTracker.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTracker.kt
@@ -17,12 +17,9 @@ suspend fun <T> PerformanceTracker.startCancellableTrace(name: String, block: su
 
 private fun PerformanceTrace.recordCancellation(cancellation: CancellationException) {
     val outcomeFailure = runCatching {
-        this[ATTRIBUTE_OUTCOME] = OUTCOME_CANCELLED
+        setOutcome(TraceOutcome.Cancelled)
     }.exceptionOrNull()
     if (outcomeFailure != null && outcomeFailure !== cancellation) {
         cancellation.addSuppressed(outcomeFailure)
     }
 }
-
-private const val ATTRIBUTE_OUTCOME = "outcome"
-private const val OUTCOME_CANCELLED = "cancelled"

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTracker.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTracker.kt
@@ -1,5 +1,24 @@
 package sk.styk.martin.apkanalyzer.core.common.performance
 
+import kotlin.coroutines.cancellation.CancellationException
+
 interface PerformanceTracker {
     fun startTrace(name: String): PerformanceTrace
 }
+
+suspend fun <T> PerformanceTracker.startCancellableTrace(name: String, block: suspend (PerformanceTrace) -> T): T = startTrace(name).use { trace ->
+    try {
+        block(trace)
+    } catch (cancellation: CancellationException) {
+        val outcomeFailure = runCatching {
+            trace[ATTRIBUTE_OUTCOME] = OUTCOME_CANCELLED
+        }.exceptionOrNull()
+        if (outcomeFailure != null && outcomeFailure !== cancellation) {
+            cancellation.addSuppressed(outcomeFailure)
+        }
+        throw cancellation
+    }
+}
+
+private const val ATTRIBUTE_OUTCOME = "outcome"
+private const val OUTCOME_CANCELLED = "cancelled"

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTracker.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTracker.kt
@@ -10,13 +10,17 @@ suspend fun <T> PerformanceTracker.startCancellableTrace(name: String, block: su
     try {
         block(trace)
     } catch (cancellation: CancellationException) {
-        val outcomeFailure = runCatching {
-            trace[ATTRIBUTE_OUTCOME] = OUTCOME_CANCELLED
-        }.exceptionOrNull()
-        if (outcomeFailure != null && outcomeFailure !== cancellation) {
-            cancellation.addSuppressed(outcomeFailure)
-        }
+        trace.recordCancellation(cancellation)
         throw cancellation
+    }
+}
+
+private fun PerformanceTrace.recordCancellation(cancellation: CancellationException) {
+    val outcomeFailure = runCatching {
+        this[ATTRIBUTE_OUTCOME] = OUTCOME_CANCELLED
+    }.exceptionOrNull()
+    if (outcomeFailure != null && outcomeFailure !== cancellation) {
+        cancellation.addSuppressed(outcomeFailure)
     }
 }
 

--- a/docs/technical/repository-load-performance.md
+++ b/docs/technical/repository-load-performance.md
@@ -204,6 +204,20 @@ interface PerformanceTracker {
 interface PerformanceTrace : AutoCloseable {
     operator fun set(name: String, value: Long)
     operator fun set(name: String, value: String)
+    fun setOutcome(outcome: TraceOutcome)
+    fun setPermission(permission: TracePermission)
+}
+
+enum class TraceOutcome {
+    Success,
+    Degraded,
+    Error,
+    Cancelled,
+}
+
+enum class TracePermission {
+    Granted,
+    Denied,
 }
 ```
 
@@ -219,6 +233,8 @@ Requirements for the adapter and contract:
 - `startCancellableTrace` starts and scopes an independent trace handle. It records the standard
   `outcome=cancelled` attribute and closes the handle when the block returns, throws, or is cancelled.
 - `trace[name] = longValue` records a metric, while `trace[name] = stringValue` records an attribute.
+- Shared values use typed setters such as `trace.setOutcome(TraceOutcome.Success)` and
+  `trace.setPermission(TracePermission.Granted)`; operation-specific attributes stay local.
 - Each emitting repository owns private operation-specific names that satisfy Firebase naming limits.
 - Callers record the parent outcome attribute inside the trace block before it returns or throws.
 - Instrumentation must not change repository results, cache semantics, dispatcher selection, or

--- a/docs/technical/repository-load-performance.md
+++ b/docs/technical/repository-load-performance.md
@@ -204,8 +204,8 @@ interface PerformanceTracker {
 }
 
 interface PerformanceTrace : AutoCloseable {
-    fun putMetric(name: String, value: Long)
-    fun putAttribute(name: String, value: String)
+    operator fun set(name: String, value: Long)
+    operator fun set(name: String, value: String)
 }
 ```
 
@@ -218,8 +218,9 @@ adapter imports `FirebasePerformance` or `Trace`; domain modules and features in
 
 Requirements for the adapter and contract:
 
-- `startTrace` starts and returns an independent trace handle. Callers scope it with `use`, which
-  closes the handle when the block returns, throws, or is cancelled.
+- `startCancellableTrace` starts and scopes an independent trace handle. It records the standard
+  `outcome=cancelled` attribute and closes the handle when the block returns, throws, or is cancelled.
+- `trace[name] = longValue` records a metric, while `trace[name] = stringValue` records an attribute.
 - Each emitting repository owns private trace, metric, and attribute names that satisfy Firebase
   naming limits. Duration metrics end in `_us` because Firebase custom metrics do not carry a unit.
 - Use `measureTimedValue` beside each emitting repository and store whole microseconds rather than

--- a/docs/technical/repository-load-performance.md
+++ b/docs/technical/repository-load-performance.md
@@ -10,9 +10,7 @@ analysis, and their supporting repository operations
 - Log every screen opening from the visible Navigation 3 destination.
 - Use log levels consistently so Crashlytics records unexpected recoverable and terminal failures as
   non-fatals without turning expected states into errors.
-- Measure the complete time needed to load an app and attribute that time to non-overlapping stages,
-  including manifest parsing, certificate extraction, signing-scheme detection, packaging analysis,
-  component mapping, permissions, storage, and usage.
+- Measure the complete time needed for each top-level load operation.
 - Keep Firebase Performance behind a shared infrastructure interface. Domain `core` modules and
   feature modules must not import Firebase Performance types.
 - Package names may appear in diagnostic logs. APK paths may appear when analyzing an APK file.
@@ -24,8 +22,8 @@ Use two complementary signals:
 
 1. `Logger` and Firebase Crashlytics provide chronological diagnostic breadcrumbs and non-fatal
    reports for unexpected failures.
-2. Firebase Performance custom code traces provide aggregate parent durations and per-stage timing
-   metrics for successful, degraded, failed, and cancelled loads.
+2. Firebase Performance custom code traces provide aggregate duration distributions for successful,
+   degraded, failed, and cancelled loads.
 
 Crashlytics logs are not a general remote log stream. A successful operation log is visible only
 when it is attached to a crash or recorded non-fatal event from that app session. Do not create a
@@ -38,9 +36,9 @@ most likely to regress. Screen-opening logs belong in the app navigation host, w
 Navigation 3 destination can be observed centrally. The initial metrics measure data availability,
 not navigation-to-first-frame latency.
 
-Use one parent trace per public load request and record non-overlapping stage durations as metrics on
-that trace. Do not create one nested Firebase trace per stage. Parent traces keep total duration,
-attributes, and stage metrics associated with one operation and avoid an unmanageable trace list.
+Use one trace per public load request. Firebase records its total duration automatically. Add only
+bounded attributes that materially segment the result; do not time internal calls or stages by
+default. This keeps instrumentation readable and avoids an unmanageable metric list.
 
 ## Logging Payload and Collection
 
@@ -221,11 +219,8 @@ Requirements for the adapter and contract:
 - `startCancellableTrace` starts and scopes an independent trace handle. It records the standard
   `outcome=cancelled` attribute and closes the handle when the block returns, throws, or is cancelled.
 - `trace[name] = longValue` records a metric, while `trace[name] = stringValue` records an attribute.
-- Each emitting repository owns private trace, metric, and attribute names that satisfy Firebase
-  naming limits. Duration metrics end in `_us` because Firebase custom metrics do not carry a unit.
-- Use `measureTimedValue` beside each emitting repository and store whole microseconds rather than
-  introducing a shared timing abstraction.
-- Callers record the parent outcome attribute inside the `use` block before it returns or throws.
+- Each emitting repository owns private operation-specific names that satisfy Firebase naming limits.
+- Callers record the parent outcome attribute inside the trace block before it returns or throws.
 - Instrumentation must not change repository results, cache semantics, dispatcher selection, or
   cancellation propagation.
 - The adapter calls Firebase directly. It does not catch SDK `RuntimeException`s or add logging-only
@@ -238,40 +233,21 @@ No Firebase Performance type may appear outside the internal `core:common` adapt
 ### `installed_apps_load`
 
 Start immediately before querying `PackageManager`. Stop after the basic `InstalledApp` list has
-been produced.
+been produced. The automatic trace duration includes package querying and model mapping.
 
 | Custom metric | Meaning |
 |---|---|
-| `package_query_us` | `PackageManager.getInstalledPackages` duration |
-| `app_mapping_us` | Mapping all returned `PackageInfo` values to `InstalledApp` |
-| `app_count` | Number of successfully mapped apps |
+| `package_query_ms` | `PackageManager.getInstalledPackages` duration in whole milliseconds |
+| `app_count` | Number of successfully mapped installed apps |
 
 | Attribute | Values |
 |---|---|
 | `outcome` | `success`, `error`, `cancelled` |
-| `trigger` | `initial`, `package_change` |
-| `app_count_bucket` | `0_49`, `50_99`, `100_199`, `200_399`, `400_plus` |
 
 ### `app_detail_load`
 
 Start at entry to `AppDetailRepository.details`, before either cache lookup. Stop when the repository
 returns a complete or degraded `AppDetail`, an error, or cancellation.
-
-| Custom metric | Meaning |
-|---|---|
-| `cache_lookup_us` | Installed-package or APK-file cache lookup |
-| `package_query_us` | Installed-package or APK-archive `PackageManager` lookup |
-| `intent_filters_us` | Base and split manifest parsing for component intent filters |
-| `storage_stats_us` | Installed-package storage-size lookup |
-| `usage_stats_us` | Installed-package last-used lookup |
-| `general_info_us` | General metadata and install-source mapping |
-| `certificate_us` | Certificate parsing, digests, trust assessment, and self-signature checks |
-| `signing_schemes_us` | v1 verification and APK Signing Block scheme detection |
-| `launcher_query_us` | Installed-package launcher activity queries |
-| `components_us` | Activity, service, provider, and receiver mapping |
-| `permissions_us` | Used and defined permission mapping and resolution |
-| `features_us` | Required-feature mapping |
-| `packaging_us` | APK size, installed splits, and native-library ZIP analysis |
 
 | Attribute | Values |
 |---|---|
@@ -281,27 +257,12 @@ returns a complete or degraded `AppDetail`, an error, or cancellation.
 | `intent_filters` | `available`, `unavailable` |
 | `signing_schemes` | `available`, `unavailable` |
 
-A cache hit records only `cache_lookup_us` and the attributes available on the cached result. Miss-only
-metrics are absent rather than zero. Installed-only metrics are absent for APK files.
-
-Refactor `getPackageDetails` into named, sequential, behavior-preserving stage calculations before
-constructing `AppDetail`. This is required to prevent overlapping timers and to separate certificate,
-signing-scheme, component, and packaging costs precisely.
-
 An optional sub-operation that fails while `AppDetail` remains usable produces `outcome=degraded`.
-The trace must retain the stage duration and availability attribute so degraded requests can be
-filtered away from complete requests.
+Availability attributes allow degraded requests to be filtered away from complete requests.
 
 ### `manifest_load`
 
 This trace measures the complete readable-manifest request from `ManifestParser.manifest`.
-
-| Custom metric | Meaning |
-|---|---|
-| `resource_lookup_us` | Resolve package/archive information and resources |
-| `manifest_parse_us` | Read and parse binary manifest data |
-| `xml_render_us` | Render readable namespaced XML |
-| `split_count` | Additional installed split count |
 
 | Attribute | Values |
 |---|---|
@@ -309,57 +270,44 @@ This trace measures the complete readable-manifest request from `ManifestParser.
 | `analysis_mode` | `installed`, `apk_file` |
 | `split_count_bucket` | `0`, `1_4`, `5_9`, `10_plus` |
 
-If the current renderer cannot expose parsing separately from rendering without duplicating work,
-first refactor it into explicit parse and render stages while preserving output.
-
 ## Supporting Trace Design
 
 Add these traces after the three primary traces use the same infrastructure successfully:
 
-| Trace | Metrics | Key attributes |
-|---|---|---|
-| `app_signing_index_load` | `package_query_us`, `certificate_mapping_us`, `app_count`, `certificate_count` | `outcome`, `trigger`, `app_count_bucket` |
-| `storage_stats_load` | `permission_check_us`, `stats_query_us`, `requested_count`, `loaded_count` | `outcome`, `permission`, `trigger` |
-| `usage_stats_load` | `permission_check_us`, `usage_query_us`, `usage_mapping_us`, `loaded_count` | `outcome`, `permission`, `trigger` |
-| `device_features_load` | `feature_query_us`, `feature_mapping_us`, `feature_count` | `outcome` |
+| Trace | Key attributes |
+|---|---|
+| `app_signing_index_load` | `outcome`, `trigger` |
+| `storage_stats_load` | `outcome`, `permission`, `trigger` |
+| `usage_stats_load` | `outcome`, `permission` |
+| `device_features_load` | `outcome` |
 
 The current enrichment entry points do not carry the installed-list trigger through their public
 repository APIs. Storage reports `trigger=installed_apps` for list-driven requests and
-`trigger=lifecycle_start` for foreground refreshes. Usage has no list-driven bulk refresh and reports
-`trigger=lifecycle_start`; its single-package query remains part of app-detail work. These values
-describe the trigger that each repository can observe without changing its API, cache, flow, or
-dispatcher behavior. Both enrichment traces report `permission=granted|denied` and use
-`outcome=degraded` when permission is missing or a permission/query race yields partial data.
+`trigger=lifecycle_start` for foreground refreshes. Usage has only lifecycle-driven bulk refreshes,
+so it does not record a constant trigger attribute; its single-package query remains part of
+app-detail work. Both enrichment traces report `permission=granted|denied` and use
+`outcome=degraded` when permission is missing or a storage query yields partial data.
 
-Do not emit one remote trace or non-fatal per installed app from bulk operations. One parent trace
-contains aggregate counts and total stage durations. Per-app failures are accumulated into a bounded
-failure count; one non-fatal may be recorded for the operation only when the failure is
-unexpected and materially degrades the result.
+Do not emit one remote trace or non-fatal per installed app from bulk operations. Per-app failures
+are accumulated for logging; one non-fatal may be recorded for the operation only when the failure
+is unexpected and materially degrades the result.
 
 ## Reading the Results
 
-Firebase Performance automatically records the parent duration. Custom metrics appear alongside it
-as aggregate distributions.
+Firebase Performance automatically records each trace duration. Bounded attributes segment those
+duration distributions.
 
 The console can answer:
 
 - What are p50, p90, and p95 for complete and degraded `app_detail_load` requests?
-- How much time do manifest intent filters, certificates, and signing-scheme detection contribute?
 - How do installed-package and APK-file analysis differ?
 - Are cache misses slower in the latest version?
-- Does installed-app loading degrade as the app-count bucket increases?
+- How much of installed-app loading is spent in the package-manager query?
+- How many installed apps are successfully mapped?
 - Are storage or usage enrichments slow only when permission is available?
 
-The Firebase console does not directly provide a nested waterfall, stacked stage chart, or arbitrary
-formulas across custom metrics. Stage metrics must be non-overlapping so their sum approximately
-explains the parent duration. Small gaps are expected from trace bookkeeping, cache operations,
-coroutine dispatch, object construction, and control flow.
-
-Export Performance data to BigQuery only if per-sample percentages, stacked visualizations, or more
-advanced correlations become necessary.
-
-Firebase currently permits 32 metrics including the default duration metric and five custom
-attributes on one custom trace. Every proposed trace remains below both limits.
+If a parent trace is slow, use the chronological stage logs and local profiling to identify the
+cause. Add a remote custom metric only after a concrete production question justifies its code cost.
 
 ## Rollout
 
@@ -389,7 +337,6 @@ attributes on one custom trace. Every proposed trace remains below both limits.
 ### OBS-04: Instrument app-detail loading
 
 - Add `app_detail_load` around installed-package and APK-file requests.
-- Refactor miss processing into the named non-overlapping stages.
 - Report cache state, analysis mode, optional-stage availability, and outcome.
 - Preserve both cache strategies and cancellation propagation.
 
@@ -402,8 +349,7 @@ attributes on one custom trace. Every proposed trace remains below both limits.
 ### OBS-06: Establish baselines and alerts
 
 - Collect at least one representative production release.
-- Track p50, p90, and p95 parent and stage metrics.
-- Segment app-list results by app-count bucket.
+- Track p50, p90, and p95 trace durations.
 - Segment app-detail results by analysis mode, cache hit, completeness, and signing availability.
 - Review Crashlytics non-fatals for duplicate ownership and noisy expected states.
 - Set regression thresholds and alerts only after observing real distributions.
@@ -421,11 +367,8 @@ or frame-level regressions. Keep that trace separate from repository traces.
 - Expected states and cancellation do not create Crashlytics non-fatals.
 - Every unexpected failure produces at most one non-fatal.
 - Firebase reports duration distributions for all primary and supporting traces.
-- `app_detail_load` separately reports manifest intent filters, certificates, signing schemes,
-  components, permissions, features, and packaging.
 - Cache hits and misses, installed packages and APK files, and complete and degraded results can be
   compared independently.
-- Stage metrics are non-overlapping and approximately explain parent duration.
 - No Firebase Performance type leaves the internal `core:common` adapter.
 - Performance attributes contain no package names, APK paths, screen parameters, or other
   high-cardinality request identities.

--- a/docs/technical/repository-load-performance.md
+++ b/docs/technical/repository-load-performance.md
@@ -1,6 +1,6 @@
 # App Loading Observability
 
-**Status:** Proposed
+**Status:** OBS-01 through OBS-03 implemented; later rollout stages proposed
 **Scope:** Production logging and performance measurement for navigation, app discovery, app
 analysis, and their supporting repository operations
 
@@ -222,8 +222,8 @@ Requirements for the adapter and contract:
   closes the handle when the block returns, throws, or is cancelled.
 - Each emitting repository owns private trace, metric, and attribute names that satisfy Firebase
   naming limits. Duration metrics end in `_us` because Firebase custom metrics do not carry a unit.
-- Introduce monotonic stage timing with the first repository instrumentation rather than keeping an
-  unused shared timing abstraction.
+- Use `measureTimedValue` beside each emitting repository and store whole microseconds rather than
+  introducing a shared timing abstraction.
 - Callers record the parent outcome attribute inside the `use` block before it returns or throws.
 - Instrumentation must not change repository results, cache semantics, dispatcher selection, or
   cancellation propagation.
@@ -321,6 +321,14 @@ Add these traces after the three primary traces use the same infrastructure succ
 | `storage_stats_load` | `permission_check_us`, `stats_query_us`, `requested_count`, `loaded_count` | `outcome`, `permission`, `trigger` |
 | `usage_stats_load` | `permission_check_us`, `usage_query_us`, `usage_mapping_us`, `loaded_count` | `outcome`, `permission`, `trigger` |
 | `device_features_load` | `feature_query_us`, `feature_mapping_us`, `feature_count` | `outcome` |
+
+The current enrichment entry points do not carry the installed-list trigger through their public
+repository APIs. Storage reports `trigger=installed_apps` for list-driven requests and
+`trigger=lifecycle_start` for foreground refreshes. Usage has no list-driven bulk refresh and reports
+`trigger=lifecycle_start`; its single-package query remains part of app-detail work. These values
+describe the trigger that each repository can observe without changing its API, cache, flow, or
+dispatcher behavior. Both enrichment traces report `permission=granted|denied` and use
+`outcome=degraded` when permission is missing or a permission/query race yields partial data.
 
 Do not emit one remote trace or non-fatal per installed app from bulk operations. One parent trace
 contains aggregate counts and total stage durations. Per-app failures are accumulated into a bounded


### PR DESCRIPTION
## Summary

- add one `installed_apps_load` trace around the complete basic installed-app load, with only `package_query_ms` and `app_count` as targeted custom metrics
- add independent `storage_stats_load` and `usage_stats_load` traces that rely on Firebase's automatic total duration and bounded outcome, permission, and storage-trigger attributes
- add `startCancellableTrace` so callers automatically record `outcome=cancelled`, preserve cancellation as the primary failure, and close traces exactly once
- expose concise `trace[name] = value` assignment, using `Long` for metrics and `String` for operation-specific attributes
- centralize shared values through `TraceOutcome` / `TracePermission` and typed trace setters
- remove internal stage timing, redundant installed/usage trigger attributes, and usage permission-race telemetry without changing repository APIs, caches, flows, or dispatchers

## Base

Directly based on `develop` after merged PR #141 (`OBS-02: Add performance monitoring infrastructure`).

## Validation

- `.\gradlew.bat spotlessApply`
- `.\gradlew.bat :core:common:compileDebugKotlin :core:common:compileReleaseKotlin :core:apps:compileDebugKotlin :core:apps:compileReleaseKotlin :app:compileDebugKotlin :app:compileReleaseKotlin validateAgentContext`
- `.\gradlew.bat spotlessCheck detektDebug :build-logic:convention:detektMain lintDebug :app:assembleDebug`
- `.\gradlew.bat validateAgentContext`

## Scope

App-detail, manifest, signing-index, and device-feature traces remain for later rollout stages.