### PR TITLE
OBS-05: Instrument manifest and supporting loads

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -22,6 +22,7 @@ ui/
   ApkAnalyzerViewModel.kt               - @HiltViewModel; maps PersistenceRepository.observe(Key.ColorScheme) into ApkAnalyzerState via stateIn(WhileSubscribed(5000)) — exists solely so the Activity can drive day/night mode before the Compose theme renders
   navigation/
     TopLevelDestinations.kt             - internal TOP_LEVEL_DESTINATIONS (persistentListOf<NavigationBarItem>): Apps, Browse tabs with icons/titles; internal TOP_LEVEL_KEYS
+    ScreenOpenLogging.kt                - internal logScreenOpened(key, resolveScreenOpenEvent): centralized INFO screen-opening breadcrumb, shared by ApkAnalyzerApp and the external-APK navigation host
 util/file/
   GenericFileProvider.kt                - FileProvider subclass wired through ${applicationId} in the manifest
 ```
@@ -68,6 +69,17 @@ internal fun ApkAnalyzerApp() {
 navigates *out* to another feature — all four registered here do (browse navigates into
 `feature:app-detail` from its apps screen). **Adding a new feature/screen means adding its
 `*Entries()` call here** — see the `create-feature-module` and `implement-navigation` skills.
+
+`ApkAnalyzerApp` and the external-APK navigation host each run a `LaunchedEffect` that observes
+`snapshotFlow { navigationState.currentKey }.distinctUntilChanged()` and calls
+`logScreenOpened(key, ::resolveScreenOpenEvent)` to emit one centralized INFO
+`operation=navigation event=screen_opened screen=<name> <context>` breadcrumb per distinct
+destination, including the initial/restored one. Each feature owns a `navigation/ScreenNames.kt`
+with a public `screenOpenEvent(key: NavKey): ScreenOpenEvent?` resolver next to its `NavKey`
+declarations (internal `NavKey`s can't be pattern-matched from `app`, so each feature module exposes
+its own resolver rather than a single `when` living here); `resolveScreenOpenEvent` in
+`ApkAnalyzerApp.kt` chains all of them. Screen names are stable identifiers derived from the `NavKey`
+type, never `NavKey.toString()`.
 
 ## Manifest Highlights (`app/src/main/AndroidManifest.xml`)
 

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -13,6 +13,10 @@ Sub-packages: `.dependencyinjection`, `.ui` (`.externalapk`, `.navigation`), `.u
 ApkAnalyzer.kt                          - Application class (@HiltAndroidApp); Coil SingletonImageLoader.Factory; registers injected Set<DefaultLifecycleObserver> multibindings onto ProcessLifecycleOwner
 dependencyinjection/
   ApplicationModule.kt                  - @InstallIn(SingletonComponent) @Module: app-scoped CoroutineScope
+performance/
+  FirebasePerformanceTracker.kt         - Safe Firebase Performance adapter with independent,
+                                          thread-safe, idempotently stopped trace handles
+  PerformanceModule.kt                  - Singleton Hilt binding for the core:common PerformanceTracker
 ui/
   ApkAnalyzerActivity.kt                - @AndroidEntryPoint launcher Activity; observes ApkAnalyzerViewModel.state for color scheme and hosts ApkAnalyzerApp
   ApkAnalyzerThemeHost.kt               - Shared Compose theme/night-mode host used by both activities
@@ -26,6 +30,10 @@ ui/
 util/file/
   GenericFileProvider.kt                - FileProvider subclass wired through ${applicationId} in the manifest
 ```
+
+`monitoringValidation` is a debug-derived local-only build type that enables Crashlytics and
+Performance collection and adds an adb-driven `MonitoringValidationReceiver`. Normal `debug` builds
+disable both SDKs, `release` builds enable both, and the validation receiver is absent from both.
 
 ## How `ApkAnalyzerApp.kt` wires every feature together
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,9 +14,24 @@ android {
     defaultConfig {
         applicationId = "sk.styk.martin.apkanalyzer"
         proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+        manifestPlaceholders["firebaseCollectionEnabled"] = false
+        manifestPlaceholders["firebasePerformanceLogcatEnabled"] = false
 
         versionCode = (project.findProperty("version.code") as String).toInt()
         versionName = project.findProperty("version.name") as String
+    }
+
+    buildTypes {
+        getByName("release") {
+            manifestPlaceholders["firebaseCollectionEnabled"] = true
+        }
+        create("monitoringValidation") {
+            initWith(getByName("debug"))
+            matchingFallbacks += "debug"
+            signingConfig = signingConfigs.getByName("debug")
+            manifestPlaceholders["firebaseCollectionEnabled"] = true
+            manifestPlaceholders["firebasePerformanceLogcatEnabled"] = true
+        }
     }
 
     buildFeatures {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,6 +59,15 @@
         <meta-data
             android:name="google_analytics_automatic_screen_reporting_enabled"
             android:value="false" />
+        <meta-data
+            android:name="firebase_crashlytics_collection_enabled"
+            android:value="${firebaseCollectionEnabled}" />
+        <meta-data
+            android:name="firebase_performance_collection_enabled"
+            android:value="${firebaseCollectionEnabled}" />
+        <meta-data
+            android:name="firebase_performance_logcat_enabled"
+            android:value="${firebasePerformanceLogcatEnabled}" />
 
     </application>
 

--- a/app/src/main/kotlin/sk/styk/martin/apkanalyzer/performance/FirebasePerformanceTracker.kt
+++ b/app/src/main/kotlin/sk/styk/martin/apkanalyzer/performance/FirebasePerformanceTracker.kt
@@ -1,0 +1,75 @@
+package sk.styk.martin.apkanalyzer.performance
+
+import com.google.firebase.perf.FirebasePerformance
+import com.google.firebase.perf.metrics.Trace
+import sk.styk.martin.apkanalyzer.core.common.logger.Logger
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTrace
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+internal class FirebasePerformanceTracker
+@Inject
+constructor() : PerformanceTracker {
+    override fun startTrace(name: String): PerformanceTrace {
+        val trace = runFirebasePerformanceOperation("start trace name=$name") {
+            FirebasePerformance.getInstance().newTrace(name).apply(Trace::start)
+        }
+        return if (trace == null) {
+            NoOpPerformanceTrace()
+        } else {
+            FirebasePerformanceTrace(trace)
+        }
+    }
+}
+
+private class FirebasePerformanceTrace(private val trace: Trace) : PerformanceTrace {
+    private val lock = Any()
+    private var isStopped = false
+
+    override fun putMetric(name: String, value: Long) {
+        synchronized(lock) {
+            if (isStopped) return
+            runFirebasePerformanceOperation("record metric name=$name") {
+                trace.putMetric(name, value)
+            }
+        }
+    }
+
+    override fun putAttribute(name: String, value: String) {
+        synchronized(lock) {
+            if (isStopped) return
+            runFirebasePerformanceOperation("record attribute name=$name") {
+                trace.putAttribute(name, value)
+            }
+        }
+    }
+
+    override fun stop() {
+        synchronized(lock) {
+            if (isStopped) return
+            isStopped = true
+            runFirebasePerformanceOperation("stop trace") {
+                trace.stop()
+            }
+        }
+    }
+}
+
+private class NoOpPerformanceTrace : PerformanceTrace {
+    override fun putMetric(name: String, value: Long) = Unit
+
+    override fun putAttribute(name: String, value: String) = Unit
+
+    override fun stop() = Unit
+}
+
+private inline fun <T> runFirebasePerformanceOperation(operation: String, block: () -> T): T? = try {
+    block()
+} catch (exception: RuntimeException) {
+    Logger.w(TAG, exception, "Firebase Performance failed to $operation")
+    null
+}
+
+private const val TAG = "FirebasePerformance"

--- a/app/src/main/kotlin/sk/styk/martin/apkanalyzer/performance/PerformanceModule.kt
+++ b/app/src/main/kotlin/sk/styk/martin/apkanalyzer/performance/PerformanceModule.kt
@@ -1,0 +1,16 @@
+package sk.styk.martin.apkanalyzer.performance
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal interface PerformanceModule {
+    @Binds
+    @Singleton
+    fun bindPerformanceTracker(implementation: FirebasePerformanceTracker): PerformanceTracker
+}

--- a/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/ApkAnalyzerApp.kt
+++ b/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/ApkAnalyzerApp.kt
@@ -8,12 +8,17 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.ui.NavDisplay
+import kotlinx.coroutines.flow.distinctUntilChanged
 import sk.styk.martin.apkanalyzer.core.navigation.Navigator
+import sk.styk.martin.apkanalyzer.core.navigation.ScreenOpenEvent
 import sk.styk.martin.apkanalyzer.core.navigation.rememberNavigationState
 import sk.styk.martin.apkanalyzer.core.navigation.toEntries
 import sk.styk.martin.apkanalyzer.core.uilibrary.components.NavigationBar
@@ -25,6 +30,11 @@ import sk.styk.martin.apkanalyzer.feature.browse.impl.navigation.browseEntries
 import sk.styk.martin.apkanalyzer.feature.settings.impl.navigation.settingsEntries
 import sk.styk.martin.apkanalyzer.ui.navigation.TOP_LEVEL_DESTINATIONS
 import sk.styk.martin.apkanalyzer.ui.navigation.TOP_LEVEL_KEYS
+import sk.styk.martin.apkanalyzer.ui.navigation.logScreenOpened
+import sk.styk.martin.apkanalyzer.feature.appdetail.impl.navigation.screenOpenEvent as appDetailScreenOpenEvent
+import sk.styk.martin.apkanalyzer.feature.apps.impl.navigation.screenOpenEvent as appsScreenOpenEvent
+import sk.styk.martin.apkanalyzer.feature.browse.impl.navigation.screenOpenEvent as browseScreenOpenEvent
+import sk.styk.martin.apkanalyzer.feature.settings.impl.navigation.screenOpenEvent as settingsScreenOpenEvent
 
 @Composable
 internal fun ApkAnalyzerApp() {
@@ -34,6 +44,12 @@ internal fun ApkAnalyzerApp() {
     )
     val navigator = remember {
         Navigator(navigationState)
+    }
+
+    LaunchedEffect(navigationState) {
+        snapshotFlow { navigationState.currentKey }
+            .distinctUntilChanged()
+            .collect { key -> logScreenOpened(key, ::resolveScreenOpenEvent) }
     }
 
     Scaffold { paddings ->
@@ -65,3 +81,8 @@ internal fun ApkAnalyzerApp() {
         }
     }
 }
+
+private fun resolveScreenOpenEvent(key: NavKey): ScreenOpenEvent? = appsScreenOpenEvent(key)
+    ?: appDetailScreenOpenEvent(key)
+    ?: browseScreenOpenEvent(key)
+    ?: settingsScreenOpenEvent(key)

--- a/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/externalapk/ExternalApkApp.kt
+++ b/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/externalapk/ExternalApkApp.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
@@ -18,6 +19,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.ui.NavDisplay
+import kotlinx.coroutines.flow.distinctUntilChanged
 import sk.styk.martin.apkanalyzer.R
 import sk.styk.martin.apkanalyzer.core.navigation.Navigator
 import sk.styk.martin.apkanalyzer.core.navigation.rememberNavigationState
@@ -28,6 +30,8 @@ import sk.styk.martin.apkanalyzer.core.uilibrary.theme.ApkAnalyzerTheme
 import sk.styk.martin.apkanalyzer.feature.appdetail.api.AppDetailInput
 import sk.styk.martin.apkanalyzer.feature.appdetail.api.AppDetailNavKey
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.navigation.appDetailEntries
+import sk.styk.martin.apkanalyzer.ui.navigation.logScreenOpened
+import sk.styk.martin.apkanalyzer.feature.appdetail.impl.navigation.screenOpenEvent as appDetailScreenOpenEvent
 
 @Composable
 internal fun ExternalApkApp(
@@ -79,6 +83,12 @@ private fun ExternalApkNavigation(
             navigationState = navigationState,
             onBackAtRoot = onClose,
         )
+    }
+
+    LaunchedEffect(navigationState) {
+        snapshotFlow { navigationState.currentKey }
+            .distinctUntilChanged()
+            .collect { key -> logScreenOpened(key, ::appDetailScreenOpenEvent) }
     }
 
     Scaffold(modifier = modifier) { paddings ->

--- a/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/navigation/ScreenOpenLogging.kt
+++ b/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/navigation/ScreenOpenLogging.kt
@@ -9,10 +9,7 @@ private const val OPERATION = "navigation"
 
 internal fun logScreenOpened(key: NavKey, resolveScreenOpenEvent: (NavKey) -> ScreenOpenEvent?) {
     val event = resolveScreenOpenEvent(key) ?: return
-    val message = if (event.context != null) {
-        "operation=$OPERATION event=screen_opened screen=${event.screen} ${event.context}"
-    } else {
-        "operation=$OPERATION event=screen_opened screen=${event.screen}"
-    }
+    val baseMessage = "operation=$OPERATION event=screen_opened screen=${event.screen}"
+    val message = event.context?.let { "$baseMessage $it" } ?: baseMessage
     Logger.i(TAG, message)
 }

--- a/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/navigation/ScreenOpenLogging.kt
+++ b/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/navigation/ScreenOpenLogging.kt
@@ -1,0 +1,18 @@
+package sk.styk.martin.apkanalyzer.ui.navigation
+
+import androidx.navigation3.runtime.NavKey
+import sk.styk.martin.apkanalyzer.core.common.logger.Logger
+import sk.styk.martin.apkanalyzer.core.navigation.ScreenOpenEvent
+
+private const val TAG = "Navigation"
+private const val OPERATION = "navigation"
+
+internal fun logScreenOpened(key: NavKey, resolveScreenOpenEvent: (NavKey) -> ScreenOpenEvent?) {
+    val event = resolveScreenOpenEvent(key) ?: return
+    val message = if (event.context != null) {
+        "operation=$OPERATION event=screen_opened screen=${event.screen} ${event.context}"
+    } else {
+        "operation=$OPERATION event=screen_opened screen=${event.screen}"
+    }
+    Logger.i(TAG, message)
+}

--- a/app/src/monitoringValidation/AndroidManifest.xml
+++ b/app/src/monitoringValidation/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <receiver
+            android:name=".monitoring.MonitoringValidationReceiver"
+            android:exported="true" />
+    </application>
+
+</manifest>

--- a/app/src/monitoringValidation/kotlin/sk/styk/martin/apkanalyzer/monitoring/MonitoringValidationReceiver.kt
+++ b/app/src/monitoringValidation/kotlin/sk/styk/martin/apkanalyzer/monitoring/MonitoringValidationReceiver.kt
@@ -1,0 +1,45 @@
+package sk.styk.martin.apkanalyzer.monitoring
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import dagger.hilt.android.AndroidEntryPoint
+import sk.styk.martin.apkanalyzer.core.common.logger.Logger
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
+import javax.inject.Inject
+
+@AndroidEntryPoint
+internal class MonitoringValidationReceiver : BroadcastReceiver() {
+    @Inject
+    lateinit var performanceTracker: PerformanceTracker
+
+    override fun onReceive(context: Context, intent: Intent) {
+        when (intent.getStringExtra(EXTRA_SIGNAL)) {
+            SIGNAL_CRASH -> throw IllegalStateException("Intentional monitoring validation crash")
+
+            SIGNAL_NON_FATAL -> Logger.e(
+                TAG,
+                IllegalStateException("Intentional monitoring validation non-fatal"),
+                "Recording intentional monitoring validation non-fatal",
+            )
+
+            SIGNAL_PERFORMANCE -> performanceTracker.startTrace(VALIDATION_TRACE).run {
+                putMetric(VALIDATION_METRIC, 1L)
+                putAttribute(VALIDATION_ATTRIBUTE, VALIDATION_ATTRIBUTE_VALUE)
+                stop()
+            }
+
+            else -> Logger.w(TAG, "Unknown monitoring validation signal")
+        }
+    }
+}
+
+private const val EXTRA_SIGNAL = "signal"
+private const val SIGNAL_CRASH = "crash"
+private const val SIGNAL_NON_FATAL = "non_fatal"
+private const val SIGNAL_PERFORMANCE = "performance"
+private const val VALIDATION_TRACE = "monitoring_validation"
+private const val VALIDATION_METRIC = "validation_us"
+private const val VALIDATION_ATTRIBUTE = "outcome"
+private const val VALIDATION_ATTRIBUTE_VALUE = "success"
+private const val TAG = "MonitoringValidation"

--- a/core/apps/AGENTS.md
+++ b/core/apps/AGENTS.md
@@ -62,9 +62,11 @@ components/
                             entries) and the `ProviderPathMatchType` enum for `PatternMatcher`'s int type
   ContentProviderPathPermissions.kt (internal) - `resolvePathPermissions` mapping raw `PathPermission`s
 manifest/                           - the XML-parsing engine that produces component data above
-  ManifestParser.kt / Impl           - Installed/APK AndroidManifest.xml parsing into readable namespaced XML
+  ManifestParser.kt / Impl           - Installed/APK AndroidManifest.xml parsing into readable namespaced XML;
+                                       owns manifest_load resource/parse/render stage timing
                                        and component intent filters
-  ManifestXmlRenderer.kt / Impl (internal)      - Renders parsed manifest XML for display
+  ManifestXmlRenderer.kt / Impl (internal)      - Parses binary XML once into an internal event document,
+                                                  then renders that document for display
   ComponentManifestParser.kt / Impl (internal)  - Intent-filter extraction engine `ManifestParser` delegates to
 installsource/
   InstallSourceChain.kt   - Installing/initiating/originating package, one nested fact on `AppInfo`
@@ -140,6 +142,15 @@ di/                       - Hilt module bindings (single `AppsModule.kt`, groupe
   signing-scheme, installed-only launcher, component, permission, feature, and packaging metrics.
   `outcome=degraded` is based only on the intent-filter and signing-scheme availability facts persisted
   in `AppDetail`, so cached and uncached classification stays consistent.
+- `ManifestParserImpl` owns `manifest_load` for both installed and APK-file readable manifests.
+  Resource lookup, the single binary-parser pass, and XML string rendering are sequential and
+  non-overlapping. Split metrics are emitted only after the real split count is available.
+- `AppSigningRepositoryImpl` owns one aggregate `app_signing_index_load` for each initial or
+  package-change reload. Package querying and certificate mapping are separate stages; app and
+  returned-certificate counts are aggregate metrics, never per-app traces.
+- `DeviceFeaturesRepositoryImpl` owns `device_features_load` around its one lazy platform query and
+  mapping pass. A query failure retains the existing `DeviceFeatures.Unknown` fallback and reports a
+  degraded trace; cache reads do not emit empty traces.
 - Every trace records one terminal outcome and stops in `finally`. Bulk operations aggregate counts
   and durations; never create a trace per installed app.
 

--- a/core/apps/AGENTS.md
+++ b/core/apps/AGENTS.md
@@ -134,8 +134,20 @@ di/                       - Hilt module bindings (single `AppsModule.kt`, groupe
   `installed_apps` for list-driven requests and `lifecycle_start` for foreground refreshes.
 - `UsageStatsRepositoryImpl` owns `usage_stats_load` for its lifecycle refresh. Single-package
   `queryLastUsedTime` calls belong to app-detail work and are not part of this trace.
+- `AppDetailRepositoryImpl` owns one `app_detail_load` trace from public `details()` entry through
+  cache lookup and miss processing. Cache hits record only `cache_lookup_us`; misses record sequential,
+  non-overlapping package, intent-filter, installed-only storage/usage, general-info, certificate,
+  signing-scheme, installed-only launcher, component, permission, feature, and packaging metrics.
+  `outcome=degraded` is based only on the intent-filter and signing-scheme availability facts persisted
+  in `AppDetail`, so cached and uncached classification stays consistent.
 - Every trace records one terminal outcome and stops in `finally`. Bulk operations aggregate counts
   and durations; never create a trace per installed app.
+
+`AppDetail` cannot currently distinguish missing storage/usage permission or query failure from a
+legitimate nullable value. `NativeLibraries.Empty` cannot distinguish an APK with no libraries from a
+handled ZIP-read failure, certificate extraction has the same empty-result ambiguity, and a null
+signing-scheme list combines no detected supported scheme with analyzer failure. Performance attributes
+must describe these as availability only and must not infer a failure reason.
 
 ## Signing Certificate Semantics
 

--- a/core/apps/AGENTS.md
+++ b/core/apps/AGENTS.md
@@ -126,6 +126,17 @@ di/                       - Hilt module bindings (single `AppsModule.kt`, groupe
 - `StorageStatsRepository.isPermissionGranted: StateFlow<Boolean>` - Usage access permission state
 - `UsageStatsRepository.isPermissionGranted: StateFlow<Boolean>` - Usage stats permission state
 
+## Performance Traces
+
+- `InstalledAppsRepositoryImpl` owns one `installed_apps_load` trace around the package query and
+  basic `InstalledApp` mapping only. Storage and usage enrichment must never extend this trace.
+- `StorageStatsRepositoryImpl` owns `storage_stats_load`; its observable triggers are
+  `installed_apps` for list-driven requests and `lifecycle_start` for foreground refreshes.
+- `UsageStatsRepositoryImpl` owns `usage_stats_load` for its lifecycle refresh. Single-package
+  `queryLastUsedTime` calls belong to app-detail work and are not part of this trace.
+- Every trace records one terminal outcome and stops in `finally`. Bulk operations aggregate counts
+  and durations; never create a trace per installed app.
+
 ## Signing Certificate Semantics
 
 - `SigningInfo.apkContentsSigners` contains the current signer set. Multiple current signers are one

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
@@ -45,6 +45,8 @@ import sk.styk.martin.apkanalyzer.core.apps.usagestats.UsageStatsRepository
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
 import sk.styk.martin.apkanalyzer.core.common.coroutines.runCatchingCancellable
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
+import sk.styk.martin.apkanalyzer.core.common.logger.nextOperationRequest
+import sk.styk.martin.apkanalyzer.core.common.logger.operationLogMessage
 import sk.styk.martin.apkanalyzer.core.common.model.AppReference
 import sk.styk.martin.apkanalyzer.core.common.model.AppSize
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
@@ -53,6 +55,7 @@ import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.cancellation.CancellationException
 
 @Suppress("TooManyFunctions")
 @Singleton
@@ -95,72 +98,217 @@ internal class AppDetailRepositoryImpl @Inject constructor(
     }
 
     private suspend fun installedPackageDetails(packageName: PackageName): Result<AppDetail> {
+        val requestId = nextOperationRequest()
+        val context = "mode=installed package=${packageName.value}"
         val cacheKey = CacheKey.InstalledPackage(packageName)
-        cache[cacheKey]?.let { return Result.success(it) }
-        Logger.d(TAG, "Loading details of $packageName")
-        return runCatchingCancellable {
-            val reference = AppReference.InstalledPackage(packageName)
-            val packageInfo = packageManager.getPackageInfo(packageName.value, analysisFlags)
-            val intentFilters = manifestParser.componentIntentFilters(reference)
-            getPackageDetails(
-                analysisMode = AppDetail.AnalysisMode.InstalledPackage,
-                packageInfo = packageInfo,
-                intentFiltersByComponent = intentFilters.getOrDefault(emptyMap()),
-                areIntentFiltersAvailable = intentFilters.isSuccess,
-                totalSize = storageStatsRepository.queryTotalSize(packageName),
-                lastUsedTime = usageStatsRepository.queryLastUsedTime(packageName),
-            )
-        }.onSuccess { cache[cacheKey] = it }
+        Logger.d(TAG, operationLogMessage(OPERATION, requestId, event = "started", context = context))
+        Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_CACHE_LOOKUP, event = "started", context = context))
+        cache[cacheKey]?.let {
+            Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_CACHE_LOOKUP, event = "succeeded", context = "cache_hit=true $context"))
+            val event = if (it.areComponentIntentFiltersAvailable) "succeeded" else "degraded"
+            Logger.i(TAG, operationLogMessage(OPERATION, requestId, event = event, context = "cache_hit=true $context"))
+            return Result.success(it)
+        }
+
+        Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_CACHE_LOOKUP, event = "succeeded", context = "cache_hit=false $context"))
+        return try {
+            runCatchingCancellable {
+                val reference = AppReference.InstalledPackage(packageName)
+
+                Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_PACKAGE_QUERY, event = "started", context = context))
+                val packageInfo = packageManager.getPackageInfo(packageName.value, analysisFlags)
+                Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_PACKAGE_QUERY, event = "succeeded", context = context))
+
+                val intentFilters = manifestParser.componentIntentFilters(reference)
+                Logger.d(
+                    TAG,
+                    operationLogMessage(
+                        OPERATION,
+                        requestId,
+                        stage = STAGE_INTENT_FILTERS,
+                        event = if (intentFilters.isSuccess) "succeeded" else "degraded",
+                        context = context,
+                    ),
+                )
+
+                val totalSize = storageStatsRepository.queryTotalSize(packageName)
+                Logger.d(
+                    TAG,
+                    operationLogMessage(
+                        OPERATION,
+                        requestId,
+                        stage = STAGE_STORAGE_STATS,
+                        event = if (totalSize != null) "succeeded" else "degraded",
+                        context = "available=${totalSize != null} $context",
+                    ),
+                )
+
+                val lastUsedTime = usageStatsRepository.queryLastUsedTime(packageName)
+                Logger.d(
+                    TAG,
+                    operationLogMessage(
+                        OPERATION,
+                        requestId,
+                        stage = STAGE_USAGE_STATS,
+                        event = if (lastUsedTime != null) "succeeded" else "degraded",
+                        context = "available=${lastUsedTime != null} $context",
+                    ),
+                )
+
+                getPackageDetails(
+                    requestId = requestId,
+                    context = context,
+                    analysisMode = AppDetail.AnalysisMode.InstalledPackage,
+                    packageInfo = packageInfo,
+                    intentFiltersByComponent = intentFilters.getOrDefault(emptyMap()),
+                    areIntentFiltersAvailable = intentFilters.isSuccess,
+                    totalSize = totalSize,
+                    lastUsedTime = lastUsedTime,
+                )
+            }.onSuccess { detail ->
+                cache[cacheKey] = detail
+                val event = if (detail.areComponentIntentFiltersAvailable) "succeeded" else "degraded"
+                Logger.i(TAG, operationLogMessage(OPERATION, requestId, event = event, context = context))
+            }.onFailure {
+                Logger.e(TAG, it, operationLogMessage(OPERATION, requestId, event = "failed", context = context))
+            }
+        } catch (cancellation: CancellationException) {
+            Logger.d(TAG, operationLogMessage(OPERATION, requestId, event = "cancelled", context = context))
+            throw cancellation
+        }
     }
 
     private suspend fun apkFilePackageDetails(accessibleFile: File): Result<AppDetail> {
+        val requestId = nextOperationRequest()
+        val context = "mode=apk_file apk_path=${accessibleFile.absolutePath}"
         val cacheKey = CacheKey.ApkFile(accessibleFile.absolutePath, accessibleFile.lastModified())
-        cache[cacheKey]?.let { return Result.success(it) }
-        Logger.d(TAG, "Loading details of ${accessibleFile.absolutePath}")
-        return runCatchingCancellable {
-            val reference = AppReference.ApkFile(accessibleFile.absolutePath)
-            val intentFilters = manifestParser.componentIntentFilters(reference)
-            getPackageDetails(
-                analysisMode = AppDetail.AnalysisMode.ApkFile,
-                packageInfo = packageManager.getPackageArchiveInfoWithCorrectPath(accessibleFile.absolutePath, analysisFlags)
-                    ?: error("Cannot parse APK file: ${accessibleFile.absolutePath}"),
-                intentFiltersByComponent = intentFilters.getOrDefault(emptyMap()),
-                areIntentFiltersAvailable = intentFilters.isSuccess,
-            )
-        }.onSuccess { cache[cacheKey] = it }
+        Logger.d(TAG, operationLogMessage(OPERATION, requestId, event = "started", context = context))
+        Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_CACHE_LOOKUP, event = "started", context = context))
+        cache[cacheKey]?.let {
+            Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_CACHE_LOOKUP, event = "succeeded", context = "cache_hit=true $context"))
+            val event = if (it.areComponentIntentFiltersAvailable) "succeeded" else "degraded"
+            Logger.i(TAG, operationLogMessage(OPERATION, requestId, event = event, context = "cache_hit=true $context"))
+            return Result.success(it)
+        }
+
+        Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_CACHE_LOOKUP, event = "succeeded", context = "cache_hit=false $context"))
+        return try {
+            runCatchingCancellable {
+                val reference = AppReference.ApkFile(accessibleFile.absolutePath)
+
+                Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_PACKAGE_QUERY, event = "started", context = context))
+                val packageInfo = packageManager.getPackageArchiveInfoWithCorrectPath(accessibleFile.absolutePath, analysisFlags)
+                    ?: error("Cannot parse APK file: ${accessibleFile.absolutePath}")
+                Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_PACKAGE_QUERY, event = "succeeded", context = context))
+
+                val intentFilters = manifestParser.componentIntentFilters(reference)
+                Logger.d(
+                    TAG,
+                    operationLogMessage(
+                        OPERATION,
+                        requestId,
+                        stage = STAGE_INTENT_FILTERS,
+                        event = if (intentFilters.isSuccess) "succeeded" else "degraded",
+                        context = context,
+                    ),
+                )
+
+                getPackageDetails(
+                    requestId = requestId,
+                    context = context,
+                    analysisMode = AppDetail.AnalysisMode.ApkFile,
+                    packageInfo = packageInfo,
+                    intentFiltersByComponent = intentFilters.getOrDefault(emptyMap()),
+                    areIntentFiltersAvailable = intentFilters.isSuccess,
+                )
+            }.onSuccess { detail ->
+                cache[cacheKey] = detail
+                val event = if (detail.areComponentIntentFiltersAvailable) "succeeded" else "degraded"
+                Logger.i(TAG, operationLogMessage(OPERATION, requestId, event = event, context = context))
+            }.onFailure {
+                Logger.e(TAG, it, operationLogMessage(OPERATION, requestId, event = "failed", context = context))
+            }
+        } catch (cancellation: CancellationException) {
+            Logger.d(TAG, operationLogMessage(OPERATION, requestId, event = "cancelled", context = context))
+            throw cancellation
+        }
     }
 
     private fun getPackageDetails(
+        requestId: Long,
+        context: String,
         analysisMode: AppDetail.AnalysisMode,
         packageInfo: PackageInfo,
         intentFiltersByComponent: Map<ComponentIntentFilterKey, List<ComponentIntentFilter>>,
         areIntentFiltersAvailable: Boolean,
         totalSize: AppSize? = null,
         lastUsedTime: Instant? = null,
-    ) = AppDetail(
-        analysisMode = analysisMode,
-        info = getGeneralData(packageInfo, totalSize, lastUsedTime),
-        signing = certificateExtractor.getAppSigning(packageInfo)
-            .copy(
-                signingSchemeVersions = packageInfo.applicationInfo?.sourceDir
-                    ?.let(apkSigningBlockAnalyzer::detectSchemeVersions),
+    ): AppDetail {
+        Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_GENERAL_INFO, event = "started", context = context))
+        val info = getGeneralData(packageInfo, totalSize, lastUsedTime)
+        Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_GENERAL_INFO, event = "succeeded", context = context))
+
+        Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_CERTIFICATES, event = "started", context = context))
+        val signing = certificateExtractor.getAppSigning(packageInfo)
+        Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_CERTIFICATES, event = "succeeded", context = context))
+
+        Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_SIGNING_SCHEMES, event = "started", context = context))
+        val signingSchemeVersions = packageInfo.applicationInfo?.sourceDir?.let(apkSigningBlockAnalyzer::detectSchemeVersions)
+        Logger.d(
+            TAG,
+            operationLogMessage(
+                OPERATION,
+                requestId,
+                stage = STAGE_SIGNING_SCHEMES,
+                event = if (signingSchemeVersions != null) "succeeded" else "degraded",
+                context = context,
             ),
-        activities = getActivities(
-            packageInfo = packageInfo,
-            launcherActivityNames = when (analysisMode) {
-                AppDetail.AnalysisMode.InstalledPackage -> queryLauncherActivityNames(PackageName(packageInfo.packageName))
-                AppDetail.AnalysisMode.ApkFile -> null
-            },
-            intentFiltersByComponent = intentFiltersByComponent,
-        ),
-        services = getServices(packageInfo, intentFiltersByComponent),
-        contentProviders = getContentProviders(packageInfo, intentFiltersByComponent),
-        receivers = getBroadcastReceivers(packageInfo, intentFiltersByComponent),
-        permissions = getPermissions(packageInfo),
-        features = getFeatures(packageInfo),
-        nativeLibraries = readNativeLibraries(packageInfo.applicationInfo),
-        areComponentIntentFiltersAvailable = areIntentFiltersAvailable,
-    )
+        )
+
+        val launcherActivityNames = when (analysisMode) {
+            AppDetail.AnalysisMode.InstalledPackage -> {
+                Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_LAUNCHER_QUERY, event = "started", context = context))
+                queryLauncherActivityNames(PackageName(packageInfo.packageName)).also {
+                    Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_LAUNCHER_QUERY, event = "succeeded", context = context))
+                }
+            }
+
+            AppDetail.AnalysisMode.ApkFile -> null
+        }
+
+        Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_COMPONENT_MAPPING, event = "started", context = context))
+        val activities = getActivities(packageInfo, launcherActivityNames, intentFiltersByComponent)
+        val services = getServices(packageInfo, intentFiltersByComponent)
+        val contentProviders = getContentProviders(packageInfo, intentFiltersByComponent)
+        val receivers = getBroadcastReceivers(packageInfo, intentFiltersByComponent)
+        Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_COMPONENT_MAPPING, event = "succeeded", context = context))
+
+        Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_PERMISSIONS, event = "started", context = context))
+        val permissions = getPermissions(packageInfo)
+        Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_PERMISSIONS, event = "succeeded", context = context))
+
+        Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_FEATURES, event = "started", context = context))
+        val features = getFeatures(packageInfo)
+        Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_FEATURES, event = "succeeded", context = context))
+
+        Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_PACKAGING, event = "started", context = context))
+        val nativeLibraries = readNativeLibraries(packageInfo.applicationInfo)
+        Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_PACKAGING, event = "succeeded", context = context))
+
+        return AppDetail(
+            analysisMode = analysisMode,
+            info = info,
+            signing = signing.copy(signingSchemeVersions = signingSchemeVersions),
+            activities = activities,
+            services = services,
+            contentProviders = contentProviders,
+            receivers = receivers,
+            permissions = permissions,
+            features = features,
+            nativeLibraries = nativeLibraries,
+            areComponentIntentFiltersAvailable = areIntentFiltersAvailable,
+        )
+    }
 
     private fun getGeneralData(
         packageInfo: PackageInfo,
@@ -226,7 +374,7 @@ internal class AppDetailRepositoryImpl @Inject constructor(
         .flatMap { category ->
             val intent = Intent(Intent.ACTION_MAIN).addCategory(category).setPackage(packageName.value)
             runCatching { packageManager.queryIntentActivities(intent, 0) }
-                .onFailure { Logger.w(TAG, "Can not resolve launcher activities of $packageName") }
+                .onFailure { Logger.w(TAG, it, "Can not resolve launcher activities of $packageName") }
                 .getOrDefault(emptyList())
                 .map { it.activityInfo.name }
         }
@@ -336,6 +484,20 @@ internal class AppDetailRepositoryImpl @Inject constructor(
 
     companion object {
         private const val TAG = "AppDetailRepositoryImpl"
+        private const val OPERATION = "app_detail"
+        private const val STAGE_CACHE_LOOKUP = "cache_lookup"
+        private const val STAGE_PACKAGE_QUERY = "package_query"
+        private const val STAGE_INTENT_FILTERS = "intent_filters"
+        private const val STAGE_STORAGE_STATS = "storage_stats"
+        private const val STAGE_USAGE_STATS = "usage_stats"
+        private const val STAGE_GENERAL_INFO = "general_info"
+        private const val STAGE_CERTIFICATES = "certificates"
+        private const val STAGE_SIGNING_SCHEMES = "signing_schemes"
+        private const val STAGE_LAUNCHER_QUERY = "launcher_query"
+        private const val STAGE_COMPONENT_MAPPING = "component_mapping"
+        private const val STAGE_PERMISSIONS = "permissions"
+        private const val STAGE_FEATURES = "features"
+        private const val STAGE_PACKAGING = "packaging"
 
         private val launcherCategories = listOf(Intent.CATEGORY_LAUNCHER, Intent.CATEGORY_LEANBACK_LAUNCHER)
     }

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
@@ -28,6 +28,8 @@ import sk.styk.martin.apkanalyzer.core.apps.manifest.ManifestParser
 import sk.styk.martin.apkanalyzer.core.apps.model.AppDetail
 import sk.styk.martin.apkanalyzer.core.apps.model.AppInfo
 import sk.styk.martin.apkanalyzer.core.apps.model.InstallLocation
+import sk.styk.martin.apkanalyzer.core.apps.packaging.InstalledSplitApk
+import sk.styk.martin.apkanalyzer.core.apps.packaging.NativeLibraries
 import sk.styk.martin.apkanalyzer.core.apps.packaging.computeApkSize
 import sk.styk.martin.apkanalyzer.core.apps.packaging.readInstalledSplits
 import sk.styk.martin.apkanalyzer.core.apps.packaging.readNativeLibraries
@@ -50,6 +52,13 @@ import sk.styk.martin.apkanalyzer.core.common.logger.operationLogMessage
 import sk.styk.martin.apkanalyzer.core.common.model.AppReference
 import sk.styk.martin.apkanalyzer.core.common.model.AppSize
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceAttributeName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceMetricName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTrace
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTraceName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
+import sk.styk.martin.apkanalyzer.core.common.performance.measureStage
+import sk.styk.martin.apkanalyzer.core.common.performance.measureSuspendStage
 import java.io.File
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
@@ -71,6 +80,7 @@ internal class AppDetailRepositoryImpl @Inject constructor(
     packageChangesObserver: PackageChangesObserver,
     appScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
+    private val performanceTracker: PerformanceTracker,
 ) : AppDetailRepository {
 
     private val cache = ConcurrentHashMap<CacheKey, AppDetail>()
@@ -92,21 +102,42 @@ internal class AppDetailRepositoryImpl @Inject constructor(
             .launchIn(appScope + dispatcherProvider.default())
     }
 
-    override suspend fun details(reference: AppReference): Result<AppDetail> = when (reference) {
-        is AppReference.InstalledPackage -> installedPackageDetails(reference.packageName)
-        is AppReference.ApkFile -> apkFilePackageDetails(File(reference.path))
+    override suspend fun details(reference: AppReference): Result<AppDetail> {
+        val trace = performanceTracker.startTrace(PerformanceTraceName.APP_DETAIL_LOAD)
+        trace.putAttribute(PerformanceAttributeName.ANALYSIS_MODE, reference.analysisModeAttribute)
+        var outcome = OUTCOME_ERROR
+        try {
+            val result = when (reference) {
+                is AppReference.InstalledPackage -> installedPackageDetails(reference.packageName, trace)
+                is AppReference.ApkFile -> apkFilePackageDetails(File(reference.path), trace)
+            }
+            result.onSuccess(trace::putAvailabilityAttributes)
+            outcome = result.fold(
+                onSuccess = { detail -> if (detail.isPerformanceDegraded) OUTCOME_DEGRADED else OUTCOME_SUCCESS },
+                onFailure = { OUTCOME_ERROR },
+            )
+            return result
+        } catch (cancellation: CancellationException) {
+            outcome = OUTCOME_CANCELLED
+            throw cancellation
+        } finally {
+            trace.putAttribute(PerformanceAttributeName.OUTCOME, outcome)
+            trace.stop()
+        }
     }
 
     @Suppress("SuspendFunSwallowedCancellation")
-    private suspend fun installedPackageDetails(packageName: PackageName): Result<AppDetail> {
+    private suspend fun installedPackageDetails(packageName: PackageName, trace: PerformanceTrace): Result<AppDetail> {
         val requestId = nextOperationRequest()
         val context = "mode=installed package=${packageName.value}"
         val cacheKey = CacheKey.InstalledPackage(packageName)
         Logger.d(TAG, operationLogMessage(OPERATION, requestId, event = "started", context = context))
         Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_CACHE_LOOKUP, event = "started", context = context))
-        cache[cacheKey]?.let {
+        val cachedDetail = trace.measureStage(PerformanceMetricName.CACHE_LOOKUP_US) { cache[cacheKey] }
+        trace.putAttribute(PerformanceAttributeName.CACHE_HIT, cachedDetail?.let { ATTRIBUTE_TRUE } ?: ATTRIBUTE_FALSE)
+        cachedDetail?.let {
             Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_CACHE_LOOKUP, event = "succeeded", context = "cache_hit=true $context"))
-            val event = if (it.areComponentIntentFiltersAvailable) "succeeded" else "degraded"
+            val event = if (it.isPerformanceDegraded) "degraded" else "succeeded"
             Logger.i(TAG, operationLogMessage(OPERATION, requestId, event = event, context = "cache_hit=true $context"))
             return Result.success(it)
         }
@@ -117,10 +148,18 @@ internal class AppDetailRepositoryImpl @Inject constructor(
                 val reference = AppReference.InstalledPackage(packageName)
 
                 Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_PACKAGE_QUERY, event = "started", context = context))
-                val packageInfo = packageManager.getPackageInfo(packageName.value, analysisFlags)
+                val packageInfo = trace.measureStage(PerformanceMetricName.PACKAGE_QUERY_US) {
+                    packageManager.getPackageInfo(packageName.value, analysisFlags)
+                }
                 Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_PACKAGE_QUERY, event = "succeeded", context = context))
 
-                val intentFilters = manifestParser.componentIntentFilters(reference)
+                val intentFilters = trace.measureSuspendStage(PerformanceMetricName.INTENT_FILTERS_US) {
+                    manifestParser.componentIntentFilters(reference)
+                }
+                trace.putAttribute(
+                    PerformanceAttributeName.INTENT_FILTERS,
+                    if (intentFilters.isSuccess) AVAILABILITY_AVAILABLE else AVAILABILITY_UNAVAILABLE,
+                )
                 Logger.d(
                     TAG,
                     operationLogMessage(
@@ -132,7 +171,9 @@ internal class AppDetailRepositoryImpl @Inject constructor(
                     ),
                 )
 
-                val totalSize = storageStatsRepository.queryTotalSize(packageName)
+                val totalSize = trace.measureSuspendStage(PerformanceMetricName.STORAGE_STATS_US) {
+                    storageStatsRepository.queryTotalSize(packageName)
+                }
                 Logger.d(
                     TAG,
                     operationLogMessage(
@@ -144,7 +185,9 @@ internal class AppDetailRepositoryImpl @Inject constructor(
                     ),
                 )
 
-                val lastUsedTime = usageStatsRepository.queryLastUsedTime(packageName)
+                val lastUsedTime = trace.measureSuspendStage(PerformanceMetricName.USAGE_STATS_US) {
+                    usageStatsRepository.queryLastUsedTime(packageName)
+                }
                 Logger.d(
                     TAG,
                     operationLogMessage(
@@ -165,10 +208,11 @@ internal class AppDetailRepositoryImpl @Inject constructor(
                     areIntentFiltersAvailable = intentFilters.isSuccess,
                     totalSize = totalSize,
                     lastUsedTime = lastUsedTime,
+                    trace = trace,
                 )
             }.onSuccess { detail ->
                 cache[cacheKey] = detail
-                val event = if (detail.areComponentIntentFiltersAvailable) "succeeded" else "degraded"
+                val event = if (detail.isPerformanceDegraded) "degraded" else "succeeded"
                 Logger.i(TAG, operationLogMessage(OPERATION, requestId, event = event, context = context))
             }.onFailure {
                 Logger.e(TAG, it, operationLogMessage(OPERATION, requestId, event = "failed", context = context))
@@ -180,15 +224,17 @@ internal class AppDetailRepositoryImpl @Inject constructor(
     }
 
     @Suppress("SuspendFunSwallowedCancellation")
-    private suspend fun apkFilePackageDetails(accessibleFile: File): Result<AppDetail> {
+    private suspend fun apkFilePackageDetails(accessibleFile: File, trace: PerformanceTrace): Result<AppDetail> {
         val requestId = nextOperationRequest()
         val context = "mode=apk_file apk_path=${accessibleFile.absolutePath}"
         val cacheKey = CacheKey.ApkFile(accessibleFile.absolutePath, accessibleFile.lastModified())
         Logger.d(TAG, operationLogMessage(OPERATION, requestId, event = "started", context = context))
         Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_CACHE_LOOKUP, event = "started", context = context))
-        cache[cacheKey]?.let {
+        val cachedDetail = trace.measureStage(PerformanceMetricName.CACHE_LOOKUP_US) { cache[cacheKey] }
+        trace.putAttribute(PerformanceAttributeName.CACHE_HIT, cachedDetail?.let { ATTRIBUTE_TRUE } ?: ATTRIBUTE_FALSE)
+        cachedDetail?.let {
             Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_CACHE_LOOKUP, event = "succeeded", context = "cache_hit=true $context"))
-            val event = if (it.areComponentIntentFiltersAvailable) "succeeded" else "degraded"
+            val event = if (it.isPerformanceDegraded) "degraded" else "succeeded"
             Logger.i(TAG, operationLogMessage(OPERATION, requestId, event = event, context = "cache_hit=true $context"))
             return Result.success(it)
         }
@@ -199,11 +245,19 @@ internal class AppDetailRepositoryImpl @Inject constructor(
                 val reference = AppReference.ApkFile(accessibleFile.absolutePath)
 
                 Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_PACKAGE_QUERY, event = "started", context = context))
-                val packageInfo = packageManager.getPackageArchiveInfoWithCorrectPath(accessibleFile.absolutePath, analysisFlags)
-                    ?: error("Cannot parse APK file: ${accessibleFile.absolutePath}")
+                val packageInfo = trace.measureStage(PerformanceMetricName.PACKAGE_QUERY_US) {
+                    packageManager.getPackageArchiveInfoWithCorrectPath(accessibleFile.absolutePath, analysisFlags)
+                        ?: error("Cannot parse APK file: ${accessibleFile.absolutePath}")
+                }
                 Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_PACKAGE_QUERY, event = "succeeded", context = context))
 
-                val intentFilters = manifestParser.componentIntentFilters(reference)
+                val intentFilters = trace.measureSuspendStage(PerformanceMetricName.INTENT_FILTERS_US) {
+                    manifestParser.componentIntentFilters(reference)
+                }
+                trace.putAttribute(
+                    PerformanceAttributeName.INTENT_FILTERS,
+                    if (intentFilters.isSuccess) AVAILABILITY_AVAILABLE else AVAILABILITY_UNAVAILABLE,
+                )
                 Logger.d(
                     TAG,
                     operationLogMessage(
@@ -222,10 +276,11 @@ internal class AppDetailRepositoryImpl @Inject constructor(
                     packageInfo = packageInfo,
                     intentFiltersByComponent = intentFilters.getOrDefault(emptyMap()),
                     areIntentFiltersAvailable = intentFilters.isSuccess,
+                    trace = trace,
                 )
             }.onSuccess { detail ->
                 cache[cacheKey] = detail
-                val event = if (detail.areComponentIntentFiltersAvailable) "succeeded" else "degraded"
+                val event = if (detail.isPerformanceDegraded) "degraded" else "succeeded"
                 Logger.i(TAG, operationLogMessage(OPERATION, requestId, event = event, context = context))
             }.onFailure {
                 Logger.e(TAG, it, operationLogMessage(OPERATION, requestId, event = "failed", context = context))
@@ -245,17 +300,28 @@ internal class AppDetailRepositoryImpl @Inject constructor(
         areIntentFiltersAvailable: Boolean,
         totalSize: AppSize? = null,
         lastUsedTime: Instant? = null,
+        trace: PerformanceTrace,
     ): AppDetail {
         Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_GENERAL_INFO, event = "started", context = context))
-        val info = getGeneralData(packageInfo, totalSize, lastUsedTime)
+        val info = trace.measureStage(PerformanceMetricName.GENERAL_INFO_US) {
+            getGeneralData(packageInfo, totalSize, lastUsedTime)
+        }
         Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_GENERAL_INFO, event = "succeeded", context = context))
 
         Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_CERTIFICATES, event = "started", context = context))
-        val signing = certificateExtractor.getAppSigning(packageInfo)
+        val signing = trace.measureStage(PerformanceMetricName.CERTIFICATE_US) {
+            certificateExtractor.getAppSigning(packageInfo)
+        }
         Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_CERTIFICATES, event = "succeeded", context = context))
 
         Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_SIGNING_SCHEMES, event = "started", context = context))
-        val signingSchemeVersions = packageInfo.applicationInfo?.sourceDir?.let(apkSigningBlockAnalyzer::detectSchemeVersions)
+        val signingSchemeVersions = trace.measureStage(PerformanceMetricName.SIGNING_SCHEMES_US) {
+            packageInfo.applicationInfo?.sourceDir?.let(apkSigningBlockAnalyzer::detectSchemeVersions)
+        }
+        trace.putAttribute(
+            PerformanceAttributeName.SIGNING_SCHEMES,
+            if (signingSchemeVersions != null) AVAILABILITY_AVAILABLE else AVAILABILITY_UNAVAILABLE,
+        )
         Logger.d(
             TAG,
             operationLogMessage(
@@ -270,44 +336,60 @@ internal class AppDetailRepositoryImpl @Inject constructor(
         val launcherActivityNames = when (analysisMode) {
             AppDetail.AnalysisMode.InstalledPackage -> {
                 Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_LAUNCHER_QUERY, event = "started", context = context))
-                queryLauncherActivityNames(PackageName(packageInfo.packageName)).also {
-                    Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_LAUNCHER_QUERY, event = "succeeded", context = context))
+                trace.measureStage(PerformanceMetricName.LAUNCHER_QUERY_US) {
+                    queryLauncherActivityNames(PackageName(packageInfo.packageName))
                 }
+                    .also {
+                        Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_LAUNCHER_QUERY, event = "succeeded", context = context))
+                    }
             }
 
             AppDetail.AnalysisMode.ApkFile -> null
         }
 
         Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_COMPONENT_MAPPING, event = "started", context = context))
-        val activities = getActivities(packageInfo, launcherActivityNames, intentFiltersByComponent)
-        val services = getServices(packageInfo, intentFiltersByComponent)
-        val contentProviders = getContentProviders(packageInfo, intentFiltersByComponent)
-        val receivers = getBroadcastReceivers(packageInfo, intentFiltersByComponent)
+        val components = trace.measureStage(PerformanceMetricName.COMPONENTS_US) {
+            AppComponents(
+                activities = getActivities(packageInfo, launcherActivityNames, intentFiltersByComponent),
+                services = getServices(packageInfo, intentFiltersByComponent),
+                contentProviders = getContentProviders(packageInfo, intentFiltersByComponent),
+                receivers = getBroadcastReceivers(packageInfo, intentFiltersByComponent),
+            )
+        }
         Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_COMPONENT_MAPPING, event = "succeeded", context = context))
 
         Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_PERMISSIONS, event = "started", context = context))
-        val permissions = getPermissions(packageInfo)
+        val permissions = trace.measureStage(PerformanceMetricName.PERMISSIONS_US) {
+            getPermissions(packageInfo)
+        }
         Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_PERMISSIONS, event = "succeeded", context = context))
 
         Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_FEATURES, event = "started", context = context))
-        val features = getFeatures(packageInfo)
+        val features = trace.measureStage(PerformanceMetricName.FEATURES_US) {
+            getFeatures(packageInfo)
+        }
         Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_FEATURES, event = "succeeded", context = context))
 
         Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_PACKAGING, event = "started", context = context))
-        val nativeLibraries = readNativeLibraries(packageInfo.applicationInfo)
+        val packaging = trace.measureStage(PerformanceMetricName.PACKAGING_US) {
+            getPackaging(packageInfo.applicationInfo)
+        }
         Logger.d(TAG, operationLogMessage(OPERATION, requestId, stage = STAGE_PACKAGING, event = "succeeded", context = context))
 
         return AppDetail(
             analysisMode = analysisMode,
-            info = info,
+            info = info.copy(
+                apkSize = packaging.apkSize,
+                installedSplits = packaging.installedSplits,
+            ),
             signing = signing.copy(signingSchemeVersions = signingSchemeVersions),
-            activities = activities,
-            services = services,
-            contentProviders = contentProviders,
-            receivers = receivers,
+            activities = components.activities,
+            services = components.services,
+            contentProviders = components.contentProviders,
+            receivers = components.receivers,
             permissions = permissions,
             features = features,
-            nativeLibraries = nativeLibraries,
+            nativeLibraries = packaging.nativeLibraries,
             areComponentIntentFiltersAvailable = areIntentFiltersAvailable,
         )
     }
@@ -340,7 +422,6 @@ internal class AppDetailRepositoryImpl @Inject constructor(
             dataDirectory = applicationInfo?.dataDir,
             installSourceChain = installSourceChain,
             installLocation = InstallLocation.from(packageInfo.installLocation),
-            apkSize = computeApkSize(applicationInfo),
             firstInstallTime = if (packageInfo.firstInstallTime > 0) Instant.ofEpochMilli(packageInfo.firstInstallTime) else null,
             lastUpdateTime = if (packageInfo.lastUpdateTime > 0) Instant.ofEpochMilli(packageInfo.lastUpdateTime) else null,
             minSdkVersion = minSdk,
@@ -349,9 +430,14 @@ internal class AppDetailRepositoryImpl @Inject constructor(
             targetSdkLabel = sdkVersionResolver.resolveVersion(applicationInfo?.targetSdkVersion),
             totalSize = totalSize,
             lastUsedTime = lastUsedTime,
-            installedSplits = readInstalledSplits(applicationInfo),
         )
     }
+
+    private fun getPackaging(applicationInfo: ApplicationInfo?): AppPackaging = AppPackaging(
+        apkSize = computeApkSize(applicationInfo),
+        installedSplits = readInstalledSplits(applicationInfo),
+        nativeLibraries = readNativeLibraries(applicationInfo),
+    )
 
     private fun getActivities(
         packageInfo: PackageInfo,
@@ -484,6 +570,19 @@ internal class AppDetailRepositoryImpl @Inject constructor(
         data class ApkFile(val path: String, val lastModified: Long) : CacheKey
     }
 
+    private data class AppComponents(
+        val activities: List<Activity>,
+        val services: List<Service>,
+        val contentProviders: List<ContentProvider>,
+        val receivers: List<BroadcastReceiver>,
+    )
+
+    private data class AppPackaging(
+        val apkSize: AppSize,
+        val installedSplits: List<InstalledSplitApk>,
+        val nativeLibraries: NativeLibraries,
+    )
+
     companion object {
         private const val TAG = "AppDetailRepositoryImpl"
         private const val OPERATION = "app_detail"
@@ -504,3 +603,34 @@ internal class AppDetailRepositoryImpl @Inject constructor(
         private val launcherCategories = listOf(Intent.CATEGORY_LAUNCHER, Intent.CATEGORY_LEANBACK_LAUNCHER)
     }
 }
+
+private val AppReference.analysisModeAttribute: String
+    get() = when (this) {
+        is AppReference.InstalledPackage -> ANALYSIS_MODE_INSTALLED
+        is AppReference.ApkFile -> ANALYSIS_MODE_APK_FILE
+    }
+
+private val AppDetail.isPerformanceDegraded: Boolean
+    get() = !areComponentIntentFiltersAvailable || signing.signingSchemeVersions == null
+
+private fun PerformanceTrace.putAvailabilityAttributes(detail: AppDetail) {
+    putAttribute(
+        PerformanceAttributeName.INTENT_FILTERS,
+        if (detail.areComponentIntentFiltersAvailable) AVAILABILITY_AVAILABLE else AVAILABILITY_UNAVAILABLE,
+    )
+    putAttribute(
+        PerformanceAttributeName.SIGNING_SCHEMES,
+        if (detail.signing.signingSchemeVersions != null) AVAILABILITY_AVAILABLE else AVAILABILITY_UNAVAILABLE,
+    )
+}
+
+private const val OUTCOME_SUCCESS = "success"
+private const val OUTCOME_DEGRADED = "degraded"
+private const val OUTCOME_ERROR = "error"
+private const val OUTCOME_CANCELLED = "cancelled"
+private const val ANALYSIS_MODE_INSTALLED = "installed"
+private const val ANALYSIS_MODE_APK_FILE = "apk_file"
+private const val ATTRIBUTE_TRUE = "true"
+private const val ATTRIBUTE_FALSE = "false"
+private const val AVAILABILITY_AVAILABLE = "available"
+private const val AVAILABILITY_UNAVAILABLE = "unavailable"

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
@@ -97,6 +97,7 @@ internal class AppDetailRepositoryImpl @Inject constructor(
         is AppReference.ApkFile -> apkFilePackageDetails(File(reference.path))
     }
 
+    @Suppress("SuspendFunSwallowedCancellation")
     private suspend fun installedPackageDetails(packageName: PackageName): Result<AppDetail> {
         val requestId = nextOperationRequest()
         val context = "mode=installed package=${packageName.value}"
@@ -178,6 +179,7 @@ internal class AppDetailRepositoryImpl @Inject constructor(
         }
     }
 
+    @Suppress("SuspendFunSwallowedCancellation")
     private suspend fun apkFilePackageDetails(accessibleFile: File): Result<AppDetail> {
         val requestId = nextOperationRequest()
         val context = "mode=apk_file apk_path=${accessibleFile.absolutePath}"

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
@@ -27,6 +28,11 @@ import sk.styk.martin.apkanalyzer.core.common.logger.nextOperationRequest
 import sk.styk.martin.apkanalyzer.core.common.logger.operationLogMessage
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.model.bytes
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceAttributeName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceMetricName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTraceName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
+import sk.styk.martin.apkanalyzer.core.common.performance.measureStage
 import java.io.File
 import java.time.Instant
 import javax.inject.Inject
@@ -45,16 +51,18 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
     storageStatsRepository: StorageStatsRepository,
     usageStatsRepository: UsageStatsRepository,
     appScope: CoroutineScope,
+    private val performanceTracker: PerformanceTracker,
 ) : InstalledAppsRepository {
 
     @Suppress("TooGenericExceptionCaught")
     private val cachedApps = packageChangesObserver.observe()
-        .onStart { emit(Unit) }
-        .mapLatest {
+        .map { InstalledAppsLoadTrigger.PackageChange }
+        .onStart { emit(InstalledAppsLoadTrigger.Initial) }
+        .mapLatest { trigger ->
             val requestId = nextOperationRequest()
             Logger.d(INSTALLED_APPS, operationLogMessage(OPERATION_INSTALLED_APPS, requestId, event = "started"))
             try {
-                val apps = loadAllApps(requestId)
+                val apps = loadAllApps(requestId, trigger)
                 Logger.i(
                     INSTALLED_APPS,
                     operationLogMessage(OPERATION_INSTALLED_APPS, requestId, event = "succeeded", context = "count=${apps.size}"),
@@ -92,21 +100,51 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
     override fun apps(): Flow<List<InstalledApp>> = cachedApps
 
     @SuppressLint("QueryPermissionsNeeded")
-    private fun loadAllApps(requestId: Long): List<InstalledApp> {
-        Logger.d(INSTALLED_APPS, operationLogMessage(OPERATION_INSTALLED_APPS, requestId, stage = STAGE_PACKAGE_QUERY, event = "started"))
-        val packages = packageManager.getInstalledPackages(PackageManager.GET_PERMISSIONS)
-        Logger.d(
-            INSTALLED_APPS,
-            operationLogMessage(OPERATION_INSTALLED_APPS, requestId, stage = STAGE_PACKAGE_QUERY, event = "succeeded", context = "count=${packages.size}"),
-        )
+    private fun loadAllApps(requestId: Long, trigger: InstalledAppsLoadTrigger): List<InstalledApp> {
+        val trace = performanceTracker.startTrace(PerformanceTraceName.INSTALLED_APPS_LOAD)
+        trace.putAttribute(PerformanceAttributeName.TRIGGER, trigger.attributeValue)
+        var outcome = OUTCOME_ERROR
+        try {
+            Logger.d(INSTALLED_APPS, operationLogMessage(OPERATION_INSTALLED_APPS, requestId, stage = STAGE_PACKAGE_QUERY, event = "started"))
+            val packages = trace.measureStage(PerformanceMetricName.PACKAGE_QUERY_US) {
+                packageManager.getInstalledPackages(PackageManager.GET_PERMISSIONS)
+            }
+            Logger.d(
+                INSTALLED_APPS,
+                operationLogMessage(
+                    OPERATION_INSTALLED_APPS,
+                    requestId,
+                    stage = STAGE_PACKAGE_QUERY,
+                    event = "succeeded",
+                    context = "count=${packages.size}",
+                ),
+            )
 
-        Logger.d(INSTALLED_APPS, operationLogMessage(OPERATION_INSTALLED_APPS, requestId, stage = STAGE_APP_MAPPING, event = "started"))
-        val apps = packages.mapNotNull { packageInfo -> packageInfo.applicationInfo?.let { packageInfo.toInstalledApp() } }
-        Logger.d(
-            INSTALLED_APPS,
-            operationLogMessage(OPERATION_INSTALLED_APPS, requestId, stage = STAGE_APP_MAPPING, event = "succeeded", context = "count=${apps.size}"),
-        )
-        return apps
+            Logger.d(INSTALLED_APPS, operationLogMessage(OPERATION_INSTALLED_APPS, requestId, stage = STAGE_APP_MAPPING, event = "started"))
+            val apps = trace.measureStage(PerformanceMetricName.APP_MAPPING_US) {
+                packages.mapNotNull { packageInfo -> packageInfo.applicationInfo?.let { packageInfo.toInstalledApp() } }
+            }
+            Logger.d(
+                INSTALLED_APPS,
+                operationLogMessage(
+                    OPERATION_INSTALLED_APPS,
+                    requestId,
+                    stage = STAGE_APP_MAPPING,
+                    event = "succeeded",
+                    context = "count=${apps.size}",
+                ),
+            )
+            trace.putMetric(PerformanceMetricName.APP_COUNT, apps.size.toLong())
+            trace.putAttribute(PerformanceAttributeName.APP_COUNT_BUCKET, appCountBucket(apps.size))
+            outcome = OUTCOME_SUCCESS
+            return apps
+        } catch (cancellation: CancellationException) {
+            outcome = OUTCOME_CANCELLED
+            throw cancellation
+        } finally {
+            trace.putAttribute(PerformanceAttributeName.OUTCOME, outcome)
+            trace.stop()
+        }
     }
 
     private fun PackageInfo.toInstalledApp(): InstalledApp {
@@ -132,3 +170,22 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
         )
     }
 }
+
+private enum class InstalledAppsLoadTrigger(val attributeValue: String) {
+    Initial(TRIGGER_INITIAL),
+    PackageChange(TRIGGER_PACKAGE_CHANGE),
+}
+
+private fun appCountBucket(appCount: Int): String = when (appCount) {
+    in 0..49 -> "0_49"
+    in 50..99 -> "50_99"
+    in 100..199 -> "100_199"
+    in 200..399 -> "200_399"
+    else -> "400_plus"
+}
+
+private const val OUTCOME_SUCCESS = "success"
+private const val OUTCOME_ERROR = "error"
+private const val OUTCOME_CANCELLED = "cancelled"
+private const val TRIGGER_INITIAL = "initial"
+private const val TRIGGER_PACKAGE_CHANGE = "package_change"

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
@@ -47,6 +47,7 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
     appScope: CoroutineScope,
 ) : InstalledAppsRepository {
 
+    @Suppress("TooGenericExceptionCaught")
     private val cachedApps = packageChangesObserver.observe()
         .onStart { emit(Unit) }
         .mapLatest {

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
@@ -23,13 +23,19 @@ import sk.styk.martin.apkanalyzer.core.apps.storagestats.StorageStatsRepository
 import sk.styk.martin.apkanalyzer.core.apps.usagestats.UsageStatsRepository
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
+import sk.styk.martin.apkanalyzer.core.common.logger.nextOperationRequest
+import sk.styk.martin.apkanalyzer.core.common.logger.operationLogMessage
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.model.bytes
 import java.io.File
 import java.time.Instant
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 
 internal const val INSTALLED_APPS = "InstalledApps"
+private const val OPERATION_INSTALLED_APPS = "installed_apps"
+private const val STAGE_PACKAGE_QUERY = "package_query"
+private const val STAGE_APP_MAPPING = "app_mapping"
 
 internal class InstalledAppsRepositoryImpl @Inject constructor(
     private val packageManager: PackageManager,
@@ -43,9 +49,24 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
 
     private val cachedApps = packageChangesObserver.observe()
         .onStart { emit(Unit) }
-        .onEach { Logger.i(INSTALLED_APPS, "Load apps") }
-        .mapLatest { loadAllApps() }
-        .onEach { Logger.i(INSTALLED_APPS, "Apps loaded: ${it.size}") }
+        .mapLatest {
+            val requestId = nextOperationRequest()
+            Logger.d(INSTALLED_APPS, operationLogMessage(OPERATION_INSTALLED_APPS, requestId, event = "started"))
+            try {
+                val apps = loadAllApps(requestId)
+                Logger.i(
+                    INSTALLED_APPS,
+                    operationLogMessage(OPERATION_INSTALLED_APPS, requestId, event = "succeeded", context = "count=${apps.size}"),
+                )
+                apps
+            } catch (cancellation: CancellationException) {
+                Logger.d(INSTALLED_APPS, operationLogMessage(OPERATION_INSTALLED_APPS, requestId, event = "cancelled"))
+                throw cancellation
+            } catch (failure: Throwable) {
+                Logger.e(INSTALLED_APPS, failure, operationLogMessage(OPERATION_INSTALLED_APPS, requestId, event = "failed"))
+                throw failure
+            }
+        }
         .onEach { apps -> storageStatsRepository.requestTotalSizes(apps.map { it.packageName }) }
         .flatMapLatest { apps ->
             combine(
@@ -58,7 +79,7 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
                             totalSize = totalSizes[app.packageName],
                             lastUsedTime = lastUsedTimes[app.packageName],
                         )
-                    }.also { Logger.i(INSTALLED_APPS, "Enriched ${it.size} apps") }
+                    }
                 } else {
                     apps
                 }
@@ -70,8 +91,21 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
     override fun apps(): Flow<List<InstalledApp>> = cachedApps
 
     @SuppressLint("QueryPermissionsNeeded")
-    private fun loadAllApps(): List<InstalledApp> = packageManager.getInstalledPackages(PackageManager.GET_PERMISSIONS).mapNotNull { packageInfo ->
-        packageInfo.applicationInfo?.let { packageInfo.toInstalledApp() }
+    private fun loadAllApps(requestId: Long): List<InstalledApp> {
+        Logger.d(INSTALLED_APPS, operationLogMessage(OPERATION_INSTALLED_APPS, requestId, stage = STAGE_PACKAGE_QUERY, event = "started"))
+        val packages = packageManager.getInstalledPackages(PackageManager.GET_PERMISSIONS)
+        Logger.d(
+            INSTALLED_APPS,
+            operationLogMessage(OPERATION_INSTALLED_APPS, requestId, stage = STAGE_PACKAGE_QUERY, event = "succeeded", context = "count=${packages.size}"),
+        )
+
+        Logger.d(INSTALLED_APPS, operationLogMessage(OPERATION_INSTALLED_APPS, requestId, stage = STAGE_APP_MAPPING, event = "started"))
+        val apps = packages.mapNotNull { packageInfo -> packageInfo.applicationInfo?.let { packageInfo.toInstalledApp() } }
+        Logger.d(
+            INSTALLED_APPS,
+            operationLogMessage(OPERATION_INSTALLED_APPS, requestId, stage = STAGE_APP_MAPPING, event = "succeeded", context = "count=${apps.size}"),
+        )
+        return apps
     }
 
     private fun PackageInfo.toInstalledApp(): InstalledApp {

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
@@ -176,14 +176,6 @@ private enum class InstalledAppsLoadTrigger(val attributeValue: String) {
     PackageChange(TRIGGER_PACKAGE_CHANGE),
 }
 
-private fun appCountBucket(appCount: Int): String = when (appCount) {
-    in 0..49 -> "0_49"
-    in 50..99 -> "50_99"
-    in 100..199 -> "100_199"
-    in 200..399 -> "200_399"
-    else -> "400_plus"
-}
-
 private const val OUTCOME_SUCCESS = "success"
 private const val OUTCOME_ERROR = "error"
 private const val OUTCOME_CANCELLED = "cancelled"

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/PerformanceBuckets.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/PerformanceBuckets.kt
@@ -1,0 +1,16 @@
+package sk.styk.martin.apkanalyzer.core.apps
+
+internal fun appCountBucket(appCount: Int): String = when (appCount) {
+    in 0..49 -> "0_49"
+    in 50..99 -> "50_99"
+    in 100..199 -> "100_199"
+    in 200..399 -> "200_399"
+    else -> "400_plus"
+}
+
+internal fun splitCountBucket(splitCount: Int): String = when (splitCount) {
+    0 -> "0"
+    in 1..4 -> "1_4"
+    in 5..9 -> "5_9"
+    else -> "10_plus"
+}

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/devicefeatures/DeviceFeaturesRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/devicefeatures/DeviceFeaturesRepositoryImpl.kt
@@ -5,10 +5,13 @@ import android.content.pm.PackageManager
 import kotlinx.coroutines.withContext
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
+import sk.styk.martin.apkanalyzer.core.common.logger.nextOperationRequest
+import sk.styk.martin.apkanalyzer.core.common.logger.operationLogMessage
 import javax.inject.Inject
 import javax.inject.Singleton
 
 private const val TAG = "DeviceFeaturesRepositoryImpl"
+private const val OPERATION = "device_features"
 
 @Singleton
 internal class DeviceFeaturesRepositoryImpl @Inject constructor(
@@ -21,8 +24,10 @@ internal class DeviceFeaturesRepositoryImpl @Inject constructor(
     override suspend fun deviceFeatures(): DeviceFeatures = withContext(dispatcherProvider.io()) { cachedDeviceFeatures }
 
     private fun readDeviceFeatures(): DeviceFeatures {
+        val requestId = nextOperationRequest()
+        Logger.d(TAG, operationLogMessage(OPERATION, requestId, event = "started"))
         val systemFeatures = runCatching { packageManager.systemAvailableFeatures }
-            .onFailure { Logger.e(TAG, it, "Can not read device features") }
+            .onFailure { Logger.w(TAG, it, operationLogMessage(OPERATION, requestId, event = "degraded", context = "reason=feature_query_failed")) }
             .getOrNull()
             ?: return DeviceFeatures.Unknown
 
@@ -33,6 +38,8 @@ internal class DeviceFeaturesRepositoryImpl @Inject constructor(
             openGlEsVersion = systemFeatures
                 .firstOrNull { it.name == null && it.reqGlEsVersion != FeatureInfo.GL_ES_VERSION_UNDEFINED }
                 ?.reqGlEsVersion,
-        )
+        ).also {
+            Logger.i(TAG, operationLogMessage(OPERATION, requestId, event = "succeeded", context = "feature_count=${it.featureVersions.size}"))
+        }
     }
 }

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/devicefeatures/DeviceFeaturesRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/devicefeatures/DeviceFeaturesRepositoryImpl.kt
@@ -7,8 +7,14 @@ import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.logger.nextOperationRequest
 import sk.styk.martin.apkanalyzer.core.common.logger.operationLogMessage
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceAttributeName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceMetricName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTraceName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
+import sk.styk.martin.apkanalyzer.core.common.performance.measureStage
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.cancellation.CancellationException
 
 private const val TAG = "DeviceFeaturesRepositoryImpl"
 private const val OPERATION = "device_features"
@@ -17,6 +23,7 @@ private const val OPERATION = "device_features"
 internal class DeviceFeaturesRepositoryImpl @Inject constructor(
     private val packageManager: PackageManager,
     private val dispatcherProvider: DispatcherProvider,
+    private val performanceTracker: PerformanceTracker,
 ) : DeviceFeaturesRepository {
 
     private val cachedDeviceFeatures: DeviceFeatures by lazy { readDeviceFeatures() }
@@ -25,21 +32,65 @@ internal class DeviceFeaturesRepositoryImpl @Inject constructor(
 
     private fun readDeviceFeatures(): DeviceFeatures {
         val requestId = nextOperationRequest()
+        val trace = performanceTracker.startTrace(PerformanceTraceName.DEVICE_FEATURES_LOAD)
+        var outcome = OUTCOME_ERROR
         Logger.d(TAG, operationLogMessage(OPERATION, requestId, event = "started"))
-        val systemFeatures = runCatching { packageManager.systemAvailableFeatures }
-            .onFailure { Logger.w(TAG, it, operationLogMessage(OPERATION, requestId, event = "degraded", context = "reason=feature_query_failed")) }
-            .getOrNull()
-            ?: return DeviceFeatures.Unknown
+        try {
+            val systemFeatures: Array<FeatureInfo>? = try {
+                trace.measureStage(PerformanceMetricName.FEATURE_QUERY_US) {
+                    packageManager.systemAvailableFeatures
+                }
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (failure: Throwable) {
+                Logger.w(
+                    TAG,
+                    failure,
+                    operationLogMessage(OPERATION, requestId, event = "degraded", context = "reason=feature_query_failed"),
+                )
+                trace.putMetric(PerformanceMetricName.FEATURE_COUNT, 0)
+                outcome = OUTCOME_DEGRADED
+                return DeviceFeatures.Unknown
+            }
+            if (systemFeatures == null) {
+                Logger.w(TAG, operationLogMessage(OPERATION, requestId, event = "degraded", context = "reason=feature_query_unavailable"))
+                trace.putMetric(PerformanceMetricName.FEATURE_COUNT, 0)
+                outcome = OUTCOME_DEGRADED
+                return DeviceFeatures.Unknown
+            }
 
-        return DeviceFeatures(
-            featureVersions = systemFeatures
-                .filter { it.name != null }
-                .associate { it.name to it.version },
-            openGlEsVersion = systemFeatures
-                .firstOrNull { it.name == null && it.reqGlEsVersion != FeatureInfo.GL_ES_VERSION_UNDEFINED }
-                ?.reqGlEsVersion,
-        ).also {
-            Logger.i(TAG, operationLogMessage(OPERATION, requestId, event = "succeeded", context = "feature_count=${it.featureVersions.size}"))
+            val deviceFeatures = trace.measureStage(PerformanceMetricName.FEATURE_MAPPING_US) {
+                DeviceFeatures(
+                    featureVersions = systemFeatures
+                        .filter { it.name != null }
+                        .associate { it.name to it.version },
+                    openGlEsVersion = systemFeatures
+                        .firstOrNull { it.name == null && it.reqGlEsVersion != FeatureInfo.GL_ES_VERSION_UNDEFINED }
+                        ?.reqGlEsVersion,
+                )
+            }
+            trace.putMetric(PerformanceMetricName.FEATURE_COUNT, deviceFeatures.featureVersions.size.toLong())
+            Logger.i(
+                TAG,
+                operationLogMessage(OPERATION, requestId, event = "succeeded", context = "feature_count=${deviceFeatures.featureVersions.size}"),
+            )
+            outcome = OUTCOME_SUCCESS
+            return deviceFeatures
+        } catch (cancellation: CancellationException) {
+            outcome = OUTCOME_CANCELLED
+            Logger.d(TAG, operationLogMessage(OPERATION, requestId, event = "cancelled"))
+            throw cancellation
+        } catch (failure: Throwable) {
+            Logger.e(TAG, failure, operationLogMessage(OPERATION, requestId, event = "failed"))
+            throw failure
+        } finally {
+            trace.putAttribute(PerformanceAttributeName.OUTCOME, outcome)
+            trace.stop()
         }
     }
 }
+
+private const val OUTCOME_SUCCESS = "success"
+private const val OUTCOME_DEGRADED = "degraded"
+private const val OUTCOME_ERROR = "error"
+private const val OUTCOME_CANCELLED = "cancelled"

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/manifest/ManifestParserImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/manifest/ManifestParserImpl.kt
@@ -5,6 +5,7 @@ import android.content.res.Resources
 import kotlinx.coroutines.withContext
 import sk.styk.martin.apkanalyzer.core.apps.components.ComponentIntentFilter
 import sk.styk.martin.apkanalyzer.core.apps.components.ComponentIntentFilterKey
+import sk.styk.martin.apkanalyzer.core.apps.splitCountBucket
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
 import sk.styk.martin.apkanalyzer.core.common.coroutines.runCatchingCancellable
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
@@ -12,6 +13,11 @@ import sk.styk.martin.apkanalyzer.core.common.logger.nextOperationRequest
 import sk.styk.martin.apkanalyzer.core.common.logger.operationLogMessage
 import sk.styk.martin.apkanalyzer.core.common.model.AppReference
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceAttributeName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceMetricName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTraceName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
+import sk.styk.martin.apkanalyzer.core.common.performance.measureStage
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -24,11 +30,54 @@ internal class ManifestParserImpl @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val manifestXmlRenderer: ManifestXmlRenderer,
     private val componentManifestParser: ComponentManifestParser,
+    private val performanceTracker: PerformanceTracker,
 ) : ManifestParser {
 
-    override suspend fun manifest(reference: AppReference): Result<ParsedManifest> = when (reference) {
-        is AppReference.InstalledPackage -> installedPackageManifest(reference.packageName)
-        is AppReference.ApkFile -> apkFileManifest(reference.path)
+    @Suppress("SuspendFunSwallowedCancellation")
+    override suspend fun manifest(reference: AppReference): Result<ParsedManifest> {
+        val requestId = nextOperationRequest()
+        val trace = performanceTracker.startTrace(PerformanceTraceName.MANIFEST_LOAD)
+        trace.putAttribute(PerformanceAttributeName.ANALYSIS_MODE, reference.analysisMode())
+        var outcome = OUTCOME_ERROR
+        Logger.d(TAG, operationLogMessage(OPERATION_MANIFEST, requestId, event = "started", context = reference.diagnosticContext()))
+        return try {
+            val result = withContext(dispatcherProvider.io()) {
+                runCatchingCancellable {
+                    val manifestResources = trace.measureStage(PerformanceMetricName.RESOURCE_LOOKUP_US) {
+                        manifestResources(reference)
+                    }
+                    trace.putMetric(PerformanceMetricName.SPLIT_COUNT, manifestResources.additionalInstalledSplits.toLong())
+                    trace.putAttribute(
+                        PerformanceAttributeName.SPLIT_COUNT_BUCKET,
+                        splitCountBucket(manifestResources.additionalInstalledSplits),
+                    )
+                    val document = trace.measureStage(PerformanceMetricName.MANIFEST_PARSE_US) {
+                        manifestXmlRenderer.parse(manifestResources.resources)
+                    }
+                    val xml = trace.measureStage(PerformanceMetricName.XML_RENDER_US) {
+                        manifestXmlRenderer.render(document)
+                    }
+                    ParsedManifest(
+                        xml = xml,
+                        additionalInstalledSplits = manifestResources.additionalInstalledSplits,
+                    )
+                }
+            }
+            result.onSuccess {
+                Logger.i(TAG, operationLogMessage(OPERATION_MANIFEST, requestId, event = "succeeded", context = reference.diagnosticContext()))
+            }.onFailure {
+                Logger.e(TAG, it, operationLogMessage(OPERATION_MANIFEST, requestId, event = "failed", context = reference.diagnosticContext()))
+            }
+            outcome = if (result.isSuccess) OUTCOME_SUCCESS else OUTCOME_ERROR
+            result
+        } catch (cancellation: CancellationException) {
+            outcome = OUTCOME_CANCELLED
+            Logger.d(TAG, operationLogMessage(OPERATION_MANIFEST, requestId, event = "cancelled", context = reference.diagnosticContext()))
+            throw cancellation
+        } finally {
+            trace.putAttribute(PerformanceAttributeName.OUTCOME, outcome)
+            trace.stop()
+        }
     }
 
     @Suppress("SuspendFunSwallowedCancellation")
@@ -63,51 +112,19 @@ internal class ManifestParserImpl @Inject constructor(
         }
     }
 
-    @Suppress("SuspendFunSwallowedCancellation")
-    private suspend fun installedPackageManifest(packageName: PackageName): Result<ParsedManifest> {
-        val requestId = nextOperationRequest()
-        Logger.d(TAG, operationLogMessage(OPERATION_MANIFEST, requestId, event = "started", context = "mode=installed package=${packageName.value}"))
-        return try {
-            withContext(dispatcherProvider.io()) {
-                runCatchingCancellable {
-                    val applicationInfo = packageManager.getApplicationInfo(packageName.value, 0)
-                    ParsedManifest(
-                        xml = manifestXmlRenderer.render(resourcesForApk(applicationInfo.sourceDir)),
-                        additionalInstalledSplits = applicationInfo.splitSourceDirs.orEmpty().size,
-                    )
-                }
-            }.onSuccess {
-                Logger.i(TAG, operationLogMessage(OPERATION_MANIFEST, requestId, event = "succeeded", context = "mode=installed package=${packageName.value}"))
-            }.onFailure {
-                Logger.e(TAG, it, operationLogMessage(OPERATION_MANIFEST, requestId, event = "failed", context = "mode=installed package=${packageName.value}"))
-            }
-        } catch (cancellation: CancellationException) {
-            Logger.d(TAG, operationLogMessage(OPERATION_MANIFEST, requestId, event = "cancelled", context = "mode=installed package=${packageName.value}"))
-            throw cancellation
+    private fun manifestResources(reference: AppReference): ManifestResources = when (reference) {
+        is AppReference.InstalledPackage -> {
+            val applicationInfo = packageManager.getApplicationInfo(reference.packageName.value, 0)
+            ManifestResources(
+                resources = resourcesForApk(applicationInfo.sourceDir),
+                additionalInstalledSplits = applicationInfo.splitSourceDirs.orEmpty().size,
+            )
         }
-    }
 
-    @Suppress("SuspendFunSwallowedCancellation")
-    private suspend fun apkFileManifest(apkPath: String): Result<ParsedManifest> {
-        val requestId = nextOperationRequest()
-        Logger.d(TAG, operationLogMessage(OPERATION_MANIFEST, requestId, event = "started", context = "mode=apk_file apk_path=$apkPath"))
-        return try {
-            withContext(dispatcherProvider.io()) {
-                runCatchingCancellable {
-                    ParsedManifest(
-                        xml = manifestXmlRenderer.render(resourcesForApk(apkPath)),
-                        additionalInstalledSplits = 0,
-                    )
-                }
-            }.onSuccess {
-                Logger.i(TAG, operationLogMessage(OPERATION_MANIFEST, requestId, event = "succeeded", context = "mode=apk_file apk_path=$apkPath"))
-            }.onFailure {
-                Logger.e(TAG, it, operationLogMessage(OPERATION_MANIFEST, requestId, event = "failed", context = "mode=apk_file apk_path=$apkPath"))
-            }
-        } catch (cancellation: CancellationException) {
-            Logger.d(TAG, operationLogMessage(OPERATION_MANIFEST, requestId, event = "cancelled", context = "mode=apk_file apk_path=$apkPath"))
-            throw cancellation
-        }
+        is AppReference.ApkFile -> ManifestResources(
+            resources = resourcesForApk(reference.path),
+            additionalInstalledSplits = 0,
+        )
     }
 
     private fun installedComponentIntentFilters(packageName: PackageName): List<Pair<ComponentIntentFilterKey, ComponentIntentFilter>> {
@@ -132,7 +149,18 @@ internal class ManifestParserImpl @Inject constructor(
     }
 }
 
+private data class ManifestResources(val resources: Resources, val additionalInstalledSplits: Int)
+
+private fun AppReference.analysisMode(): String = when (this) {
+    is AppReference.InstalledPackage -> "installed"
+    is AppReference.ApkFile -> "apk_file"
+}
+
 private fun AppReference.diagnosticContext(): String = when (this) {
     is AppReference.InstalledPackage -> "mode=installed package=${packageName.value}"
     is AppReference.ApkFile -> "mode=apk_file apk_path=$path"
 }
+
+private const val OUTCOME_SUCCESS = "success"
+private const val OUTCOME_ERROR = "error"
+private const val OUTCOME_CANCELLED = "cancelled"

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/manifest/ManifestParserImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/manifest/ManifestParserImpl.kt
@@ -8,9 +8,16 @@ import sk.styk.martin.apkanalyzer.core.apps.components.ComponentIntentFilterKey
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
 import sk.styk.martin.apkanalyzer.core.common.coroutines.runCatchingCancellable
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
+import sk.styk.martin.apkanalyzer.core.common.logger.nextOperationRequest
+import sk.styk.martin.apkanalyzer.core.common.logger.operationLogMessage
 import sk.styk.martin.apkanalyzer.core.common.model.AppReference
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+
+private const val TAG = "ManifestParser"
+private const val OPERATION_MANIFEST = "manifest"
+private const val OPERATION_COMPONENT_INTENT_FILTERS = "component_intent_filters"
 
 internal class ManifestParserImpl @Inject constructor(
     private val packageManager: PackageManager,
@@ -24,43 +31,79 @@ internal class ManifestParserImpl @Inject constructor(
         is AppReference.ApkFile -> apkFileManifest(reference.path)
     }
 
-    override suspend fun componentIntentFilters(reference: AppReference): Result<Map<ComponentIntentFilterKey, List<ComponentIntentFilter>>> =
-        withContext(dispatcherProvider.io()) {
-            runCatchingCancellable {
-                when (reference) {
-                    is AppReference.InstalledPackage -> installedComponentIntentFilters(reference.packageName)
-                    is AppReference.ApkFile -> componentManifestParser.parse(resourcesForApk(reference.path))
+    override suspend fun componentIntentFilters(reference: AppReference): Result<Map<ComponentIntentFilterKey, List<ComponentIntentFilter>>> {
+        val requestId = nextOperationRequest()
+        Logger.d(TAG, operationLogMessage(OPERATION_COMPONENT_INTENT_FILTERS, requestId, event = "started"))
+        return try {
+            withContext(dispatcherProvider.io()) {
+                runCatchingCancellable {
+                    when (reference) {
+                        is AppReference.InstalledPackage -> installedComponentIntentFilters(reference.packageName)
+                        is AppReference.ApkFile -> componentManifestParser.parse(resourcesForApk(reference.path))
+                    }
+                        .groupBy(
+                            keySelector = { it.first },
+                            valueTransform = { it.second },
+                        )
+                        .mapValues { (_, filters) -> filters.distinct() }
                 }
-                    .groupBy(
-                        keySelector = { it.first },
-                        valueTransform = { it.second },
-                    )
-                    .mapValues { (_, filters) -> filters.distinct() }
+            }.onSuccess {
+                Logger.d(TAG, operationLogMessage(OPERATION_COMPONENT_INTENT_FILTERS, requestId, event = "succeeded", context = "count=${it.size}"))
             }.onFailure {
-                Logger.e(TAG, it, "Can not read component intent filters from $reference")
+                Logger.w(
+                    TAG,
+                    it,
+                    operationLogMessage(OPERATION_COMPONENT_INTENT_FILTERS, requestId, event = "degraded", context = reference.diagnosticContext()),
+                )
             }
-        }
-
-    private suspend fun installedPackageManifest(packageName: PackageName): Result<ParsedManifest> = withContext(dispatcherProvider.io()) {
-        runCatchingCancellable {
-            val applicationInfo = packageManager.getApplicationInfo(packageName.value, 0)
-            ParsedManifest(
-                xml = manifestXmlRenderer.render(resourcesForApk(applicationInfo.sourceDir)),
-                additionalInstalledSplits = applicationInfo.splitSourceDirs.orEmpty().size,
-            )
-        }.onFailure {
-            Logger.e(TAG, it, "Can not read manifest for installed package $packageName")
+        } catch (cancellation: CancellationException) {
+            Logger.d(TAG, operationLogMessage(OPERATION_COMPONENT_INTENT_FILTERS, requestId, event = "cancelled"))
+            throw cancellation
         }
     }
 
-    private suspend fun apkFileManifest(apkPath: String): Result<ParsedManifest> = withContext(dispatcherProvider.io()) {
-        runCatchingCancellable {
-            ParsedManifest(
-                xml = manifestXmlRenderer.render(resourcesForApk(apkPath)),
-                additionalInstalledSplits = 0,
-            )
-        }.onFailure {
-            Logger.e(TAG, it, "Can not read manifest from $apkPath")
+    private suspend fun installedPackageManifest(packageName: PackageName): Result<ParsedManifest> {
+        val requestId = nextOperationRequest()
+        Logger.d(TAG, operationLogMessage(OPERATION_MANIFEST, requestId, event = "started", context = "mode=installed package=${packageName.value}"))
+        return try {
+            withContext(dispatcherProvider.io()) {
+                runCatchingCancellable {
+                    val applicationInfo = packageManager.getApplicationInfo(packageName.value, 0)
+                    ParsedManifest(
+                        xml = manifestXmlRenderer.render(resourcesForApk(applicationInfo.sourceDir)),
+                        additionalInstalledSplits = applicationInfo.splitSourceDirs.orEmpty().size,
+                    )
+                }
+            }.onSuccess {
+                Logger.i(TAG, operationLogMessage(OPERATION_MANIFEST, requestId, event = "succeeded", context = "mode=installed package=${packageName.value}"))
+            }.onFailure {
+                Logger.e(TAG, it, operationLogMessage(OPERATION_MANIFEST, requestId, event = "failed", context = "mode=installed package=${packageName.value}"))
+            }
+        } catch (cancellation: CancellationException) {
+            Logger.d(TAG, operationLogMessage(OPERATION_MANIFEST, requestId, event = "cancelled", context = "mode=installed package=${packageName.value}"))
+            throw cancellation
+        }
+    }
+
+    private suspend fun apkFileManifest(apkPath: String): Result<ParsedManifest> {
+        val requestId = nextOperationRequest()
+        Logger.d(TAG, operationLogMessage(OPERATION_MANIFEST, requestId, event = "started", context = "mode=apk_file apk_path=$apkPath"))
+        return try {
+            withContext(dispatcherProvider.io()) {
+                runCatchingCancellable {
+                    ParsedManifest(
+                        xml = manifestXmlRenderer.render(resourcesForApk(apkPath)),
+                        additionalInstalledSplits = 0,
+                    )
+                }
+            }.onSuccess {
+                Logger.i(TAG, operationLogMessage(OPERATION_MANIFEST, requestId, event = "succeeded", context = "mode=apk_file apk_path=$apkPath"))
+            }.onFailure {
+                Logger.e(TAG, it, operationLogMessage(OPERATION_MANIFEST, requestId, event = "failed", context = "mode=apk_file apk_path=$apkPath"))
+            }
+        } catch (cancellation: CancellationException) {
+            Logger.d(TAG, operationLogMessage(OPERATION_MANIFEST, requestId, event = "cancelled", context = "mode=apk_file apk_path=$apkPath"))
+            throw cancellation
         }
     }
 
@@ -84,8 +127,9 @@ internal class ManifestParserImpl @Inject constructor(
         applicationInfo.splitPublicSourceDirs = null
         return packageManager.getResourcesForApplication(applicationInfo)
     }
+}
 
-    companion object {
-        private const val TAG = "ManifestParser"
-    }
+private fun AppReference.diagnosticContext(): String = when (this) {
+    is AppReference.InstalledPackage -> "mode=installed package=${packageName.value}"
+    is AppReference.ApkFile -> "mode=apk_file apk_path=$path"
 }

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/manifest/ManifestParserImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/manifest/ManifestParserImpl.kt
@@ -31,6 +31,7 @@ internal class ManifestParserImpl @Inject constructor(
         is AppReference.ApkFile -> apkFileManifest(reference.path)
     }
 
+    @Suppress("SuspendFunSwallowedCancellation")
     override suspend fun componentIntentFilters(reference: AppReference): Result<Map<ComponentIntentFilterKey, List<ComponentIntentFilter>>> {
         val requestId = nextOperationRequest()
         Logger.d(TAG, operationLogMessage(OPERATION_COMPONENT_INTENT_FILTERS, requestId, event = "started"))
@@ -62,6 +63,7 @@ internal class ManifestParserImpl @Inject constructor(
         }
     }
 
+    @Suppress("SuspendFunSwallowedCancellation")
     private suspend fun installedPackageManifest(packageName: PackageName): Result<ParsedManifest> {
         val requestId = nextOperationRequest()
         Logger.d(TAG, operationLogMessage(OPERATION_MANIFEST, requestId, event = "started", context = "mode=installed package=${packageName.value}"))
@@ -85,6 +87,7 @@ internal class ManifestParserImpl @Inject constructor(
         }
     }
 
+    @Suppress("SuspendFunSwallowedCancellation")
     private suspend fun apkFileManifest(apkPath: String): Result<ParsedManifest> {
         val requestId = nextOperationRequest()
         Logger.d(TAG, operationLogMessage(OPERATION_MANIFEST, requestId, event = "started", context = "mode=apk_file apk_path=$apkPath"))

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/manifest/ManifestXmlRenderer.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/manifest/ManifestXmlRenderer.kt
@@ -3,5 +3,27 @@ package sk.styk.martin.apkanalyzer.core.apps.manifest
 import android.content.res.Resources
 
 internal interface ManifestXmlRenderer {
-    fun render(resources: Resources): String
+    fun parse(resources: Resources): ManifestXmlDocument
+
+    fun render(document: ManifestXmlDocument): String
 }
+
+internal data class ManifestXmlDocument(val nodes: List<ManifestXmlNode>)
+
+internal sealed interface ManifestXmlNode {
+    data class StartTag(
+        val depth: Int,
+        val name: String,
+        val attributes: List<ManifestXmlAttribute>,
+    ) : ManifestXmlNode
+
+    data class EndTag(val depth: Int, val name: String) : ManifestXmlNode
+
+    data class Text(val depth: Int, val value: String) : ManifestXmlNode
+}
+
+internal data class ManifestXmlAttribute(
+    val prefix: String?,
+    val name: String,
+    val value: String,
+)

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/manifest/ManifestXmlRendererImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/manifest/ManifestXmlRendererImpl.kt
@@ -6,35 +6,52 @@ import javax.inject.Inject
 
 internal class ManifestXmlRendererImpl @Inject constructor() : ManifestXmlRenderer {
 
-    override fun render(resources: Resources): String {
-        val output = StringBuilder()
+    override fun parse(resources: Resources): ManifestXmlDocument {
+        val nodes = mutableListOf<ManifestXmlNode>()
         resources.assets.openXmlResourceParser(MANIFEST_FILE_NAME).use { parser ->
             var eventType = parser.eventType
             while (eventType != XmlResourceParser.END_DOCUMENT) {
                 when (eventType) {
-                    XmlResourceParser.START_TAG -> appendStartTag(output, parser, resources)
-                    XmlResourceParser.END_TAG -> appendEndTag(output, parser)
-                    XmlResourceParser.TEXT -> appendText(output, parser)
+                    XmlResourceParser.START_TAG -> nodes += parser.toStartTag(resources)
+
+                    XmlResourceParser.END_TAG -> nodes += ManifestXmlNode.EndTag(
+                        depth = parser.depth,
+                        name = parser.name,
+                    )
+
+                    XmlResourceParser.TEXT ->
+                        parser.text
+                            ?.trim()
+                            ?.takeIf { it.isNotEmpty() }
+                            ?.let { nodes += ManifestXmlNode.Text(depth = parser.depth, value = it) }
                 }
                 eventType = parser.next()
+            }
+        }
+        return ManifestXmlDocument(nodes)
+    }
+
+    override fun render(document: ManifestXmlDocument): String {
+        val output = StringBuilder()
+        document.nodes.forEach { node ->
+            when (node) {
+                is ManifestXmlNode.StartTag -> appendStartTag(output, node)
+                is ManifestXmlNode.EndTag -> appendEndTag(output, node)
+                is ManifestXmlNode.Text -> appendText(output, node)
             }
         }
         return output.toString().trim().takeIf { it.isNotEmpty() }
             ?: error("Manifest is empty")
     }
 
-    private fun appendStartTag(
-        output: StringBuilder,
-        parser: XmlResourceParser,
-        resources: Resources,
-    ) {
-        output.appendIndent(parser.depth - 1)
+    private fun appendStartTag(output: StringBuilder, node: ManifestXmlNode.StartTag) {
+        output.appendIndent(node.depth - 1)
             .append('<')
-            .append(parser.name)
+            .append(node.name)
 
-        if (parser.depth == 1) {
+        if (node.depth == 1) {
             output.append("\n")
-                .appendIndent(parser.depth)
+                .appendIndent(node.depth)
                 .append("xmlns:")
                 .append(ANDROID_PREFIX)
                 .append("=\"")
@@ -42,49 +59,52 @@ internal class ManifestXmlRendererImpl @Inject constructor() : ManifestXmlRender
                 .append('"')
         }
 
-        for (index in 0 until parser.attributeCount) {
+        node.attributes.forEach { attribute ->
             output.append("\n")
-                .appendIndent(parser.depth)
+                .appendIndent(node.depth)
                 .appendQualifiedName(
-                    prefix = ANDROID_PREFIX.takeIf { parser.getAttributeNameResource(index) != 0 },
-                    name = parser.getAttributeName(index),
+                    prefix = attribute.prefix,
+                    name = attribute.name,
                 )
                 .append("=\"")
-                .append(attributeValue(parser, resources, index).escapeXml())
+                .append(attribute.value.escapeXml())
                 .append('"')
         }
         output.append(">\n")
     }
 
-    private fun appendEndTag(output: StringBuilder, parser: XmlResourceParser) {
-        output.appendIndent(parser.depth - 1)
+    private fun appendEndTag(output: StringBuilder, node: ManifestXmlNode.EndTag) {
+        output.appendIndent(node.depth - 1)
             .append("</")
-            .append(parser.name)
+            .append(node.name)
             .append(">\n")
     }
 
-    private fun appendText(output: StringBuilder, parser: XmlResourceParser) {
-        parser.text
-            ?.trim()
-            ?.takeIf { it.isNotEmpty() }
-            ?.let {
-                output.appendIndent(parser.depth)
-                    .append(it.escapeXml())
-                    .append('\n')
-            }
+    private fun appendText(output: StringBuilder, node: ManifestXmlNode.Text) {
+        output.appendIndent(node.depth)
+            .append(node.value.escapeXml())
+            .append('\n')
     }
 
-    private fun attributeValue(
-        parser: XmlResourceParser,
-        resources: Resources,
-        index: Int,
-    ): String {
-        val resourceId = parser.getAttributeResourceValue(index, 0)
+    private fun XmlResourceParser.toStartTag(resources: Resources): ManifestXmlNode.StartTag = ManifestXmlNode.StartTag(
+        depth = depth,
+        name = name,
+        attributes = List(attributeCount) { index ->
+            ManifestXmlAttribute(
+                prefix = ANDROID_PREFIX.takeIf { getAttributeNameResource(index) != 0 },
+                name = getAttributeName(index),
+                value = attributeValue(resources, index),
+            )
+        },
+    )
+
+    private fun XmlResourceParser.attributeValue(resources: Resources, index: Int): String {
+        val resourceId = getAttributeResourceValue(index, 0)
         if (resourceId != 0) {
             return runCatching { "@${resources.getResourceName(resourceId)}" }
-                .getOrDefault(parser.getAttributeValue(index))
+                .getOrDefault(getAttributeValue(index))
         }
-        return parser.getAttributeValue(index)
+        return getAttributeValue(index)
     }
 }
 

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/signing/ApkSigningBlockAnalyzerImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/signing/ApkSigningBlockAnalyzerImpl.kt
@@ -18,7 +18,7 @@ internal class ApkSigningBlockAnalyzerImpl @Inject constructor(private val signi
             .takeIf { it.isNotEmpty() }
             ?.sorted()
     }.onFailure {
-        Logger.e(TAG, it, "Could not determine APK signing schemes")
+        Logger.w(TAG, it, "Could not determine APK signing schemes")
     }.getOrNull()
 
     private fun hasVerifiedJarSignature(apkPath: String): Boolean = JarFile(apkPath, true).use { jarFile ->

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/signing/AppSigningRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/signing/AppSigningRepositoryImpl.kt
@@ -29,6 +29,7 @@ internal class AppSigningRepositoryImpl @Inject constructor(
     appScope: CoroutineScope,
 ) : AppSigningRepository {
 
+    @Suppress("TooGenericExceptionCaught")
     private val cachedSigning = packageChangesObserver.observe()
         .onStart { emit(Unit) }
         .mapLatest {

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/signing/AppSigningRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/signing/AppSigningRepositoryImpl.kt
@@ -11,8 +11,15 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.shareIn
 import sk.styk.martin.apkanalyzer.core.apps.PackageChangesObserver
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
+import sk.styk.martin.apkanalyzer.core.common.logger.Logger
+import sk.styk.martin.apkanalyzer.core.common.logger.nextOperationRequest
+import sk.styk.martin.apkanalyzer.core.common.logger.operationLogMessage
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+
+private const val TAG = "AppSigningRepositoryImpl"
+private const val OPERATION = "device_signing"
 
 internal class AppSigningRepositoryImpl @Inject constructor(
     private val packageManager: PackageManager,
@@ -24,7 +31,21 @@ internal class AppSigningRepositoryImpl @Inject constructor(
 
     private val cachedSigning = packageChangesObserver.observe()
         .onStart { emit(Unit) }
-        .mapLatest { loadAllSigning() }
+        .mapLatest {
+            val requestId = nextOperationRequest()
+            Logger.d(TAG, operationLogMessage(OPERATION, requestId, event = "started"))
+            try {
+                val result = loadAllSigning()
+                Logger.i(TAG, operationLogMessage(OPERATION, requestId, event = "succeeded", context = "app_count=${result.size}"))
+                result
+            } catch (cancellation: CancellationException) {
+                Logger.d(TAG, operationLogMessage(OPERATION, requestId, event = "cancelled"))
+                throw cancellation
+            } catch (failure: Throwable) {
+                Logger.e(TAG, failure, operationLogMessage(OPERATION, requestId, event = "failed"))
+                throw failure
+            }
+        }
         .flowOn(dispatcherProvider.io())
         .shareIn(appScope, SharingStarted.Lazily, replay = 1)
 

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/signing/AppSigningRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/signing/AppSigningRepositoryImpl.kt
@@ -6,15 +6,22 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.shareIn
 import sk.styk.martin.apkanalyzer.core.apps.PackageChangesObserver
+import sk.styk.martin.apkanalyzer.core.apps.appCountBucket
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.logger.nextOperationRequest
 import sk.styk.martin.apkanalyzer.core.common.logger.operationLogMessage
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceAttributeName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceMetricName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTraceName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
+import sk.styk.martin.apkanalyzer.core.common.performance.measureStage
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -27,16 +34,18 @@ internal class AppSigningRepositoryImpl @Inject constructor(
     packageChangesObserver: PackageChangesObserver,
     dispatcherProvider: DispatcherProvider,
     appScope: CoroutineScope,
+    private val performanceTracker: PerformanceTracker,
 ) : AppSigningRepository {
 
     @Suppress("TooGenericExceptionCaught")
     private val cachedSigning = packageChangesObserver.observe()
-        .onStart { emit(Unit) }
-        .mapLatest {
+        .map { AppSigningLoadTrigger.PackageChange }
+        .onStart { emit(AppSigningLoadTrigger.Initial) }
+        .mapLatest { trigger ->
             val requestId = nextOperationRequest()
             Logger.d(TAG, operationLogMessage(OPERATION, requestId, event = "started"))
             try {
-                val result = loadAllSigning()
+                val result = loadAllSigning(trigger)
                 Logger.i(TAG, operationLogMessage(OPERATION, requestId, event = "succeeded", context = "app_count=${result.size}"))
                 result
             } catch (cancellation: CancellationException) {
@@ -53,6 +62,40 @@ internal class AppSigningRepositoryImpl @Inject constructor(
     override fun signing(): Flow<Map<PackageName, AppSigning>> = cachedSigning
 
     @SuppressLint("QueryPermissionsNeeded")
-    private fun loadAllSigning(): Map<PackageName, AppSigning> = packageManager.getInstalledPackages(PackageManager.GET_SIGNING_CERTIFICATES)
-        .associate { PackageName(it.packageName) to certificateExtractor.getAppSigning(it) }
+    private fun loadAllSigning(trigger: AppSigningLoadTrigger): Map<PackageName, AppSigning> {
+        val trace = performanceTracker.startTrace(PerformanceTraceName.APP_SIGNING_INDEX_LOAD)
+        trace.putAttribute(PerformanceAttributeName.TRIGGER, trigger.attributeValue)
+        var outcome = OUTCOME_ERROR
+        try {
+            val packages = trace.measureStage(PerformanceMetricName.PACKAGE_QUERY_US) {
+                packageManager.getInstalledPackages(PackageManager.GET_SIGNING_CERTIFICATES)
+            }
+            val signing = trace.measureStage(PerformanceMetricName.CERTIFICATE_MAPPING_US) {
+                packages.associate { PackageName(it.packageName) to certificateExtractor.getAppSigning(it) }
+            }
+            val certificateCount = signing.values.sumOf { it.currentCertificates.size + it.pastCertificates.size }
+            trace.putMetric(PerformanceMetricName.APP_COUNT, signing.size.toLong())
+            trace.putMetric(PerformanceMetricName.CERTIFICATE_COUNT, certificateCount.toLong())
+            trace.putAttribute(PerformanceAttributeName.APP_COUNT_BUCKET, appCountBucket(signing.size))
+            outcome = OUTCOME_SUCCESS
+            return signing
+        } catch (cancellation: CancellationException) {
+            outcome = OUTCOME_CANCELLED
+            throw cancellation
+        } finally {
+            trace.putAttribute(PerformanceAttributeName.OUTCOME, outcome)
+            trace.stop()
+        }
+    }
 }
+
+private enum class AppSigningLoadTrigger(val attributeValue: String) {
+    Initial(TRIGGER_INITIAL),
+    PackageChange(TRIGGER_PACKAGE_CHANGE),
+}
+
+private const val OUTCOME_SUCCESS = "success"
+private const val OUTCOME_ERROR = "error"
+private const val OUTCOME_CANCELLED = "cancelled"
+private const val TRIGGER_INITIAL = "initial"
+private const val TRIGGER_PACKAGE_CHANGE = "package_change"

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/signing/CertificateExtractorImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/signing/CertificateExtractorImpl.kt
@@ -38,7 +38,7 @@ internal class CertificateExtractorImpl @Inject constructor(private val digestMa
 
     private fun List<Signature>.toCertificates(packageName: String) = mapNotNull { signature ->
         runCatching { signature.toCertificateData() }
-            .onFailure { Logger.e(TAG, it, "Could not parse certificate for $packageName") }
+            .onFailure { Logger.w(TAG, it, "Could not parse certificate for $packageName") }
             .getOrNull()
     }
 

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
@@ -21,9 +21,15 @@ import sk.styk.martin.apkanalyzer.core.common.logger.operationLogMessage
 import sk.styk.martin.apkanalyzer.core.common.model.AppSize
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.model.bytes
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceAttributeName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceMetricName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTraceName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
+import sk.styk.martin.apkanalyzer.core.common.performance.measureStage
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.cancellation.CancellationException
 
 private const val TAG = "StorageStatsRepositoryImpl"
 private const val OPERATION = "storage_stats"
@@ -35,6 +41,7 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
     private val appOpsManager: AppOpsManager,
     private val dispatcherProvider: DispatcherProvider,
     private val applicationScope: CoroutineScope,
+    private val performanceTracker: PerformanceTracker,
 ) : StorageStatsRepository,
     DefaultLifecycleObserver {
 
@@ -48,7 +55,7 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
 
     override fun onStart(owner: LifecycleOwner) {
         applicationScope.launch(dispatcherProvider.io()) {
-            fetchTotalSizes(packageNames)
+            fetchTotalSizes(packageNames, TRIGGER_LIFECYCLE_START)
         }
     }
 
@@ -64,7 +71,7 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
     override fun requestTotalSizes(packageNames: List<PackageName>) {
         this.packageNames = packageNames
         applicationScope.launch(dispatcherProvider.io()) {
-            fetchTotalSizes(packageNames)
+            fetchTotalSizes(packageNames, TRIGGER_INSTALLED_APPS)
         }
     }
 
@@ -94,58 +101,85 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
         null
     }
 
-    private fun fetchTotalSizes(packageNames: List<PackageName>) {
+    private fun fetchTotalSizes(packageNames: List<PackageName>, trigger: String) {
         val requestId = nextOperationRequest()
-        val hasPermission = checkPermission()
-        isPermissionGranted.value = hasPermission
-        if (!hasPermission) {
-            Logger.w(TAG, operationLogMessage(OPERATION, requestId, event = "degraded", context = "reason=permission_missing"))
-            return
-        }
-
-        Logger.d(TAG, operationLogMessage(OPERATION, requestId, event = "started", context = "requested_count=${packageNames.size}"))
-        val user = UserHandle.getUserHandleForUid(Process.myUid())
-        var uninstallRaceCount = 0
-        var permissionRaceCount = 0
-        var queryFailureCount = 0
-        var lastQueryFailure: IOException? = null
-        val sizes = packageNames.mapNotNull { packageName ->
-            when (val result = queryPackageSize(user, packageName)) {
-                is SizeQueryResult.Success -> packageName to result.size
-
-                SizeQueryResult.UninstallRace -> {
-                    uninstallRaceCount++
-                    null
-                }
-
-                SizeQueryResult.PermissionRace -> {
-                    permissionRaceCount++
-                    null
-                }
-
-                is SizeQueryResult.Failure -> {
-                    queryFailureCount++
-                    lastQueryFailure = result.error
-                    null
-                }
+        val trace = performanceTracker.startTrace(PerformanceTraceName.STORAGE_STATS_LOAD)
+        trace.putAttribute(PerformanceAttributeName.TRIGGER, trigger)
+        trace.putMetric(PerformanceMetricName.REQUESTED_COUNT, packageNames.size.toLong())
+        var outcome = OUTCOME_ERROR
+        try {
+            val hasPermission = trace.measureStage(PerformanceMetricName.PERMISSION_CHECK_US) {
+                checkPermission()
             }
-        }.toMap()
-        totalSizes.value = sizes
+            trace.putAttribute(PerformanceAttributeName.PERMISSION, if (hasPermission) PERMISSION_GRANTED else PERMISSION_DENIED)
+            isPermissionGranted.value = hasPermission
+            if (!hasPermission) {
+                trace.putMetric(PerformanceMetricName.LOADED_COUNT, 0)
+                Logger.w(TAG, operationLogMessage(OPERATION, requestId, event = "degraded", context = "reason=permission_missing"))
+                outcome = OUTCOME_DEGRADED
+                return
+            }
 
-        if (uninstallRaceCount > 0) {
-            Logger.w(TAG, operationLogMessage(OPERATION, requestId, event = "degraded", context = "reason=uninstall_race skipped_count=$uninstallRaceCount"))
+            Logger.d(TAG, operationLogMessage(OPERATION, requestId, event = "started", context = "requested_count=${packageNames.size}"))
+            val user = UserHandle.getUserHandleForUid(Process.myUid())
+            var uninstallRaceCount = 0
+            var permissionRaceCount = 0
+            var queryFailureCount = 0
+            var lastQueryFailure: IOException? = null
+            val sizes = trace.measureStage(PerformanceMetricName.STATS_QUERY_US) {
+                packageNames.mapNotNull { packageName ->
+                    when (val result = queryPackageSize(user, packageName)) {
+                        is SizeQueryResult.Success -> packageName to result.size
+
+                        SizeQueryResult.UninstallRace -> {
+                            uninstallRaceCount++
+                            null
+                        }
+
+                        SizeQueryResult.PermissionRace -> {
+                            permissionRaceCount++
+                            null
+                        }
+
+                        is SizeQueryResult.Failure -> {
+                            queryFailureCount++
+                            lastQueryFailure = result.error
+                            null
+                        }
+                    }
+                }.toMap()
+            }
+            totalSizes.value = sizes
+            trace.putMetric(PerformanceMetricName.LOADED_COUNT, sizes.size.toLong())
+
+            if (uninstallRaceCount > 0) {
+                Logger.w(
+                    TAG,
+                    operationLogMessage(OPERATION, requestId, event = "degraded", context = "reason=uninstall_race skipped_count=$uninstallRaceCount"),
+                )
+            }
+            if (permissionRaceCount > 0) {
+                Logger.w(
+                    TAG,
+                    operationLogMessage(OPERATION, requestId, event = "degraded", context = "reason=permission_race skipped_count=$permissionRaceCount"),
+                )
+            }
+            lastQueryFailure?.let {
+                Logger.w(
+                    TAG,
+                    it,
+                    operationLogMessage(OPERATION, requestId, event = "degraded", context = "reason=stats_query_failed failed_count=$queryFailureCount"),
+                )
+            }
+            Logger.i(TAG, operationLogMessage(OPERATION, requestId, event = "succeeded", context = "loaded_count=${sizes.size}"))
+            outcome = if (uninstallRaceCount > 0 || permissionRaceCount > 0 || queryFailureCount > 0) OUTCOME_DEGRADED else OUTCOME_SUCCESS
+        } catch (cancellation: CancellationException) {
+            outcome = OUTCOME_CANCELLED
+            throw cancellation
+        } finally {
+            trace.putAttribute(PerformanceAttributeName.OUTCOME, outcome)
+            trace.stop()
         }
-        if (permissionRaceCount > 0) {
-            Logger.w(TAG, operationLogMessage(OPERATION, requestId, event = "degraded", context = "reason=permission_race skipped_count=$permissionRaceCount"))
-        }
-        lastQueryFailure?.let {
-            Logger.w(
-                TAG,
-                it,
-                operationLogMessage(OPERATION, requestId, event = "degraded", context = "reason=stats_query_failed failed_count=$queryFailureCount"),
-            )
-        }
-        Logger.i(TAG, operationLogMessage(OPERATION, requestId, event = "succeeded", context = "loaded_count=${sizes.size}"))
     }
 
     private fun queryPackageSize(user: UserHandle, packageName: PackageName): SizeQueryResult = try {
@@ -166,3 +200,12 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
         data class Failure(val error: IOException) : SizeQueryResult
     }
 }
+
+private const val OUTCOME_SUCCESS = "success"
+private const val OUTCOME_DEGRADED = "degraded"
+private const val OUTCOME_ERROR = "error"
+private const val OUTCOME_CANCELLED = "cancelled"
+private const val PERMISSION_GRANTED = "granted"
+private const val PERMISSION_DENIED = "denied"
+private const val TRIGGER_LIFECYCLE_START = "lifecycle_start"
+private const val TRIGGER_INSTALLED_APPS = "installed_apps"

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
@@ -14,15 +14,19 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import sk.styk.martin.apkanalyzer.core.apps.INSTALLED_APPS
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
+import sk.styk.martin.apkanalyzer.core.common.logger.nextOperationRequest
+import sk.styk.martin.apkanalyzer.core.common.logger.operationLogMessage
 import sk.styk.martin.apkanalyzer.core.common.model.AppSize
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.model.bytes
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
+
+private const val TAG = "StorageStatsRepositoryImpl"
+private const val OPERATION = "storage_stats"
 
 @Singleton
 internal class StorageStatsRepositoryImpl @Inject constructor(
@@ -65,37 +69,100 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun queryTotalSize(packageName: PackageName): AppSize? = totalSizes.value[packageName] ?: if (checkPermission()) {
-        queryPackageSize(UserHandle.getUserHandleForUid(Process.myUid()), packageName)
+        when (val result = queryPackageSize(UserHandle.getUserHandleForUid(Process.myUid()), packageName)) {
+            is SizeQueryResult.Success -> result.size
+
+            SizeQueryResult.UninstallRace -> null
+
+            SizeQueryResult.PermissionRace -> null
+
+            is SizeQueryResult.Failure -> {
+                Logger.w(
+                    TAG,
+                    result.error,
+                    operationLogMessage(
+                        OPERATION,
+                        nextOperationRequest(),
+                        event = "degraded",
+                        context = "reason=stats_query_failed package=${packageName.value}",
+                    ),
+                )
+                null
+            }
+        }
     } else {
         null
     }
 
     private fun fetchTotalSizes(packageNames: List<PackageName>) {
+        val requestId = nextOperationRequest()
         val hasPermission = checkPermission()
         isPermissionGranted.value = hasPermission
-        if (!hasPermission) return
+        if (!hasPermission) {
+            Logger.w(TAG, operationLogMessage(OPERATION, requestId, event = "degraded", context = "reason=permission_missing"))
+            return
+        }
 
-        Logger.d(INSTALLED_APPS, "Load apps total size")
+        Logger.d(TAG, operationLogMessage(OPERATION, requestId, event = "started", context = "requested_count=${packageNames.size}"))
         val user = UserHandle.getUserHandleForUid(Process.myUid())
-        totalSizes.value = packageNames.mapNotNull { packageName ->
-            queryPackageSize(user, packageName)?.let { packageName to it }
+        var uninstallRaceCount = 0
+        var permissionRaceCount = 0
+        var queryFailureCount = 0
+        var lastQueryFailure: IOException? = null
+        val sizes = packageNames.mapNotNull { packageName ->
+            when (val result = queryPackageSize(user, packageName)) {
+                is SizeQueryResult.Success -> packageName to result.size
+
+                SizeQueryResult.UninstallRace -> {
+                    uninstallRaceCount++
+                    null
+                }
+
+                SizeQueryResult.PermissionRace -> {
+                    permissionRaceCount++
+                    null
+                }
+
+                is SizeQueryResult.Failure -> {
+                    queryFailureCount++
+                    lastQueryFailure = result.error
+                    null
+                }
+            }
         }.toMap()
-        Logger.d(INSTALLED_APPS, "Apps total size loaded")
+        totalSizes.value = sizes
+
+        if (uninstallRaceCount > 0) {
+            Logger.w(TAG, operationLogMessage(OPERATION, requestId, event = "degraded", context = "reason=uninstall_race skipped_count=$uninstallRaceCount"))
+        }
+        if (permissionRaceCount > 0) {
+            Logger.w(TAG, operationLogMessage(OPERATION, requestId, event = "degraded", context = "reason=permission_race skipped_count=$permissionRaceCount"))
+        }
+        lastQueryFailure?.let {
+            Logger.w(
+                TAG,
+                it,
+                operationLogMessage(OPERATION, requestId, event = "degraded", context = "reason=stats_query_failed failed_count=$queryFailureCount"),
+            )
+        }
+        Logger.i(TAG, operationLogMessage(OPERATION, requestId, event = "succeeded", context = "loaded_count=${sizes.size}"))
     }
 
-    private fun queryPackageSize(user: UserHandle, packageName: PackageName): AppSize? = try {
+    private fun queryPackageSize(user: UserHandle, packageName: PackageName): SizeQueryResult = try {
         val stats = storageStatsManager.queryStatsForPackage(StorageManager.UUID_DEFAULT, packageName.value, user)
-        stats.appBytes.bytes + stats.dataBytes.bytes + stats.cacheBytes.bytes
+        SizeQueryResult.Success(stats.appBytes.bytes + stats.dataBytes.bytes + stats.cacheBytes.bytes)
     } catch (_: PackageManager.NameNotFoundException) {
-        null
-    } catch (_: IOException) {
-        Logger.w(TAG, "Failed to query storage stats for $packageName")
-        null
+        SizeQueryResult.UninstallRace
+    } catch (e: IOException) {
+        SizeQueryResult.Failure(e)
     } catch (_: SecurityException) {
-        null
+        SizeQueryResult.PermissionRace
     }
 
-    private companion object {
-        const val TAG = "StorageStatsRepository"
+    private sealed interface SizeQueryResult {
+        data class Success(val size: AppSize) : SizeQueryResult
+        data object UninstallRace : SizeQueryResult
+        data object PermissionRace : SizeQueryResult
+        data class Failure(val error: IOException) : SizeQueryResult
     }
 }

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/usagestats/UsageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/usagestats/UsageStatsRepositoryImpl.kt
@@ -12,15 +12,19 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import sk.styk.martin.apkanalyzer.core.apps.INSTALLED_APPS
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
+import sk.styk.martin.apkanalyzer.core.common.logger.nextOperationRequest
+import sk.styk.martin.apkanalyzer.core.common.logger.operationLogMessage
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Duration.Companion.days
 import kotlin.time.toJavaDuration
+
+private const val TAG = "UsageStatsRepositoryImpl"
+private const val OPERATION = "usage_stats"
 
 @Singleton
 internal class UsageStatsRepositoryImpl @Inject constructor(
@@ -54,15 +58,20 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
     }
 
     private fun fetchUsageTimes() {
+        val requestId = nextOperationRequest()
         val hasPermission = checkPermission()
         isPermissionGranted.value = hasPermission
-        if (!hasPermission) return
+        if (!hasPermission) {
+            Logger.w(TAG, operationLogMessage(OPERATION, requestId, event = "degraded", context = "reason=permission_missing"))
+            return
+        }
 
-        Logger.d(INSTALLED_APPS, "Load apps last used time")
-        lastUsedTimes.value = queryRawUsageStats()
+        Logger.d(TAG, operationLogMessage(OPERATION, requestId, event = "started"))
+        val usages = queryRawUsageStats()
             .groupBy { PackageName(it.packageName) }
             .mapValues { (_, usages) -> Instant.ofEpochMilli(usages.maxOf { it.lastTimeUsed }) }
-        Logger.d(INSTALLED_APPS, "Apps last used time loaded")
+        lastUsedTimes.value = usages
+        Logger.i(TAG, operationLogMessage(OPERATION, requestId, event = "succeeded", context = "loaded_count=${usages.size}"))
     }
 
     @SuppressLint("MissingPermission")

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/usagestats/UsageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/usagestats/UsageStatsRepositoryImpl.kt
@@ -17,9 +17,15 @@ import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.logger.nextOperationRequest
 import sk.styk.martin.apkanalyzer.core.common.logger.operationLogMessage
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceAttributeName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceMetricName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTraceName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
+import sk.styk.martin.apkanalyzer.core.common.performance.measureStage
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration.Companion.days
 import kotlin.time.toJavaDuration
 
@@ -33,6 +39,7 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
     private val appOpsManager: AppOpsManager,
     private val dispatcherProvider: DispatcherProvider,
     private val applicationScope: CoroutineScope,
+    private val performanceTracker: PerformanceTracker,
 ) : UsageStatsRepository,
     DefaultLifecycleObserver {
 
@@ -49,7 +56,7 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun queryLastUsedTime(packageName: PackageName): Instant? = lastUsedTimes.value[packageName] ?: if (checkPermission()) {
-        queryRawUsageStats()
+        queryRawUsageStats().usages
             .filter { it.packageName == packageName.value }
             .maxOfOrNull { it.lastTimeUsed }
             ?.let { Instant.ofEpochMilli(it) }
@@ -59,28 +66,58 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
 
     private fun fetchUsageTimes() {
         val requestId = nextOperationRequest()
-        val hasPermission = checkPermission()
-        isPermissionGranted.value = hasPermission
-        if (!hasPermission) {
-            Logger.w(TAG, operationLogMessage(OPERATION, requestId, event = "degraded", context = "reason=permission_missing"))
-            return
-        }
+        val trace = performanceTracker.startTrace(PerformanceTraceName.USAGE_STATS_LOAD)
+        trace.putAttribute(PerformanceAttributeName.TRIGGER, TRIGGER_LIFECYCLE_START)
+        var outcome = OUTCOME_ERROR
+        try {
+            val hasPermission = trace.measureStage(PerformanceMetricName.PERMISSION_CHECK_US) {
+                checkPermission()
+            }
+            trace.putAttribute(PerformanceAttributeName.PERMISSION, if (hasPermission) PERMISSION_GRANTED else PERMISSION_DENIED)
+            isPermissionGranted.value = hasPermission
+            if (!hasPermission) {
+                trace.putMetric(PerformanceMetricName.LOADED_COUNT, 0)
+                Logger.w(TAG, operationLogMessage(OPERATION, requestId, event = "degraded", context = "reason=permission_missing"))
+                outcome = OUTCOME_DEGRADED
+                return
+            }
 
-        Logger.d(TAG, operationLogMessage(OPERATION, requestId, event = "started"))
-        val usages = queryRawUsageStats()
-            .groupBy { PackageName(it.packageName) }
-            .mapValues { (_, usages) -> Instant.ofEpochMilli(usages.maxOf { it.lastTimeUsed }) }
-        lastUsedTimes.value = usages
-        Logger.i(TAG, operationLogMessage(OPERATION, requestId, event = "succeeded", context = "loaded_count=${usages.size}"))
+            Logger.d(TAG, operationLogMessage(OPERATION, requestId, event = "started"))
+            val queryResult = trace.measureStage(PerformanceMetricName.USAGE_QUERY_US) {
+                queryRawUsageStats(detectPermissionRace = true)
+            }
+            val usages = trace.measureStage(PerformanceMetricName.USAGE_MAPPING_US) {
+                queryResult.usages
+                    .groupBy { PackageName(it.packageName) }
+                    .mapValues { (_, usages) -> Instant.ofEpochMilli(usages.maxOf { it.lastTimeUsed }) }
+            }
+            lastUsedTimes.value = usages
+            trace.putMetric(PerformanceMetricName.LOADED_COUNT, usages.size.toLong())
+            if (queryResult.permissionRace) {
+                trace.putAttribute(PerformanceAttributeName.PERMISSION, PERMISSION_DENIED)
+            }
+            Logger.i(TAG, operationLogMessage(OPERATION, requestId, event = "succeeded", context = "loaded_count=${usages.size}"))
+            outcome = if (queryResult.permissionRace) OUTCOME_DEGRADED else OUTCOME_SUCCESS
+        } catch (cancellation: CancellationException) {
+            outcome = OUTCOME_CANCELLED
+            throw cancellation
+        } finally {
+            trace.putAttribute(PerformanceAttributeName.OUTCOME, outcome)
+            trace.stop()
+        }
     }
 
     @SuppressLint("MissingPermission")
-    private fun queryRawUsageStats() = try {
+    private fun queryRawUsageStats(detectPermissionRace: Boolean = false): UsageStatsQueryResult = try {
         val now = Instant.now()
         val yearAgo = now - 365.days.toJavaDuration()
-        usageStatsManager.queryUsageStats(UsageStatsManager.INTERVAL_BEST, yearAgo.toEpochMilli(), now.toEpochMilli())
+        val usages = usageStatsManager.queryUsageStats(UsageStatsManager.INTERVAL_BEST, yearAgo.toEpochMilli(), now.toEpochMilli())
+        UsageStatsQueryResult(
+            usages = usages,
+            permissionRace = detectPermissionRace && usages.isEmpty() && !checkPermission(),
+        )
     } catch (_: SecurityException) {
-        emptyList()
+        UsageStatsQueryResult(usages = emptyList(), permissionRace = true)
     }
 
     private fun checkPermission(): Boolean {
@@ -92,4 +129,14 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
 
         return mode == AppOpsManager.MODE_ALLOWED
     }
+
+    private data class UsageStatsQueryResult(val usages: List<android.app.usage.UsageStats>, val permissionRace: Boolean)
 }
+
+private const val OUTCOME_SUCCESS = "success"
+private const val OUTCOME_DEGRADED = "degraded"
+private const val OUTCOME_ERROR = "error"
+private const val OUTCOME_CANCELLED = "cancelled"
+private const val PERMISSION_GRANTED = "granted"
+private const val PERMISSION_DENIED = "denied"
+private const val TRIGGER_LIFECYCLE_START = "lifecycle_start"

--- a/core/common/AGENTS.md
+++ b/core/common/AGENTS.md
@@ -17,6 +17,10 @@ logger/
   OperationLog.kt         - `nextOperationRequest()` process-local request-id counter and
                             `operationLogMessage(...)` shared `operation=<op> request=<n> [stage=<s>]
                             event=<e> [context]` message-shape formatter for load-operation logging
+performance/
+  PerformanceTracker.kt   - Firebase-free parent-trace and trace-handle contracts
+  PerformanceTiming.kt    - Elapsed-realtime nanosecond clock and sync/suspend stage timing helpers
+  PerformanceNames.kt     - Central low-cardinality trace, metric, and attribute names
 resources/
   ResourcesManager.kt     - Android resources access (strings, colors, dimensions)
 settings/
@@ -43,6 +47,11 @@ util/                     - General Android and formatting utilities
 - `Logger` - Static logging: `Logger.d("Tag", "msg")`, `Logger.e("Tag", throwable, "msg")`
 - `nextOperationRequest()` / `operationLogMessage(...)` - Consistent operation/stage/event logging
   convention for public load operations across repositories
+- `PerformanceTracker` / `PerformanceTrace` - Firebase-free performance instrumentation contracts
+- `measureStage(...)` / `measureSuspendStage(...)` - Exception- and cancellation-safe whole-microsecond
+  stage timing with a monotonic nanosecond clock
+- `PerformanceTraceName` / `PerformanceMetricName` / `PerformanceAttributeName` - Fixed production
+  telemetry names
 - `ResourcesManager` - Injectable Android resources access
 - `PersistenceRepository` - DataStore preferences abstraction
 - `AppSource` - App install source classification

--- a/core/common/AGENTS.md
+++ b/core/common/AGENTS.md
@@ -14,6 +14,9 @@ coroutines/
   RunCatching.kt          - Result capture for suspend code that rethrows cancellation
 logger/
   Logger.kt               - Timber + Firebase Crashlytics logging wrapper (object)
+  OperationLog.kt         - `nextOperationRequest()` process-local request-id counter and
+                            `operationLogMessage(...)` shared `operation=<op> request=<n> [stage=<s>]
+                            event=<e> [context]` message-shape formatter for load-operation logging
 resources/
   ResourcesManager.kt     - Android resources access (strings, colors, dimensions)
 settings/
@@ -38,6 +41,8 @@ util/                     - General Android and formatting utilities
 
 - `DispatcherProvider` - Inject in ViewModels/Repositories for coroutine dispatching
 - `Logger` - Static logging: `Logger.d("Tag", "msg")`, `Logger.e("Tag", throwable, "msg")`
+- `nextOperationRequest()` / `operationLogMessage(...)` - Consistent operation/stage/event logging
+  convention for public load operations across repositories
 - `ResourcesManager` - Injectable Android resources access
 - `PersistenceRepository` - DataStore preferences abstraction
 - `AppSource` - App install source classification

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/logger/OperationLog.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/logger/OperationLog.kt
@@ -1,0 +1,28 @@
+package sk.styk.martin.apkanalyzer.core.common.logger
+
+import java.util.concurrent.atomic.AtomicLong
+
+private val requestSequence = AtomicLong(0)
+
+fun nextOperationRequest(): Long = requestSequence.incrementAndGet()
+
+fun operationLogMessage(
+    operation: String,
+    request: Long,
+    event: String,
+    stage: String? = null,
+    context: String? = null,
+): String {
+    val builder = StringBuilder("operation=")
+        .append(operation)
+        .append(" request=")
+        .append(request)
+    if (stage != null) {
+        builder.append(" stage=").append(stage)
+    }
+    builder.append(" event=").append(event)
+    if (context != null) {
+        builder.append(' ').append(context)
+    }
+    return builder.toString()
+}

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceNames.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceNames.kt
@@ -1,0 +1,56 @@
+package sk.styk.martin.apkanalyzer.core.common.performance
+
+object PerformanceTraceName {
+    const val INSTALLED_APPS_LOAD = "installed_apps_load"
+    const val APP_DETAIL_LOAD = "app_detail_load"
+    const val MANIFEST_LOAD = "manifest_load"
+    const val APP_SIGNING_INDEX_LOAD = "app_signing_index_load"
+    const val STORAGE_STATS_LOAD = "storage_stats_load"
+    const val USAGE_STATS_LOAD = "usage_stats_load"
+    const val DEVICE_FEATURES_LOAD = "device_features_load"
+}
+
+object PerformanceMetricName {
+    const val PACKAGE_QUERY_US = "package_query_us"
+    const val APP_MAPPING_US = "app_mapping_us"
+    const val APP_COUNT = "app_count"
+    const val CACHE_LOOKUP_US = "cache_lookup_us"
+    const val INTENT_FILTERS_US = "intent_filters_us"
+    const val STORAGE_STATS_US = "storage_stats_us"
+    const val USAGE_STATS_US = "usage_stats_us"
+    const val GENERAL_INFO_US = "general_info_us"
+    const val CERTIFICATE_US = "certificate_us"
+    const val SIGNING_SCHEMES_US = "signing_schemes_us"
+    const val LAUNCHER_QUERY_US = "launcher_query_us"
+    const val COMPONENTS_US = "components_us"
+    const val PERMISSIONS_US = "permissions_us"
+    const val FEATURES_US = "features_us"
+    const val PACKAGING_US = "packaging_us"
+    const val RESOURCE_LOOKUP_US = "resource_lookup_us"
+    const val MANIFEST_PARSE_US = "manifest_parse_us"
+    const val XML_RENDER_US = "xml_render_us"
+    const val SPLIT_COUNT = "split_count"
+    const val CERTIFICATE_MAPPING_US = "certificate_mapping_us"
+    const val CERTIFICATE_COUNT = "certificate_count"
+    const val PERMISSION_CHECK_US = "permission_check_us"
+    const val STATS_QUERY_US = "stats_query_us"
+    const val REQUESTED_COUNT = "requested_count"
+    const val LOADED_COUNT = "loaded_count"
+    const val USAGE_QUERY_US = "usage_query_us"
+    const val USAGE_MAPPING_US = "usage_mapping_us"
+    const val FEATURE_QUERY_US = "feature_query_us"
+    const val FEATURE_MAPPING_US = "feature_mapping_us"
+    const val FEATURE_COUNT = "feature_count"
+}
+
+object PerformanceAttributeName {
+    const val OUTCOME = "outcome"
+    const val TRIGGER = "trigger"
+    const val APP_COUNT_BUCKET = "app_count_bucket"
+    const val ANALYSIS_MODE = "analysis_mode"
+    const val CACHE_HIT = "cache_hit"
+    const val INTENT_FILTERS = "intent_filters"
+    const val SIGNING_SCHEMES = "signing_schemes"
+    const val SPLIT_COUNT_BUCKET = "split_count_bucket"
+    const val PERMISSION = "permission"
+}

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTiming.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTiming.kt
@@ -1,0 +1,37 @@
+package sk.styk.martin.apkanalyzer.core.common.performance
+
+import android.os.SystemClock
+
+fun interface MonotonicClock {
+    fun nowNanos(): Long
+}
+
+data object ElapsedRealtimeMonotonicClock : MonotonicClock {
+    override fun nowNanos(): Long = SystemClock.elapsedRealtimeNanos()
+}
+
+inline fun <T> PerformanceTrace.measureStage(
+    metricName: String,
+    clock: MonotonicClock = ElapsedRealtimeMonotonicClock,
+    block: () -> T,
+): T {
+    val startedAtNanos = clock.nowNanos()
+    return try {
+        block()
+    } finally {
+        putMetric(metricName, (clock.nowNanos() - startedAtNanos) / 1_000L)
+    }
+}
+
+suspend inline fun <T> PerformanceTrace.measureSuspendStage(
+    metricName: String,
+    clock: MonotonicClock = ElapsedRealtimeMonotonicClock,
+    block: suspend () -> T,
+): T {
+    val startedAtNanos = clock.nowNanos()
+    return try {
+        block()
+    } finally {
+        putMetric(metricName, (clock.nowNanos() - startedAtNanos) / 1_000L)
+    }
+}

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTracker.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTracker.kt
@@ -1,0 +1,13 @@
+package sk.styk.martin.apkanalyzer.core.common.performance
+
+interface PerformanceTracker {
+    fun startTrace(name: String): PerformanceTrace
+}
+
+interface PerformanceTrace {
+    fun putMetric(name: String, value: Long)
+
+    fun putAttribute(name: String, value: String)
+
+    fun stop()
+}

--- a/core/navigation/AGENTS.md
+++ b/core/navigation/AGENTS.md
@@ -26,6 +26,12 @@ Imperative navigation controller wrapping `NavigationState`.
 - `goBack()` - Pop current sub-stack, go back to the previous top-level tab, or invoke the host's
   `onBackAtRoot` callback from the start destination.
 
+### `ScreenOpenEvent`
+`data class ScreenOpenEvent(val screen: String, val context: String? = null)`. Shared return type for
+per-feature `screenOpenEvent(key: NavKey): ScreenOpenEvent?` resolvers used to log centralized
+screen-opening breadcrumbs from the navigation hosts in `app`. Carries a stable screen name and
+optional diagnostic context, kept separate from `NavKey.toString()`.
+
 ## Usage Pattern
 ```kotlin
 val navigationState = rememberNavigationState(startKey = AppsNavKey, topLevelKeys = TOP_LEVEL_KEYS)

--- a/core/navigation/src/main/kotlin/sk/styk/martin/apkanalyzer/core/navigation/ScreenOpenEvent.kt
+++ b/core/navigation/src/main/kotlin/sk/styk/martin/apkanalyzer/core/navigation/ScreenOpenEvent.kt
@@ -1,0 +1,3 @@
+package sk.styk.martin.apkanalyzer.core.navigation
+
+data class ScreenOpenEvent(val screen: String, val context: String? = null)

--- a/docs/technical/repository-load-performance.md
+++ b/docs/technical/repository-load-performance.md
@@ -373,6 +373,14 @@ Add these traces after the three primary traces use the same infrastructure succ
 | `usage_stats_load` | `permission_check_us`, `usage_query_us`, `usage_mapping_us`, `loaded_count` | `outcome`, `permission`, `trigger` |
 | `device_features_load` | `feature_query_us`, `feature_mapping_us`, `feature_count` | `outcome` |
 
+The current enrichment entry points do not carry the installed-list trigger through their public
+repository APIs. Storage reports `trigger=installed_apps` for list-driven requests and
+`trigger=lifecycle_start` for foreground refreshes. Usage has no list-driven bulk refresh and reports
+`trigger=lifecycle_start`; its single-package query remains part of app-detail work. These values
+describe the trigger that each repository can observe without changing its API, cache, flow, or
+dispatcher behavior. Both enrichment traces report `permission=granted|denied` and use
+`outcome=degraded` when permission is missing or a permission/query race yields partial data.
+
 Do not emit one remote trace or non-fatal per installed app from bulk operations. One parent trace
 contains aggregate counts and total stage durations. Per-app failures are accumulated into a bounded
 failure count; one non-fatal may be recorded for the operation only when the failure is

--- a/docs/technical/repository-load-performance.md
+++ b/docs/technical/repository-load-performance.md
@@ -342,6 +342,16 @@ An optional sub-operation that fails while `AppDetail` remains usable produces `
 The trace must retain the stage duration and availability attribute so degraded requests can be
 filtered away from complete requests.
 
+OBS-04 uses the two availability facts persisted in `AppDetail` to classify complete versus degraded
+results: component intent filters and signing schemes. Storage size and last-used time remain nullable
+domain values that currently combine permission denial, query failure or race, and legitimate absence,
+so they cannot safely affect the parent outcome or be reconstructed on a cache hit. Likewise,
+`NativeLibraries.Empty` combines an APK with no native libraries and a handled ZIP-read failure, while
+certificate extraction exposes an empty result for both legitimate absence and handled failure.
+`ApkSigningBlockAnalyzer` returns `null` for both no detectable supported scheme and analyzer failure;
+therefore `signing_schemes=unavailable` is an availability statement, not a failure diagnosis. OBS-04
+does not speculate beyond these APIs or change their established result behavior.
+
 ### `manifest_load`
 
 This trace measures the complete readable-manifest request from `ManifestParser.manifest`.
@@ -412,6 +422,8 @@ Firebase currently permits 32 metrics including the default duration metric and 
 attributes on one custom trace. Every proposed trace remains below both limits.
 
 ## Rollout
+
+OBS-01 through OBS-04 are implemented. OBS-05 and later stages remain deferred.
 
 ### OBS-01: Make logging consistent
 

--- a/docs/technical/repository-load-performance.md
+++ b/docs/technical/repository-load-performance.md
@@ -1,6 +1,6 @@
 # App Loading Observability
 
-**Status:** Proposed
+**Status:** Implemented through OBS-05
 **Scope:** Production logging and performance measurement for navigation, app discovery, app
 analysis, and their supporting repository operations
 
@@ -372,6 +372,15 @@ This trace measures the complete readable-manifest request from `ManifestParser.
 If the current renderer cannot expose parsing separately from rendering without duplicating work,
 first refactor it into explicit parse and render stages while preserving output.
 
+OBS-05 refactors the internal renderer into one binary-parser pass that produces an in-memory event
+document, followed by a separate string-rendering pass over that document. `manifest_parse_us`
+therefore includes opening and walking the binary XML parser plus resolving attribute resource names;
+`xml_render_us` includes only namespaced text construction and escaping. The readable XML output and
+resource lookup sequence are unchanged, and no parser work is repeated. `split_count` and
+`split_count_bucket` are recorded after resource lookup succeeds. A failed installed-package lookup
+cannot reveal its real split count, so those fields are absent rather than reported as a fabricated
+zero.
+
 ## Supporting Trace Design
 
 Add these traces after the three primary traces use the same infrastructure successfully:
@@ -395,6 +404,54 @@ Do not emit one remote trace or non-fatal per installed app from bulk operations
 contains aggregate counts and total stage durations. Per-app failures are accumulated into a bounded
 failure count; one non-fatal may be recorded for the operation only when the failure is
 unexpected and materially degrades the result.
+
+OBS-05 uses `trigger=initial|package_change` for `app_signing_index_load`. `certificate_count` is the
+number of current plus historical certificates present in the returned index. The existing
+`CertificateExtractor` owns recoverable malformed-certificate non-fatals and drops those individual
+certificates without exposing a failure count. The aggregate repository therefore cannot truthfully
+reconstruct a degraded outcome: a completed index is `success`, a propagated failure is `error`, and
+cancellation is `cancelled`. No per-app Performance traces are emitted.
+
+`device_features_load` wraps only the first lazy platform load; later reads return the process cache
+without starting empty traces. A thrown or null platform feature query returns the established
+`DeviceFeatures.Unknown` fallback with `outcome=degraded` and `feature_count=0`. A mapping failure is
+`error`, cancellation is rethrown as `cancelled`, and successful mapping reports the named feature
+count. The OpenGL ES pseudo-feature remains represented separately and is not included in
+`feature_count`.
+
+## Public Core Load-Entry Inventory
+
+This inventory covers every public repository or manager surface under `core/*`. “Covered by parent”
+means the work is timed inside an owning trace rather than receiving another remote trace. “Excluded”
+means the entry is intentionally outside repository-load telemetry because it is a state accessor,
+bounded deterministic transformation, settings access, or transfer/write operation.
+
+| Module and public entry point | Classification | Rationale |
+|---|---|---|
+| `core:apps` `InstalledAppsRepository.apps()` | Instrumented | `installed_apps_load` measures each initial or package-change package query and basic mapping; storage and usage enrichment use their own traces. |
+| `core:apps` `AppDetailRepository.details(reference)` | Instrumented | `app_detail_load` owns cache lookup and every miss-stage metric for installed and APK-file analysis. |
+| `core:apps` `ManifestParser.manifest(reference)` | Instrumented | `manifest_load` owns resource lookup, one binary parse, XML rendering, mode, split count, and terminal outcome. This parser is included because it is a required public load boundary even though its type is not named Repository or Manager. |
+| `core:apps` `ManifestParser.componentIntentFilters(reference)` | Covered by parent | Public app-detail calls time this work as `intent_filters_us`; adding another trace would double-count the same manifest parsing. |
+| `core:apps` `AppSigningRepository.signing()` | Instrumented | `app_signing_index_load` measures one aggregate initial/package-change query and certificate mapping pass when the lazily shared flow loads. |
+| `core:apps` `DeviceFeaturesRepository.deviceFeatures()` | Instrumented | `device_features_load` measures the first lazy query and mapping; cache reads deliberately emit no trace. |
+| `core:apps` `StorageStatsRepository.requestTotalSizes(...)` | Instrumented | `storage_stats_load` owns list-driven and lifecycle refreshes with permission, query, and aggregate count metrics. |
+| `core:apps` `StorageStatsRepository.queryTotalSize(packageName)` | Covered by parent | Single-package work is timed as `storage_stats_us` by `app_detail_load`; a child remote trace would duplicate it. |
+| `core:apps` `StorageStatsRepository.isPermissionGranted`, `totalSizes` | Excluded: state accessors | Reading already-held `StateFlow` references performs no load; the operations that populate them are instrumented. |
+| `core:apps` `UsageStatsRepository.queryLastUsedTime(packageName)` | Covered by parent | Single-package work is timed as `usage_stats_us` by `app_detail_load`. |
+| `core:apps` `UsageStatsRepository.isPermissionGranted`, `lastUsedTimes` | Instrumented population; accessor excluded | `usage_stats_load` measures lifecycle population; obtaining the existing `StateFlow` references is not a load. |
+| `core:apps` `AppExportManager.exportApk(...)`, `exportIcon(...)` | Excluded: transfer/write operations | These SAF exports write user-selected documents and are not repository data availability. They need a separate export-observability design if required. |
+| `core:app-index` `AppIndexRepository.index()` | Excluded: deterministic derived load | The lazily shared CPU transform has no platform I/O; its installed-app and certificate sources are instrumented. The grouping itself is not claimed as covered by those upstream durations. |
+| `core:app-permissions` `DevicePermissionsRepository.permissions()` | Excluded: deterministic derived load | The lazily shared flow deduplicates and labels permissions after `InstalledAppsRepository` emits. It is outside the owning installed-list duration and does not justify another OBS-05 trace. |
+| `core:user-preferences` `RecentlyViewedAppsRepository.recents()`, `hasRecents()` | Excluded: small bounded settings reads | At most eight persisted package names are joined to the instrumented installed-app stream; the DataStore reads are low-volume preference access. |
+| `core:user-preferences` `RecentlyViewedAppsRepository.addRecent(...)` | Excluded: mutation | This bounded MRU update is a preference write, not a load operation. |
+| `core:user-preferences` `SearchHistoryRepository.queries()` | Excluded: small bounded settings read | The flow reads at most 15 persisted query strings and has no platform/package analysis. |
+| `core:user-preferences` `SearchHistoryRepository.addQuery(...)`, `removeQuery(...)`, `clearAll()` | Excluded: mutations | These are bounded preference updates, not load operations. |
+| `core:common` `PersistenceRepository.observe(...)`, `get(...)` | Excluded: small generic settings reads | One-key DataStore access is infrastructure for bounded preferences, not an app-loading operation; tracing each key would create noisy low-value volume. |
+| `core:common` `PersistenceRepository.save(...)` | Excluded: mutation | Saving a preference is not a load operation. |
+| `core:common` `DigestManager` digest and hex methods | Covered by parent when used by loads | Certificate digest work is included in `app_detail_load.certificate_us` and `app_signing_index_load.certificate_mapping_us`; the methods are deterministic CPU primitives and need no nested trace. |
+| `core:common` `ResourcesManager` getters and `luminance(...)` | Excluded: small/deterministic | These are direct resource/display lookups or pure color math, not repository loads. |
+| `core:common` `ClipboardManager.copy(...)` | Excluded: write operation | Clipboard mutation has no data-load result. |
+| `core:apk-files` `TemporaryApkManager.copy(...)`, `release(...)` | Excluded: transfer/cleanup operations | URI materialization and task-cache cleanup are file lifecycle operations, not repository analysis loads; they require separate import observability if needed. |
 
 ## Reading the Results
 
@@ -423,7 +480,7 @@ attributes on one custom trace. Every proposed trace remains below both limits.
 
 ## Rollout
 
-OBS-01 through OBS-04 are implemented. OBS-05 and later stages remain deferred.
+OBS-01 through OBS-05 are implemented. OBS-06 and OBS-07 remain deferred.
 
 ### OBS-01: Make logging consistent
 
@@ -464,6 +521,9 @@ OBS-01 through OBS-04 are implemented. OBS-05 and later stages remain deferred.
 - Add `manifest_load` for readable manifests.
 - Add the signing-index and device-feature traces.
 - Complete the public repository/manager load-entry inventory and document every exclusion.
+
+Implemented as the final currently authorized implementation layer. It does not establish production
+baselines, alerts, or UI/navigation timing.
 
 ### OBS-06: Establish baselines and alerts
 

--- a/docs/technical/repository-load-performance.md
+++ b/docs/technical/repository-load-performance.md
@@ -1,21 +1,160 @@
-# Repository Load Performance
+# App Loading Observability
 
 **Status:** Proposed
-**Scope:** Production measurement of installed-app list and app-detail repository load times
+**Scope:** Production logging and performance measurement for navigation, app discovery, app
+analysis, and their supporting repository operations
+
+## Requirements
+
+- Log when a loading operation and each meaningful stage starts, succeeds, degrades, is cancelled,
+  or fails.
+- Log every screen opening from the visible Navigation 3 destination.
+- Use log levels consistently so Crashlytics records unexpected recoverable and terminal failures as
+  non-fatals without turning expected states into errors.
+- Measure the complete time needed to load an app and attribute that time to non-overlapping stages,
+  including manifest parsing, certificate extraction, signing-scheme detection, packaging analysis,
+  component mapping, permissions, storage, and usage.
+- Keep Firebase Performance behind an app-owned interface. Domain `core` modules and feature modules
+  must not import Firebase Performance types.
+- Package names may appear in diagnostic logs. APK paths may appear when analyzing an APK file.
+  Logging sanitization is outside this rollout.
 
 ## Decision
 
-Use Firebase Performance custom code traces inside the repositories. Do not add performance
-tracking to Composables or ViewModels in the first iteration.
+Use two complementary signals:
 
-The initial metrics intentionally measure data-loading time, not perceived screen-loading time.
-Repository instrumentation is simpler, has stable boundaries, avoids UI lifecycle coupling, and
-isolates the work most likely to regress. UI-to-first-frame measurement can be added later if
-repository improvements stop correlating with user experience.
+1. `Logger` and Firebase Crashlytics provide chronological diagnostic breadcrumbs and non-fatal
+   reports for unexpected failures.
+2. Firebase Performance custom code traces provide aggregate parent durations and per-stage timing
+   metrics for successful, degraded, failed, and cancelled loads.
 
-Use one parent trace per repository request and record non-overlapping stage durations as custom
-metrics on that trace. This keeps the total duration and its breakdown associated with the same
-operation.
+Crashlytics logs are not a general remote log stream. A successful operation log is visible only
+when it is attached to a crash or recorded non-fatal event from that app session. Do not create a
+non-fatal exception merely to upload successful-operation logs. Firebase Performance is the
+production source for successful-load timing and volume trends.
+
+Performance instrumentation belongs at repository and parser/analyzer boundaries, not in
+Composables or ViewModels. These boundaries are stable, include cache behavior, and isolate the work
+most likely to regress. Screen-opening logs belong in the app navigation host, where the visible
+Navigation 3 destination can be observed centrally. The initial metrics measure data availability,
+not navigation-to-first-frame latency.
+
+Use one parent trace per public load request and record non-overlapping stage durations as metrics on
+that trace. Do not create one nested Firebase trace per stage. Parent traces keep total duration,
+attributes, and stage metrics associated with one operation and avoid an unmanageable trace list.
+
+## Logging Payload and Collection
+
+- Logs may contain the package name for an installed app and the APK path for APK-file analysis.
+- Do not add a sanitization abstraction or rewrite existing diagnostic context in this rollout.
+- Raw throwables may be reported when their failure qualifies as a non-fatal under the logging policy.
+- Do not use a user ID. A per-process request number may appear in local and Crashlytics breadcrumbs
+  to correlate overlapping operations, but it must not become a Performance attribute or custom key.
+- Performance trace names, metrics, and attributes remain low-cardinality. Package names, APK paths,
+  screen parameters, and other request identities must not become Performance attributes because
+  they fragment aggregate distributions.
+- Automatic collection is enabled in the current app for debug and release builds. The implementation
+  should disable Crashlytics and Performance collection in normal debug builds so local development
+  does not pollute production data. Provide an explicit local validation switch or dedicated build
+  configuration that enables both SDKs when verifying instrumentation.
+- Keep Firebase's normal SDK sampling behavior. Do not build a second custom sampling layer until
+  production volume demonstrates a need.
+
+## Logging Design
+
+### Message shape
+
+Use a consistent shape for loading logs:
+
+```text
+operation=<operation> request=<process-local-number> stage=<stage> event=<event> <context>
+```
+
+Allowed events are `started`, `succeeded`, `degraded`, `cancelled`, and `failed`. Context may include
+values such as `mode=installed`, `cache_hit=true`, `count=143`, `reason=permission_missing`,
+`package=<package-name>`, or `apk_path=<path>`.
+
+Every parent operation logs one start and exactly one terminal event. A stage logs a start and one
+terminal event when it performs meaningful I/O, parsing, cryptography, or bulk mapping. Do not log
+inside per-item loops; report a bounded count when the stage finishes.
+
+### Log levels
+
+| Level | Use | Crashlytics behavior |
+|---|---|---|
+| `DEBUG` | Operation/stage start, cache hit/miss, cancellation, expected absence, and successful internal stages | Breadcrumb only |
+| `INFO` | Successful completion of a public repository load or a process-level reload | Breadcrumb only |
+| `WARN` without `Throwable` | Unusual but expected or fully handled state, such as missing usage permission, an uninstall race, unsupported signing data, or unavailable optional metadata | Breadcrumb only |
+| `WARN` with `Throwable` | Unexpected recoverable failure where the operation returns a useful but degraded result | One non-fatal report with diagnostic context |
+| `ERROR` with `Throwable` | Unexpected failure that makes the parent operation fail | One non-fatal report with diagnostic context |
+
+Do not use `ERROR` without a `Throwable` for a failed operation because it cannot produce the required
+non-fatal report. Do not report coroutine cancellation as a warning, error, or non-fatal.
+
+### Non-fatal ownership
+
+Record one non-fatal for one failure. The layer that consumes an error owns the report:
+
+- If a parser or analyzer catches an exception and returns a degraded value, that component logs one
+  `WARN` with the throwable. The parent logs `degraded` without the throwable.
+- If an exception propagates and fails the public repository request, lower layers do not report it.
+  The repository boundary logs one `ERROR` with the throwable.
+- Expected platform outcomes represented by the domain API, including missing permission, missing
+  optional metadata, unsupported signing data, and package removal during a query, do not become
+  non-fatals.
+
+This prevents the same stack trace from appearing as several Crashlytics issues.
+
+### Required operation coverage
+
+The first implementation covers these operation families:
+
+| Operation | Meaningful stages |
+|---|---|
+| Installed apps | Package query, app mapping, storage enrichment, usage enrichment |
+| App detail | Cache lookup, package/archive query, component intent filters, storage, usage, general information, certificates, signing schemes, launcher lookup, component mapping, permissions, features, packaging |
+| Readable manifest | Package/resources lookup, binary manifest parsing, XML rendering |
+| Component intent filters | Package/resources lookup, base and split manifest parsing, resource resolution, grouping |
+| Device-wide signing | Package query, certificate extraction and assessment |
+| Storage stats | Permission check, package-stat queries, result mapping |
+| Usage stats | Permission check, usage query, result mapping |
+| Device features | Platform query and domain mapping |
+
+The rollout must also inventory every public repository or manager load entry point in `core/*`.
+Each entry point must be explicitly classified as instrumented, covered by a parent operation, or too
+small/deterministic to justify a remote Performance trace. Logging still applies when a separate
+Performance trace is not justified.
+
+### Screen opening
+
+Observe the visible destination once in each app navigation host:
+
+```kotlin
+LaunchedEffect(navigationState) {
+    snapshotFlow { navigationState.currentKey }
+        .distinctUntilChanged()
+        .collect { key -> logScreenOpened(key) }
+}
+```
+
+`snapshotFlow` emits the initially visible destination and every actual `currentKey` change caused by
+a push, back navigation, top-level tab switch, same-tab reset, or restored navigation state.
+`distinctUntilChanged` prevents recomposition from duplicating screen-open logs.
+
+Map each `NavKey` type to a stable screen name such as `apps`, `app_detail`, `manifest`, or
+`certificates`. Do not use `NavKey.toString()` as the screen name because parameterized keys would
+create a different screen identity for each package, APK path, permission, or component. The log may
+include those parameters as diagnostic context separately.
+
+Emit one `INFO` breadcrumb in this shape:
+
+```text
+operation=navigation event=screen_opened screen=<stable-name> <optional diagnostic context>
+```
+
+Keep the mapping close to the destination declarations so adding a new `NavKey` requires adding its
+screen name. Cover both the main `ApkAnalyzerApp` host and the external-APK navigation host. This
+phase adds screen-opening logs only; navigation-to-first-content timing remains separate.
 
 ## Current Loading Pipelines
 
@@ -25,131 +164,54 @@ operation.
 InstalledAppsRepositoryImpl
   PackageManager.getInstalledPackages(GET_PERMISSIONS)
   map PackageInfo to InstalledApp
+    resolve install source and category
+    read basic APK size and package metadata
   emit basic list
   request storage-size enrichment
   combine storage and usage data into later emissions
 ```
 
-`InstalledAppsRepositoryImpl` is eagerly shared for the lifetime of the process. Its trace therefore
-measures process-level data availability, not the time from entering `AppsScreen` until drawing its
-first content frame.
+`InstalledAppsRepositoryImpl` is eagerly shared for the lifetime of the process. Its primary trace
+measures process-level basic-list availability, not the time from entering `AppsScreen` until drawing
+the first content frame.
 
-The first iteration should measure production of the basic app list. Storage and usage enrichment
-arrive independently and should not extend the primary trace. Otherwise device permissions and the
-number of installed apps would make "list loaded" mean different things for different users.
+Storage and usage enrichment arrive independently and must not extend `installed_apps_load`.
+They receive their own traces because permissions, platform services, and the number of installed
+apps give them different performance characteristics.
 
 ### App detail
 
 ```text
 AppDetailRepositoryImpl.details(reference)
-  cache lookup for installed packages
+  cache lookup for installed packages and APK files
   PackageManager package/archive query
+  parse base and split manifests for component intent filters
   optional storage-size query
   optional usage query
   general information mapping
-  certificate extraction
-  launcher activity query
-  component mapping
+  certificate extraction and assessment
+  APK signing-scheme detection
+    verify v1 JAR signature
+    parse v2/v3/v3.1 APK Signing Block IDs
+  launcher activity query for installed packages
+  activity, service, provider, and receiver mapping
   permission mapping and resolution
   feature mapping
-  cache result for installed packages
+  APK size and installed-split analysis
+  native-library ZIP analysis
+  cache result
 ```
 
 Installed-package details are cached by package name until a package-change event clears the cache.
-APK-file details are not cached.
+APK-file details are cached by absolute path and last-modified time.
 
-The main app-detail load does not explicitly parse `AndroidManifest.xml`. Readable manifest parsing
-belongs to the separate Manifest screen and must not be reported as part of app-detail load time.
-`PackageManager` internally reads package metadata, but that work belongs to the package-query stage.
+Component intent-filter parsing is part of app-detail loading and must be included in
+`app_detail_load`. Rendering the complete readable manifest belongs to the separate Manifest screen
+and uses `manifest_load`.
 
-## Firebase Trace Design
+## Performance Integration
 
-### `installed_apps_load`
-
-Start immediately before querying `PackageManager`. Stop after the basic `InstalledApp` list has
-been produced.
-
-| Custom metric | Meaning |
-|---|---|
-| `package_query_ms` | `PackageManager.getInstalledPackages` duration |
-| `app_mapping_ms` | Mapping all returned `PackageInfo` values to `InstalledApp` |
-| `app_count` | Number of successfully mapped apps |
-
-Attributes:
-
-| Attribute | Values |
-|---|---|
-| `outcome` | `success`, `error`, `cancelled` |
-| `app_count_bucket` | `0_49`, `50_99`, `100_199`, `200_399`, `400_plus` |
-
-`app_count` is useful as a numeric metric for correlation. The bucket is useful for filtering in
-the Firebase console without creating one attribute value per exact count.
-
-### `app_detail_load`
-
-Start at entry to `AppDetailRepository.details`, before the installed-package cache lookup. Stop
-when the repository has produced either a complete `AppDetail` or an error.
-
-| Custom metric | Meaning |
-|---|---|
-| `package_query_ms` | Installed-package or APK-archive `PackageManager` lookup |
-| `detail_mapping_ms` | General information, components, permissions, and features |
-| `certificate_ms` | Signing certificate extraction and assessment |
-
-Attributes:
-
-| Attribute | Values |
-|---|---|
-| `outcome` | `success`, `error`, `cancelled` |
-| `analysis_mode` | `installed`, `apk_file` |
-| `cache_hit` | `true`, `false`, `not_applicable` |
-
-The first iteration deliberately keeps the breakdown broad. A cache hit should have a very short
-parent duration and no miss-only stage metrics. Storage and usage lookups remain part of total
-duration without their own metrics initially. After collecting a production baseline, split
-`detail_mapping_ms` or add storage and usage metrics only when the data shows that more detail would
-help diagnose a regression.
-
-Do not attach package names, app names, APK paths, permission names, certificate data, or other
-high-cardinality or user-identifying values.
-
-## Reading the Results
-
-Firebase Performance automatically records the parent trace duration. Custom metrics appear
-alongside that duration and can be inspected as aggregate distributions.
-
-The Firebase console does not provide an automatic nested waterfall or stacked breakdown. It can
-answer questions such as:
-
-- What are p50, p90, and p95 for `app_detail_load`?
-- How does `package_query_ms` differ between installed-package and APK-file analysis?
-- Are cache misses slower in the latest app version?
-- Does installed-app load degrade as the app-count bucket increases?
-
-It does not directly calculate:
-
-- what percentage of each request was spent in every stage;
-- whether stage durations add exactly to the parent duration;
-- a stacked chart of the stage breakdown;
-- arbitrary formulas across custom metrics.
-
-Stage metrics should be non-overlapping so their sum approximately explains the parent duration.
-Small unmeasured gaps are expected from trace bookkeeping, cache operations, coroutine dispatch,
-and control flow.
-
-Export Firebase Performance data to BigQuery if per-sample percentages, stacked visualizations, or
-more advanced correlations become necessary. Separate nested custom traces are not required for the
-first iteration and would make it harder to analyze one operation as a single record.
-
-Firebase currently permits up to 32 metrics, including the default duration metric, and up to five
-custom attributes on one custom trace. The proposed traces remain below both limits.
-
-## Integration Design
-
-Feature and core modules must not depend directly on Firebase APIs. Add a small tracing abstraction
-to `core:common` and provide its Firebase implementation from `app`.
-
-Conceptual API:
+Declare the Firebase-free contract in `core:common`:
 
 ```kotlin
 interface PerformanceTracker {
@@ -163,66 +225,226 @@ interface PerformanceTrace {
 }
 ```
 
-The production implementation wraps Firebase Performance `Trace`. Repository code measures stages
-with a monotonic clock and records whole milliseconds. Trace completion must be protected with
-`try`/`finally` so success, failure, and coroutine cancellation all stop the trace exactly once.
+Provide the Firebase implementation and Hilt binding from `app`. Only that adapter imports
+`FirebasePerformance` or `Trace`. Domain modules inject `PerformanceTracker` and know only the
+contract.
 
-Do not store active traces globally by name. Repository calls can overlap, so every
-`startTrace` invocation must return an independent handle.
+Requirements for the adapter and shared helpers:
+
+- Every `startTrace` call returns an independent handle because repository calls can overlap.
+- `stop()` is idempotent and thread safe.
+- Fixed trace, metric, and attribute names are declared centrally and satisfy Firebase naming limits.
+- Measure stages with a monotonic clock at nanosecond resolution and record whole microseconds in
+  metrics suffixed with `_us`. Do not use wall-clock time.
+- A shared inline/suspend measurement helper records a stage duration even when the measured block
+  throws, then rethrows the original exception or cancellation.
+- Parent completion uses `try`/`finally`, records its outcome before stopping, and stops exactly once.
+- Instrumentation must not change repository results, exception behavior, cache semantics, dispatcher
+  selection, or cancellation propagation.
+- Telemetry API failures must be surfaced through the existing safe logging policy but must not turn a
+  successful domain operation into a failure.
+
+No Firebase Performance type may appear outside `app`.
+
+## Primary Trace Design
+
+### `installed_apps_load`
+
+Start immediately before querying `PackageManager`. Stop after the basic `InstalledApp` list has
+been produced.
+
+| Custom metric | Meaning |
+|---|---|
+| `package_query_us` | `PackageManager.getInstalledPackages` duration |
+| `app_mapping_us` | Mapping all returned `PackageInfo` values to `InstalledApp` |
+| `app_count` | Number of successfully mapped apps |
+
+| Attribute | Values |
+|---|---|
+| `outcome` | `success`, `error`, `cancelled` |
+| `trigger` | `initial`, `package_change` |
+| `app_count_bucket` | `0_49`, `50_99`, `100_199`, `200_399`, `400_plus` |
+
+### `app_detail_load`
+
+Start at entry to `AppDetailRepository.details`, before either cache lookup. Stop when the repository
+returns a complete or degraded `AppDetail`, an error, or cancellation.
+
+| Custom metric | Meaning |
+|---|---|
+| `cache_lookup_us` | Installed-package or APK-file cache lookup |
+| `package_query_us` | Installed-package or APK-archive `PackageManager` lookup |
+| `intent_filters_us` | Base and split manifest parsing for component intent filters |
+| `storage_stats_us` | Installed-package storage-size lookup |
+| `usage_stats_us` | Installed-package last-used lookup |
+| `general_info_us` | General metadata and install-source mapping |
+| `certificate_us` | Certificate parsing, digests, trust assessment, and self-signature checks |
+| `signing_schemes_us` | v1 verification and APK Signing Block scheme detection |
+| `launcher_query_us` | Installed-package launcher activity queries |
+| `components_us` | Activity, service, provider, and receiver mapping |
+| `permissions_us` | Used and defined permission mapping and resolution |
+| `features_us` | Required-feature mapping |
+| `packaging_us` | APK size, installed splits, and native-library ZIP analysis |
+
+| Attribute | Values |
+|---|---|
+| `outcome` | `success`, `degraded`, `error`, `cancelled` |
+| `analysis_mode` | `installed`, `apk_file` |
+| `cache_hit` | `true`, `false` |
+| `intent_filters` | `available`, `unavailable` |
+| `signing_schemes` | `available`, `unavailable` |
+
+A cache hit records only `cache_lookup_us` and the attributes available on the cached result. Miss-only
+metrics are absent rather than zero. Installed-only metrics are absent for APK files.
+
+Refactor `getPackageDetails` into named, sequential, behavior-preserving stage calculations before
+constructing `AppDetail`. This is required to prevent overlapping timers and to separate certificate,
+signing-scheme, component, and packaging costs precisely.
+
+An optional sub-operation that fails while `AppDetail` remains usable produces `outcome=degraded`.
+The trace must retain the stage duration and availability attribute so degraded requests can be
+filtered away from complete requests.
+
+### `manifest_load`
+
+This trace measures the complete readable-manifest request from `ManifestParser.manifest`.
+
+| Custom metric | Meaning |
+|---|---|
+| `resource_lookup_us` | Resolve package/archive information and resources |
+| `manifest_parse_us` | Read and parse binary manifest data |
+| `xml_render_us` | Render readable namespaced XML |
+| `split_count` | Additional installed split count |
+
+| Attribute | Values |
+|---|---|
+| `outcome` | `success`, `error`, `cancelled` |
+| `analysis_mode` | `installed`, `apk_file` |
+| `split_count_bucket` | `0`, `1_4`, `5_9`, `10_plus` |
+
+If the current renderer cannot expose parsing separately from rendering without duplicating work,
+first refactor it into explicit parse and render stages while preserving output.
+
+## Supporting Trace Design
+
+Add these traces after the three primary traces use the same infrastructure successfully:
+
+| Trace | Metrics | Key attributes |
+|---|---|---|
+| `app_signing_index_load` | `package_query_us`, `certificate_mapping_us`, `app_count`, `certificate_count` | `outcome`, `trigger`, `app_count_bucket` |
+| `storage_stats_load` | `permission_check_us`, `stats_query_us`, `requested_count`, `loaded_count` | `outcome`, `permission`, `trigger` |
+| `usage_stats_load` | `permission_check_us`, `usage_query_us`, `usage_mapping_us`, `loaded_count` | `outcome`, `permission`, `trigger` |
+| `device_features_load` | `feature_query_us`, `feature_mapping_us`, `feature_count` | `outcome` |
+
+Do not emit one remote trace or non-fatal per installed app from bulk operations. One parent trace
+contains aggregate counts and total stage durations. Per-app failures are accumulated into a bounded
+failure count; one non-fatal may be recorded for the operation only when the failure is
+unexpected and materially degrades the result.
+
+## Reading the Results
+
+Firebase Performance automatically records the parent duration. Custom metrics appear alongside it
+as aggregate distributions.
+
+The console can answer:
+
+- What are p50, p90, and p95 for complete and degraded `app_detail_load` requests?
+- How much time do manifest intent filters, certificates, and signing-scheme detection contribute?
+- How do installed-package and APK-file analysis differ?
+- Are cache misses slower in the latest version?
+- Does installed-app loading degrade as the app-count bucket increases?
+- Are storage or usage enrichments slow only when permission is available?
+
+The Firebase console does not directly provide a nested waterfall, stacked stage chart, or arbitrary
+formulas across custom metrics. Stage metrics must be non-overlapping so their sum approximately
+explains the parent duration. Small gaps are expected from trace bookkeeping, cache operations,
+coroutine dispatch, object construction, and control flow.
+
+Export Performance data to BigQuery only if per-sample percentages, stacked visualizations, or more
+advanced correlations become necessary.
+
+Firebase currently permits 32 metrics including the default duration metric and five custom
+attributes on one custom trace. Every proposed trace remains below both limits.
 
 ## Rollout
 
-### PT-01: Add tracing infrastructure
+### OBS-01: Make logging consistent
 
-- Add `PerformanceTracker` and `PerformanceTrace` to `core:common`.
-- Add the Firebase-backed implementation and Hilt binding in `app`.
-- Ensure trace handles are independent and stop safely.
-- Confirm collection in a Firebase-enabled debug build before instrumenting repositories.
+- Add the operation/stage/event message convention.
+- Apply the log-level and single-owner non-fatal rules to current load paths.
+- Add missing start, success, degraded, cancellation, and failure logs to the required operation
+  coverage.
+- Add stable screen-name mappings and observe distinct `currentKey` changes in both navigation hosts.
+- Preserve package names and APK paths where they provide useful diagnostic context.
 
-### PT-02: Instrument installed-app loading
+### OBS-02: Add Performance infrastructure
 
-- Split package querying from model mapping without changing behavior.
-- Add the `installed_apps_load` trace and metrics.
-- Keep storage and usage enrichment outside this trace.
-- Confirm one trace is emitted for initial process loading and each package-change reload.
+- Add Firebase-free `PerformanceTracker` and `PerformanceTrace` contracts and monotonic timing helpers
+  to `core:common`.
+- Add the Firebase-backed adapter and Hilt binding in `app`.
+- Add build-aware collection control so regular debug builds do not report production telemetry.
+- Confirm independent handles, precise microsecond metrics, idempotent stop, and cancellation safety.
+- Verify Crashlytics with one intentional test crash and one intentional non-fatal in the
+  explicit monitoring-validation build.
+- Verify Performance using Firebase Performance logcat output before instrumenting repositories.
 
-### PT-03: Instrument app-detail loading
+### OBS-03: Instrument installed-app loading
 
-- Add `app_detail_load` around repository requests.
-- Report cache state, analysis mode, and outcome.
-- Measure package querying, detail mapping, and certificate extraction.
-- Preserve cache behavior and cancellation propagation.
+- Add `installed_apps_load`.
+- Split package querying from model mapping without changing emitted data.
+- Add separate storage and usage enrichment traces.
+- Emit one primary trace for initial loading and each package-change reload.
 
-### PT-04: Establish baselines
+### OBS-04: Instrument app-detail loading
 
-- Collect at least one representative release of production data.
-- Track p50, p90, and p95 parent duration and stage metrics.
+- Add `app_detail_load` around installed-package and APK-file requests.
+- Refactor miss processing into the named non-overlapping stages.
+- Report cache state, analysis mode, optional-stage availability, and outcome.
+- Preserve both cache strategies and cancellation propagation.
+
+### OBS-05: Instrument manifest and supporting loads
+
+- Add `manifest_load` for readable manifests.
+- Add the signing-index and device-feature traces.
+- Complete the public repository/manager load-entry inventory and document every exclusion.
+
+### OBS-06: Establish baselines and alerts
+
+- Collect at least one representative production release.
+- Track p50, p90, and p95 parent and stage metrics.
 - Segment app-list results by app-count bucket.
-- Segment app-detail results by analysis mode and cache hit.
-- Set regression thresholds only after observing real distributions; do not invent absolute service
-  levels before a baseline exists.
+- Segment app-detail results by analysis mode, cache hit, completeness, and signing availability.
+- Review Crashlytics non-fatals for duplicate ownership and noisy expected states.
+- Set regression thresholds and alerts only after observing real distributions.
 
-### PT-05: Reassess UI measurement
+### OBS-07: Reassess perceived loading
 
-Add screen-level first-content traces only if repository duration does not adequately explain user
-reports or frame-level regressions. That later work should measure navigation-to-first-content frame
-and remain separate from repository traces.
+Add navigation-to-first-content measurement only if repository duration does not explain user reports
+or frame-level regressions. Keep that trace separate from repository traces.
 
 ## Exit Criteria
 
-- Firebase reports `installed_apps_load` and `app_detail_load` duration distributions.
-- Every trace records an outcome and the applicable low-cardinality attributes.
-- Stage metrics provide an approximate, non-overlapping explanation of parent duration.
-- Cache hits and misses can be compared independently.
-- No Firebase type crosses the `app` module boundary.
-- No package, app, or file identity is included in performance telemetry.
+- Every in-scope load operation has start and terminal logs with stable operation and stage names.
+- Every distinct visible destination change emits one screen-opening log in the applicable navigation
+  host.
+- Expected states and cancellation do not create Crashlytics non-fatals.
+- Every unexpected failure produces at most one non-fatal.
+- Firebase reports duration distributions for all primary and supporting traces.
+- `app_detail_load` separately reports manifest intent filters, certificates, signing schemes,
+  components, permissions, features, and packaging.
+- Cache hits and misses, installed packages and APK files, and complete and degraded results can be
+  compared independently.
+- Stage metrics are non-overlapping and approximately explain parent duration.
+- No Firebase Performance type leaves `app`.
+- Performance attributes contain no package names, APK paths, screen parameters, or other
+  high-cardinality request identities.
+- Regular debug builds do not pollute production monitoring.
 
 ## Deferred
 
 - Compose or ViewModel instrumentation.
-- Navigation-to-first-frame timing.
-- Storage and usage enrichment traces.
-- Fine-grained app-detail mapping stages.
-- Manifest-screen parsing traces.
+- Navigation-to-first-content-frame timing.
+- Logging sanitization and diagnostic-data redaction.
 - Macrobenchmark and Baseline Profile modules.
 - BigQuery dashboards before the Firebase console proves insufficient.
+- Additional custom sampling before production volume demonstrates a need.

--- a/docs/technical/repository-load-performance.md
+++ b/docs/technical/repository-load-performance.md
@@ -246,6 +246,43 @@ Requirements for the adapter and shared helpers:
 
 No Firebase Performance type may appear outside `app`.
 
+### Local monitoring validation
+
+The `monitoringValidation` build type derives from `debug`, enables Crashlytics and Performance
+collection, and includes an adb-only broadcast receiver. Normal `debug` builds disable both SDKs,
+`release` builds enable both, and neither includes the receiver.
+
+Install the validation build and enable Firebase Performance logcat output:
+
+```text
+.\gradlew.bat :app:installMonitoringValidation
+adb logcat -c
+```
+
+Emit a custom validation trace, then inspect `adb logcat -s FirebasePerformance` for
+`monitoring_validation`:
+
+```text
+adb shell am broadcast --include-stopped-packages -n sk.styk.martin.apkanalyzer/sk.styk.martin.apkanalyzer.monitoring.MonitoringValidationReceiver --es signal performance
+adb logcat -s FirebasePerformance
+```
+
+Record exactly one intentional non-fatal and confirm it in Crashlytics:
+
+```text
+adb shell am broadcast --include-stopped-packages -n sk.styk.martin.apkanalyzer/sk.styk.martin.apkanalyzer.monitoring.MonitoringValidationReceiver --es signal non_fatal
+```
+
+Run the intentional crash separately and last, then relaunch the app so Crashlytics can upload the
+pending report:
+
+```text
+adb shell am broadcast --include-stopped-packages -n sk.styk.martin.apkanalyzer/sk.styk.martin.apkanalyzer.monitoring.MonitoringValidationReceiver --es signal crash
+adb shell monkey -p sk.styk.martin.apkanalyzer 1
+```
+
+The receiver has no launcher entry or UI and is compiled only into `monitoringValidation`.
+
 ## Primary Trace Design
 
 ### `installed_apps_load`

--- a/feature/app-detail/AGENTS.md
+++ b/feature/app-detail/AGENTS.md
@@ -30,6 +30,8 @@ sealed interface AppDetailInput {
 ```
 navigation/
   AppDetailEntryProvider.kt  - appDetailEntries(navigator)
+  ScreenNames.kt             - public screenOpenEvent(key: NavKey): ScreenOpenEvent? resolver consumed
+                               by app's centralized screen-opening breadcrumb logging
   GeneralInfoNavKey.kt       - Internal nav key for general info sub-screen
   PermissionsNavKey.kt       - Internal nav key for the permissions sub-screen
   ComponentsNavKey.kt        - Internal nav key for the components sub-screen

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailViewModel.kt
@@ -253,8 +253,6 @@ internal class AppDetailViewModel @AssistedInject constructor(
             val deviceFeatures = deviceFeaturesRepository.deviceFeatures()
             val detailResult = withContext(dispatcherProvider.default()) {
                 appDetailRepository.details(appReference)
-            }.onFailure {
-                Logger.e(TAG, it, "Can not load app detail for $appDetailInput")
             }
             source.value = detailResult.fold(
                 onSuccess = { detail ->

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/ComponentsViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/ComponentsViewModel.kt
@@ -30,12 +30,9 @@ import sk.styk.martin.apkanalyzer.core.apps.model.AppDetail
 import sk.styk.martin.apkanalyzer.core.common.clipboard.ClipboardManager
 import sk.styk.martin.apkanalyzer.core.common.clipboard.CopyResult
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
-import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.feature.appdetail.api.AppDetailInput
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.toAppReference
-
-private const val TAG = "ComponentsViewModel"
 
 @HiltViewModel(assistedFactory = ComponentsViewModel.Factory::class)
 internal class ComponentsViewModel @AssistedInject constructor(
@@ -109,9 +106,7 @@ internal class ComponentsViewModel @AssistedInject constructor(
         source.value = ComponentsSource.Loading
         viewModelScope.launch {
             source.value = withContext(dispatcherProvider.default()) {
-                appDetailRepository.details(appDetailInput.toAppReference()).onFailure {
-                    Logger.e(TAG, it, "Can not load components for $appDetailInput")
-                }.fold(
+                appDetailRepository.details(appDetailInput.toAppReference()).fold(
                     onSuccess = { it.toSource(canLaunch = appDetailInput is AppDetailInput.InstalledPackage) },
                     onFailure = { ComponentsSource.Error },
                 )

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/IntentFiltersViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/IntentFiltersViewModel.kt
@@ -26,12 +26,9 @@ import sk.styk.martin.apkanalyzer.core.apps.model.AppDetail
 import sk.styk.martin.apkanalyzer.core.common.clipboard.ClipboardManager
 import sk.styk.martin.apkanalyzer.core.common.clipboard.CopyResult
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
-import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.feature.appdetail.api.AppDetailInput
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.R
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.toAppReference
-
-private const val TAG = "IntentFiltersViewModel"
 
 @HiltViewModel(assistedFactory = IntentFiltersViewModel.Factory::class)
 internal class IntentFiltersViewModel @AssistedInject constructor(
@@ -96,9 +93,7 @@ internal class IntentFiltersViewModel @AssistedInject constructor(
         source.value = IntentFiltersSource.Loading
         viewModelScope.launch {
             source.value = withContext(dispatcherProvider.default()) {
-                appDetailRepository.details(appDetailInput.toAppReference()).onFailure {
-                    Logger.e(TAG, it, "Can not load intent filters for $componentName")
-                }.fold(
+                appDetailRepository.details(appDetailInput.toAppReference()).fold(
                     onSuccess = { detail ->
                         if (!detail.areComponentIntentFiltersAvailable) {
                             IntentFiltersSource.Unavailable

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/certificates/CertificatesViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/certificates/CertificatesViewModel.kt
@@ -19,13 +19,10 @@ import sk.styk.martin.apkanalyzer.core.apps.signing.Certificate
 import sk.styk.martin.apkanalyzer.core.common.clipboard.ClipboardManager
 import sk.styk.martin.apkanalyzer.core.common.clipboard.CopyResult
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
-import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.feature.appdetail.api.AppDetailInput
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.toAppReference
 import java.time.Instant
 import java.util.Locale
-
-private const val TAG = "CertificatesViewModel"
 
 @HiltViewModel(assistedFactory = CertificatesViewModel.Factory::class)
 internal class CertificatesViewModel @AssistedInject constructor(
@@ -66,9 +63,7 @@ internal class CertificatesViewModel @AssistedInject constructor(
         state.value = CertificatesState.Loading
         viewModelScope.launch {
             state.value = withContext(dispatcherProvider.default()) {
-                appDetailRepository.details(appDetailInput.toAppReference()).onFailure {
-                    Logger.e(TAG, it, "Can not load certificates for $appDetailInput")
-                }.fold(
+                appDetailRepository.details(appDetailInput.toAppReference()).fold(
                     onSuccess = { it.toCertificatesState() },
                     onFailure = { CertificatesState.Error },
                 )

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoViewModel.kt
@@ -19,11 +19,8 @@ import sk.styk.martin.apkanalyzer.core.apps.model.AppDetail
 import sk.styk.martin.apkanalyzer.core.common.clipboard.ClipboardManager
 import sk.styk.martin.apkanalyzer.core.common.clipboard.CopyResult
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
-import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.feature.appdetail.api.AppDetailInput
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.toAppReference
-
-private const val TAG = "GeneralInfoViewModel"
 
 @HiltViewModel(assistedFactory = GeneralInfoViewModel.Factory::class)
 internal class GeneralInfoViewModel @AssistedInject constructor(
@@ -63,8 +60,6 @@ internal class GeneralInfoViewModel @AssistedInject constructor(
         viewModelScope.launch {
             state.value = withContext(dispatcherProvider.default()) {
                 appDetailRepository.details(appDetailInput.toAppReference())
-            }.onFailure {
-                Logger.e(TAG, it, "Can not load general info for $appDetailInput")
             }.fold(
                 onSuccess = { it.toGeneralInfoState() },
                 onFailure = { GeneralInfoState.Error },

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/manifest/ManifestViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/manifest/ManifestViewModel.kt
@@ -19,11 +19,8 @@ import kotlinx.coroutines.withContext
 import sk.styk.martin.apkanalyzer.core.apps.manifest.ManifestParser
 import sk.styk.martin.apkanalyzer.core.apps.manifest.ParsedManifest
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
-import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.feature.appdetail.api.AppDetailInput
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.toAppReference
-
-private const val TAG = "ManifestViewModel"
 
 @HiltViewModel(assistedFactory = ManifestViewModel.Factory::class)
 internal class ManifestViewModel @AssistedInject constructor(
@@ -67,9 +64,7 @@ internal class ManifestViewModel @AssistedInject constructor(
         viewModelScope.launch {
             val result = manifestParser.manifest(appDetailInput.toAppReference())
             source.value = withContext(dispatcherProvider.default()) {
-                result.onFailure {
-                    Logger.e(TAG, it, "Can not load manifest for $appDetailInput")
-                }.fold(
+                result.fold(
                     onSuccess = { it.toSource() },
                     onFailure = { ManifestSource.Error },
                 )

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/nativelibraries/NativeLibrariesViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/nativelibraries/NativeLibrariesViewModel.kt
@@ -24,12 +24,9 @@ import sk.styk.martin.apkanalyzer.core.apps.packaging.NativeLibraryFile
 import sk.styk.martin.apkanalyzer.core.common.clipboard.ClipboardManager
 import sk.styk.martin.apkanalyzer.core.common.clipboard.CopyResult
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
-import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.model.bytes
 import sk.styk.martin.apkanalyzer.feature.appdetail.api.AppDetailInput
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.toAppReference
-
-private const val TAG = "NativeLibrariesViewModel"
 
 @HiltViewModel(assistedFactory = NativeLibrariesViewModel.Factory::class)
 internal class NativeLibrariesViewModel @AssistedInject constructor(
@@ -86,9 +83,7 @@ internal class NativeLibrariesViewModel @AssistedInject constructor(
         source.value = NativeLibrariesSource.Loading
         viewModelScope.launch {
             source.value = withContext(dispatcherProvider.default()) {
-                appDetailRepository.details(appDetailInput.toAppReference()).onFailure {
-                    Logger.e(TAG, it, "Can not load native libraries for $appDetailInput")
-                }.fold(
+                appDetailRepository.details(appDetailInput.toAppReference()).fold(
                     onSuccess = { detail ->
                         val items = detail.nativeLibraries.files.toItems(Build.SUPPORTED_ABIS.toSet())
                         NativeLibrariesSource.Ready(items.toImmutableList())

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/navigation/ScreenNames.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/navigation/ScreenNames.kt
@@ -1,0 +1,36 @@
+package sk.styk.martin.apkanalyzer.feature.appdetail.impl.navigation
+
+import androidx.navigation3.runtime.NavKey
+import sk.styk.martin.apkanalyzer.core.navigation.ScreenOpenEvent
+import sk.styk.martin.apkanalyzer.feature.appdetail.api.AppDetailInput
+import sk.styk.martin.apkanalyzer.feature.appdetail.api.AppDetailNavKey
+
+private const val SCREEN_APP_DETAIL = "app_detail"
+private const val SCREEN_GENERAL_INFO = "general_info"
+private const val SCREEN_CERTIFICATES = "certificates"
+private const val SCREEN_COMPONENTS = "components"
+private const val SCREEN_INTENT_FILTERS = "intent_filters"
+private const val SCREEN_MANIFEST = "manifest"
+private const val SCREEN_NATIVE_LIBRARIES = "native_libraries"
+private const val SCREEN_PERMISSIONS = "permissions"
+private const val SCREEN_REQUIREMENTS = "requirements"
+private const val SCREEN_SPLIT_APKS = "split_apks"
+
+fun screenOpenEvent(key: NavKey): ScreenOpenEvent? = when (key) {
+    is AppDetailNavKey -> ScreenOpenEvent(SCREEN_APP_DETAIL, key.detailInput.diagnosticContext())
+    is GeneralInfoNavKey -> ScreenOpenEvent(SCREEN_GENERAL_INFO, key.detailInput.diagnosticContext())
+    is CertificatesNavKey -> ScreenOpenEvent(SCREEN_CERTIFICATES, key.detailInput.diagnosticContext())
+    is ComponentsNavKey -> ScreenOpenEvent(SCREEN_COMPONENTS, key.detailInput.diagnosticContext())
+    is IntentFiltersNavKey -> ScreenOpenEvent(SCREEN_INTENT_FILTERS, key.detailInput.diagnosticContext())
+    is ManifestNavKey -> ScreenOpenEvent(SCREEN_MANIFEST, key.detailInput.diagnosticContext())
+    is NativeLibrariesNavKey -> ScreenOpenEvent(SCREEN_NATIVE_LIBRARIES, key.detailInput.diagnosticContext())
+    is PermissionsNavKey -> ScreenOpenEvent(SCREEN_PERMISSIONS, key.detailInput.diagnosticContext())
+    is RequirementsNavKey -> ScreenOpenEvent(SCREEN_REQUIREMENTS, key.detailInput.diagnosticContext())
+    is SplitApksNavKey -> ScreenOpenEvent(SCREEN_SPLIT_APKS, key.detailInput.diagnosticContext())
+    else -> null
+}
+
+private fun AppDetailInput.diagnosticContext(): String = when (this) {
+    is AppDetailInput.InstalledPackage -> "mode=installed package=$packageName"
+    is AppDetailInput.ApkFile -> "mode=apk_file apk_path=$apkFilePath"
+}

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/permissions/PermissionsViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/permissions/PermissionsViewModel.kt
@@ -28,12 +28,9 @@ import sk.styk.martin.apkanalyzer.core.apps.permissions.ProtectionLevel
 import sk.styk.martin.apkanalyzer.core.common.clipboard.ClipboardManager
 import sk.styk.martin.apkanalyzer.core.common.clipboard.CopyResult
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
-import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.feature.appdetail.api.AppDetailInput
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.toAppReference
-
-private const val TAG = "PermissionsViewModel"
 
 @HiltViewModel(assistedFactory = PermissionsViewModel.Factory::class)
 internal class PermissionsViewModel @AssistedInject constructor(
@@ -102,9 +99,7 @@ internal class PermissionsViewModel @AssistedInject constructor(
         source.value = PermissionsSource.Loading
         viewModelScope.launch {
             source.value = withContext(dispatcherProvider.default()) {
-                appDetailRepository.details(appDetailInput.toAppReference()).onFailure {
-                    Logger.e(TAG, it, "Can not load permissions for $appDetailInput")
-                }.fold(
+                appDetailRepository.details(appDetailInput.toAppReference()).fold(
                     onSuccess = { it.toSource() },
                     onFailure = { PermissionsSource.Error },
                 )

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/requirements/RequirementsViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/requirements/RequirementsViewModel.kt
@@ -22,12 +22,9 @@ import sk.styk.martin.apkanalyzer.core.apps.model.AppDetail
 import sk.styk.martin.apkanalyzer.core.common.clipboard.ClipboardManager
 import sk.styk.martin.apkanalyzer.core.common.clipboard.CopyResult
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
-import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.feature.appdetail.api.AppDetailInput
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.toAppReference
 import java.util.Locale
-
-private const val TAG = "RequirementsViewModel"
 
 @HiltViewModel(assistedFactory = RequirementsViewModel.Factory::class)
 internal class RequirementsViewModel @AssistedInject constructor(
@@ -71,8 +68,6 @@ internal class RequirementsViewModel @AssistedInject constructor(
             val deviceFeatures = deviceFeaturesRepository.deviceFeatures()
             state.value = withContext(dispatcherProvider.default()) {
                 appDetailRepository.details(appDetailInput.toAppReference())
-            }.onFailure {
-                Logger.e(TAG, it, "Can not load requirements for $appDetailInput")
             }.fold(
                 onSuccess = { it.toRequirementsState(deviceFeatures) },
                 onFailure = { RequirementsState.Error },

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/splitapks/SplitApksViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/splitapks/SplitApksViewModel.kt
@@ -23,11 +23,8 @@ import sk.styk.martin.apkanalyzer.core.apps.packaging.InstalledSplitApk
 import sk.styk.martin.apkanalyzer.core.common.clipboard.ClipboardManager
 import sk.styk.martin.apkanalyzer.core.common.clipboard.CopyResult
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
-import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.feature.appdetail.api.AppDetailInput
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.toAppReference
-
-private const val TAG = "SplitApksViewModel"
 
 @HiltViewModel(assistedFactory = SplitApksViewModel.Factory::class)
 internal class SplitApksViewModel @AssistedInject constructor(
@@ -84,9 +81,7 @@ internal class SplitApksViewModel @AssistedInject constructor(
         source.value = SplitApksSource.Loading
         viewModelScope.launch {
             source.value = withContext(dispatcherProvider.default()) {
-                appDetailRepository.details(appDetailInput.toAppReference()).onFailure {
-                    Logger.e(TAG, it, "Can not load split APKs for $appDetailInput")
-                }.fold(
+                appDetailRepository.details(appDetailInput.toAppReference()).fold(
                     onSuccess = { detail -> SplitApksSource.Ready(detail.info.installedSplits.sortedForDisplay().toImmutableList()) },
                     onFailure = { SplitApksSource.Error },
                 )

--- a/feature/apps/AGENTS.md
+++ b/feature/apps/AGENTS.md
@@ -14,6 +14,7 @@ The primary feature — displays the list of installed apps with filtering, sort
 ```
 navigation/
   AppEntryProvider.kt      - appEntries(navigator) - registers AppsNavKey, AppSearchNavKey, AppFilterNavKey, PermissionFilterNavKey
+  ScreenNames.kt           - public screenOpenEvent(key: NavKey): ScreenOpenEvent? resolver consumed by app's centralized screen-opening breadcrumb logging
   AppFilterNavKey.kt       - Internal nav key for filter screen
   AppSearchNavKey.kt       - Internal nav key for search screen
   PermissionFilterNavKey.kt - Internal nav key for permission filter

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/navigation/ScreenNames.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/navigation/ScreenNames.kt
@@ -1,0 +1,18 @@
+package sk.styk.martin.apkanalyzer.feature.apps.impl.navigation
+
+import androidx.navigation3.runtime.NavKey
+import sk.styk.martin.apkanalyzer.core.navigation.ScreenOpenEvent
+import sk.styk.martin.apkanalyzer.feature.apps.api.AppsNavKey
+
+private const val SCREEN_APPS = "apps"
+private const val SCREEN_APP_FILTER = "app_filter"
+private const val SCREEN_APP_SEARCH = "app_search"
+private const val SCREEN_PERMISSION_FILTER = "permission_filter"
+
+fun screenOpenEvent(key: NavKey): ScreenOpenEvent? = when (key) {
+    is AppsNavKey -> ScreenOpenEvent(SCREEN_APPS)
+    is AppFilterNavKey -> ScreenOpenEvent(SCREEN_APP_FILTER)
+    is AppSearchNavKey -> ScreenOpenEvent(SCREEN_APP_SEARCH)
+    is PermissionFilterNavKey -> ScreenOpenEvent(SCREEN_PERMISSION_FILTER)
+    else -> null
+}

--- a/feature/browse/AGENTS.md
+++ b/feature/browse/AGENTS.md
@@ -55,6 +55,8 @@ apps/                         - Apps in one tapped bucket (search + app rows), r
 navigation/
   BrowseEntryProvider.kt      - browseEntries(navigator): registers BrowseNavKey, BrowseOptionsNavKey,
                                 BrowseAppsNavKey; the apps screen navigates out to AppDetailNavKey
+  ScreenNames.kt              - public screenOpenEvent(key: NavKey): ScreenOpenEvent? resolver consumed
+                                by app's centralized screen-opening breadcrumb logging
   BrowseOptionsNavKey.kt      - Internal: dimension
   BrowseAppsNavKey.kt         - Internal: dimension, bucketKey, bucketLabel
 ```

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/navigation/ScreenNames.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/navigation/ScreenNames.kt
@@ -1,0 +1,16 @@
+package sk.styk.martin.apkanalyzer.feature.browse.impl.navigation
+
+import androidx.navigation3.runtime.NavKey
+import sk.styk.martin.apkanalyzer.core.navigation.ScreenOpenEvent
+import sk.styk.martin.apkanalyzer.feature.browse.api.BrowseNavKey
+
+private const val SCREEN_BROWSE = "browse"
+private const val SCREEN_BROWSE_OPTIONS = "browse_options"
+private const val SCREEN_BROWSE_APPS = "browse_apps"
+
+fun screenOpenEvent(key: NavKey): ScreenOpenEvent? = when (key) {
+    is BrowseNavKey -> ScreenOpenEvent(SCREEN_BROWSE)
+    is BrowseOptionsNavKey -> ScreenOpenEvent(SCREEN_BROWSE_OPTIONS, "dimension=${key.dimension}")
+    is BrowseAppsNavKey -> ScreenOpenEvent(SCREEN_BROWSE_APPS, "dimension=${key.dimension}")
+    else -> null
+}

--- a/feature/settings/AGENTS.md
+++ b/feature/settings/AGENTS.md
@@ -22,6 +22,7 @@ Note: `data object`, unlike `feature:permissions`/`feature:statistics` which use
 ```
 navigation/
   SettingsEntryProvider.kt  - settingsEntries(navigator: Navigator): EntryProviderScope<NavKey> extension; registers SettingsNavKey -> SettingsScreen(onBack = { navigator.goBack() })
+  ScreenNames.kt            - public screenOpenEvent(key: NavKey): ScreenOpenEvent? resolver consumed by app's centralized screen-opening breadcrumb logging
 SettingsAction.kt           - sealed interface: ColorSchemeSelected, RecentlyViewedAppsToggled, NavigateBack
 SettingsEvent.kt            - sealed interface: NavigateBack (one-shot)
 SettingsState.kt            - @Immutable data class: colorScheme, recentlyViewedAppsEnabled

--- a/feature/settings/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/settings/impl/navigation/ScreenNames.kt
+++ b/feature/settings/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/settings/impl/navigation/ScreenNames.kt
@@ -1,0 +1,12 @@
+package sk.styk.martin.apkanalyzer.feature.settings.impl.navigation
+
+import androidx.navigation3.runtime.NavKey
+import sk.styk.martin.apkanalyzer.core.navigation.ScreenOpenEvent
+import sk.styk.martin.apkanalyzer.feature.settings.api.SettingsNavKey
+
+private const val SCREEN_SETTINGS = "settings"
+
+fun screenOpenEvent(key: NavKey): ScreenOpenEvent? = when (key) {
+    is SettingsNavKey -> ScreenOpenEvent(SCREEN_SETTINGS)
+    else -> null
+}


### PR DESCRIPTION
## Summary

- add `manifest_load` for installed-package and APK-file readable manifests with resource lookup, single-pass binary parsing, XML rendering, split counts, modes, and terminal outcomes
- add aggregate `app_signing_index_load` and memoized `device_features_load` supporting traces without per-app remote traces
- document the complete public core repository/manager load-entry inventory and reconcile truthful telemetry limits

## Stack

OBS-05 stack layer 5, based on `martinstyk-obs-04-app-detail-traces`.

This is the final implementation layer currently authorized. OBS-06 baselines/alerts and OBS-07 UI timing remain deferred.

## Validation

- `./gradlew spotlessApply`
- `./gradlew :core:apps:compileDebugKotlin :app:compileDebugKotlin`
- specialist diff review: no findings