### PR TITLE
Refine repository agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,38 @@ re-deriving the module's structure.
 * **Commits are authored as the human user only.** Never add `Co-Authored-By: Claude`,
   `Claude-Session:`, or any AI co-author trailer. See the `git-commit-author` skill.
 
+## Development Workflow
+
+Before changing code:
+
+1. Understand the requirement and define its acceptance criteria.
+2. Search the repository for existing implementations of similar behavior.
+3. Identify the relevant modules, classes, interfaces, and module-level `AGENTS.md` files.
+4. Understand the existing architecture, patterns, and constraints.
+5. Create a concise implementation plan.
+6. Implement the smallest clean solution that satisfies the requirement and fits the architecture.
+7. Run the relevant build checks from [Verifying a Change](#verifying-a-change).
+8. Inspect the complete Git diff, including changes made earlier in the worktree.
+9. Perform a self-review for correctness, scope, architecture, failure states, and leftover code.
+10. Fix every issue found during self-review.
+11. Run the relevant verification again after the final fix.
+
+Do not start implementing before understanding the existing implementation and patterns. Do not
+introduce a new abstraction, framework, architecture pattern, or utility when an existing solution
+can be reused.
+
+## Engineering Principles
+
+* Prefer existing patterns over introducing new ones.
+* Keep changes focused on the requested behavior and do not modify unrelated files.
+* Prefer simple solutions over clever ones and avoid speculative abstractions.
+* Reuse existing functionality instead of duplicating it.
+* Preserve the architecture. Move or restructure code when necessary for a clean implementation,
+  but ask before making a large architectural change.
+* Consider failure states, empty states, and cancellation paths.
+* Do not hide errors with broad exception handling.
+* Do not leave debug code, temporary logging, or TODOs in production code.
+
 ## Verifying a Change
 
 Move fast: don't run `detektDebug`, `lintDebug`, `spotlessCheck`, or `validateAgentContext` after
@@ -60,9 +92,6 @@ is the authoritative list.
 * A module's package matches its directory with hyphens removed: `core/user-preferences` →
   `core.userpreferences`, `feature/app-detail/impl` → `feature.appdetail.impl`. `app` uses the root
   package `sk.styk.martin.apkanalyzer` with no suffix.
-* `feature:browse` is a **stub** — a placeholder screen with no ViewModel or logic. Don't assume it
-  works.
-
 ## Architecture
 
 ### ViewModels
@@ -190,6 +219,14 @@ tool.
 
 * `AGENTS.md` files are canonical. Put guidance in the closest relevant `AGENTS.md`; never copy it
   into a tool-specific file.
+* Scoped `AGENTS.md` files document durable context that cannot be inferred cheaply: module
+  boundaries, package-level organization, required patterns, non-obvious behavior, and exceptional
+  entry points.
+* Do not maintain exhaustive file trees, copied interfaces, ordinary dependency lists, or
+  implementation summaries that repository search can recover more accurately. Name a specific
+  file only when it is a canonical reference, an assembly point, or misleadingly named.
+* Prefer package or domain maps over source-file inventories. Adding or renaming an ordinary source
+  file should not require an `AGENTS.md` update.
 * `CLAUDE.md` files contain exactly `@AGENTS.md` and nothing else.
 * `.github/copilot-instructions.md` is the Copilot adapter; Copilot also reads nested `AGENTS.md`
   directly. `.claude/skills/` is shared by both tools — never mirror skills into `.github/skills/`,

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -1,93 +1,36 @@
 # app Module
 
-## Purpose
-The top-level Android application module. No business logic of its own — wires together every `core/*` and `feature/*/impl` module, hosts the launcher and external-APK document activities, defines their navigation graphs, and provides app-scoped analytics and lifecycle bindings.
+## Purpose and Boundary
 
-## Package: `sk.styk.martin.apkanalyzer` (root — no module suffix, unlike `core.*`/`feature.*`)
+The top-level Android application module wires `core/*` and `feature/*/impl` modules together. It
+owns application and Activity setup, app-scoped bindings, top-level navigation hosts, and manifest
+entry points. Put no feature or analysis logic here.
 
-Sub-packages: `.dependencyinjection`, `.ui` (`.externalapk`, `.navigation`), `.util.file`.
+This module uses the root package `sk.styk.martin.apkanalyzer`; unlike every other module, it has no
+module suffix.
 
-## Structure
+## Wiring Rules
 
-```
-ApkAnalyzer.kt                          - Application class (@HiltAndroidApp); Coil SingletonImageLoader.Factory; registers injected Set<DefaultLifecycleObserver> multibindings onto ProcessLifecycleOwner
-dependencyinjection/
-  ApplicationModule.kt                  - @InstallIn(SingletonComponent) @Module: app-scoped CoroutineScope
-ui/
-  ApkAnalyzerActivity.kt                - @AndroidEntryPoint launcher Activity; observes ApkAnalyzerViewModel.state for color scheme and hosts ApkAnalyzerApp
-  ApkAnalyzerThemeHost.kt               - Shared Compose theme/night-mode host used by both activities
-  externalapk/                           - Document-task Activity, external APK state ViewModel, and standalone Navigation 3 host
-  ApkAnalyzerApp.kt                     - Top-level @Composable: NavigationState + Navigator (core:navigation), Scaffold + bottom NavigationBar (core:ui-library), SharedTransitionLayout + entryProvider wiring every feature's nav graph, NavDisplay
-  ApkAnalyzerState.kt                   - sealed interface: Loading / Data(colorAppScheme: ColorAppScheme)
-  ApkAnalyzerViewModel.kt               - @HiltViewModel; maps PersistenceRepository.observe(Key.ColorScheme) into ApkAnalyzerState via stateIn(WhileSubscribed(5000)) — exists solely so the Activity can drive day/night mode before the Compose theme renders
-  navigation/
-    TopLevelDestinations.kt             - internal TOP_LEVEL_DESTINATIONS (persistentListOf<NavigationBarItem>): Apps, Browse tabs with icons/titles; internal TOP_LEVEL_KEYS
-util/file/
-  GenericFileProvider.kt                - FileProvider subclass wired through ${applicationId} in the manifest
-```
+`ui/ApkAnalyzerApp.kt` is the assembly point for the main Navigation 3 host. Every reachable feature
+must register its `*Entries()` function in that file. `AppsNavKey` is the start destination, and the
+top-level keys define the independent bottom-navigation stacks.
 
-## How `ApkAnalyzerApp.kt` wires every feature together
+The external-APK Activity has its own Navigation 3 host and document task. Keep its temporary APK
+ownership and back-stack lifecycle independent from the launcher Activity.
 
-```kotlin
-@Composable
-internal fun ApkAnalyzerApp() {
-    val navigationState = rememberNavigationState(startKey = AppsNavKey, topLevelKeys = TOP_LEVEL_KEYS)
-    val navigator = remember { Navigator(navigationState) }
+Both activities use the shared theme host so the persisted color scheme is applied before feature
+content renders. Material3 is allowed directly here only for app-shell plumbing such as `Scaffold`
+and theme hosting.
 
-    Scaffold(
-        bottomBar = {
-            NavigationBar(
-                items = TOP_LEVEL_DESTINATIONS,
-                selectedKey = navigationState.currentTopLevelKey,
-                isVisible = true,
-                onSelectKey = navigator::navigate,
-            )
-        },
-    ) { paddings ->
-        SharedTransitionLayout {
-            CompositionLocalProvider(LocalSharedTransitionScope provides this) {
-                val entryProvider = entryProvider {
-                    appEntries(navigator)
-                    appDetailEntries(navigator)
-                    browseEntries(navigator)
-                    settingsEntries(navigator)
-                }
-                NavDisplay(
-                    modifier = Modifier.fillMaxWidth().padding(paddings),
-                    entries = navigationState.toEntries(entryProvider),
-                    onBack = navigator::goBack,
-                )
-            }
-        }
-    }
-}
-```
+## Manifest Contracts
 
-`AppsNavKey` is the start destination. Each `*Entries()` call comes from the corresponding
-`feature/*/impl/navigation/*EntryProvider.kt` and takes a `navigator` param whenever that feature
-navigates *out* to another feature — all four registered here do (browse navigates into
-`feature:app-detail` from its apps screen). **Adding a new feature/screen means adding its
-`*Entries()` call here** — see the `create-feature-module` and `implement-navigation` skills.
+* The launcher Activity is the exported `MAIN`/`LAUNCHER` entry point.
+* The external-APK Activity is an exported document entry point for APK content and runs in an
+  isolated document task.
+* The file provider is not exported and grants URI permissions through the application ID-based
+  authority.
+* Package visibility and usage-access permissions are intentional product requirements; preserve
+  their lint suppressions when editing the manifest.
 
-## Manifest Highlights (`app/src/main/AndroidManifest.xml`)
-
-- **Permissions:** `QUERY_ALL_PACKAGES` (lint-suppressed), `PACKAGE_USAGE_STATS` (lint-suppressed, protected permission).
-- **Application:** `android:name=".ApkAnalyzer"`, `allowBackup=true`, `hardwareAccelerated=true`, `largeHeap=true`, `supportsRtl=true`.
-- **Launcher activity:** `.ui.ApkAnalyzerActivity` — `exported=true`, `windowSoftInputMode=adjustResize`, `MAIN`/`LAUNCHER`.
-- **External APK activity:** `.ui.externalapk.ExternalApkActivity` — `exported=true`, `documentLaunchMode=always`, excluded from recents, and handles `VIEW`/`INSTALL_PACKAGE` for `.apk` files in an isolated document task.
-- **Provider:** `.util.file.GenericFileProvider`, authority `${applicationId}`, `exported=false`, `grantUriPermissions=true`.
-- **Meta-data:** `google_analytics_automatic_screen_reporting_enabled = false`.
-
-## Dependencies
-
-Plugins: `apkanalyzer.application`, `apkanalyzer.hilt`, `apkanalyzer.compose`, `apkanalyzer.spotless`, `parcelize`.
-
-`projects.*`: all of `core.apkFiles`, `core.apps`, `core.appPermissions`, `core.appIndex`, `core.common`, `core.userPreferences`, `core.navigation`, `core.uiLibrary`, and all of `feature.apps.impl`, `feature.browse.impl`, `feature.settings.impl`, `feature.appDetail.impl`.
-
-Key libraries: `androidx.activity.compose`, `androidx.appcompat`, `androidx.lifecycle.viewmodel.ktx`/`.runtime.compose`/`.process` (for `ProcessLifecycleOwner`), `androidx.compose.material3`, `kotlinx.collections.immutable`, `coil.compose`, `debugImplementation(libs.leakcanary)`.
-
-`applicationId = "sk.styk.martin.apkanalyzer"`. `versionCode`/`versionName` come from
-`version.code`/`version.name` Gradle properties. `gradle.properties` supplies local defaults (`1` and
-`dev`); workflows override them with `-Pversion.code=`/`-Pversion.name=`. Continuous integration
-changes only `version.name`, while the release workflow derives both values from the pushed semantic
-version tag.
+Version name and code have local Gradle-property defaults. CI and release workflows override them;
+do not introduce a second version source.

--- a/build-logic/AGENTS.md
+++ b/build-logic/AGENTS.md
@@ -1,59 +1,39 @@
 # build-logic Module
 
 ## Purpose
-Gradle convention plugins that standardize build configuration across all modules. Located in `build-logic/convention/`.
 
-## Package: `sk.styk.martin.apkanalyzer`
+`build-logic/convention` owns the Gradle convention plugins used throughout the repository. Android
+SDK levels and the Kotlin JVM toolchain are centralized here and must not be repeated in module
+build scripts.
 
-## Plugins
+## Convention Plugin Contracts
 
-| Plugin | File | Applies |
-|--------|------|---------|
-| `apkanalyzer.agent-context` | `AgentContextPlugin.kt`, `ValidateAgentContextTask.kt` | Root-only `validateAgentContext` task for context pairs, module coverage, skill metadata, links, and duplicate adapters |
-| `apkanalyzer.library` | `LibraryPlugin.kt` | `com.android.library` + `apkanalyzer.spotless` + compileSdk/minSdk + Kotlin JVM toolchain |
-| `apkanalyzer.application` | `ApplicationPlugin.kt` | `com.android.application` + Google Services + Firebase (Crashlytics, Perf) + release config (minify+shrink) |
-| `apkanalyzer.feature.api` | `FeatureApiPlugin.kt` | `apkanalyzer.library` + `kotlin.serialization` + `navigation3-runtime` |
-| `apkanalyzer.feature.impl` | `FeatureImplPlugin.kt` | `apkanalyzer.library` + `apkanalyzer.hilt` + `apkanalyzer.compose` + `:core:ui-library` + `:core:navigation` |
-| `apkanalyzer.hilt` | `HiltPlugin.kt` | `hilt.android` + `ksp` + hilt-compiler |
-| `apkanalyzer.compose` | `ComposePlugin.kt` | `kotlin.compose` + `kotlin.serialization` + Compose BOM + compose bundle + navigation3 bundle |
-| `apkanalyzer.spotless` | `SpotlessPlugin.kt` | Spotless + ktlint + compose-rules-ktlint custom ruleset |
-| `apkanalyzer.detekt` | `DetektPlugin.kt` | Baseline-free, type-resolved Kotlin static analysis using the shared root configuration |
-| `apkanalyzer.sarif-merge` | `SarifMergePlugin.kt` | Root-only `mergeSarifReports` task that combines every module's Detekt and Lint SARIF reports into one file for upload |
+| Plugin | Responsibility |
+|---|---|
+| `apkanalyzer.agent-context` | Registers the root `validateAgentContext` task. |
+| `apkanalyzer.library` | Configures Android libraries, Kotlin, SDK levels, and formatting. |
+| `apkanalyzer.application` | Configures the Android app, Google services, Firebase, and release builds. |
+| `apkanalyzer.feature.api` | Configures serialization and Navigation 3 for dependency-light feature APIs. |
+| `apkanalyzer.feature.impl` | Configures Compose, Hilt, Navigation 3, and shared UI/navigation modules. |
+| `apkanalyzer.hilt` | Applies Hilt and KSP compiler configuration. |
+| `apkanalyzer.compose` | Applies Compose, serialization, the BOM, and shared Compose/navigation bundles. |
+| `apkanalyzer.spotless` | Applies the repository ktlint and Compose formatting rules. |
+| `apkanalyzer.detekt` | Applies baseline-free, type-resolved static analysis. |
+| `apkanalyzer.sarif-merge` | Merges module Detekt and Lint SARIF reports for CI upload. |
 
-## Utility Files (`utils/`)
+## Non-Obvious Build Behavior
 
-- `AndroidSdk.kt` - `COMPILE_SDK = 37`, `TARGET_SDK = 37`, `MIN_SDK = 28`
-- `DependenciesExtension.kt` - `implementation()`, `api()` helper extensions
-- `Kotlin.kt` - `configureKotlin()` (JVM toolchain 25)
-- `ProjectExtensions.kt` - `Project.libs` accessor for version catalog
+* `AndroidSdk.kt` and `Kotlin.kt` are the canonical SDK and toolchain sources.
+* Spotless targets are project-relative so root and module formatting scopes do not overlap.
+* Android modules run Detekt against the debug variant; convention code runs against its JVM main
+  source set.
+* Detekt and Android Lint already emit SARIF. The merge plugin combines those reports; do not add a
+  second parser or reporting pipeline.
+* `validateAgentContext` enforces module-scoped `AGENTS.md` coverage, adjacent `CLAUDE.md` adapters,
+  skill metadata, unique adapters, and valid local Markdown links.
 
-## Spotless Configuration
-- ktlint with compose-rules-ktlint custom ruleset
-- Multiline function signatures at 3+ parameters
-- Compose naming rules (ignores `@Composable` for function naming)
-- `compositionlocal-allowlist` and `lambda-param-in-effect` rules disabled
-- Module applications format their Kotlin and Kotlin Gradle sources.
-- The root application formats root Gradle scripts, `build-logic`, YAML workflows, and `.gitignore` files.
-- Project-relative targets keep root and module formatting scopes from overlapping.
+## Adding a Convention Plugin
 
-## Detekt Configuration
-- Shared rules in `config/detekt/detekt.yml`
-- Android modules analyze the debug variant with type resolution
-- `build-logic` analyzes its main JVM source set
-- CI runs every Android module's `detektDebug` task and `build-logic:convention:detektMain`
-
-## SARIF Reporting
-- Detekt (`dev.detekt`) and Android Lint (AGP) both emit a per-module `.sarif` report by default —
-  no explicit `reports {}`/`lint {}` config is needed to turn SARIF on.
-- The root-only `mergeSarifReports` task (`apkanalyzer.sarif-merge`) globs every module's
-  `build/reports/detekt/*.sarif` and `build/reports/lint-results-*.sarif` and merges them into
-  `build/reports/merged.sarif` using Detekt's own `ReportMergeTask` — no custom parsing script.
-- CI runs Detekt and Lint with `--continue` so every module's report is produced even when one
-  module fails, then runs `mergeSarifReports` and uploads the single merged file via
-  `github/codeql-action/upload-sarif`, which shows results as PR annotations and in the repo's
-  Security > Code scanning tab.
-
-## When Adding a New Plugin
-1. Create implementation class in `src/main/kotlin/sk/styk/martin/apkanalyzer/`
-2. Register in `build.gradle.kts` `gradlePlugin { plugins { register(...) } }`
-3. Add to `gradle/libs.versions.toml` under `[plugins]` section
+Implement the plugin in the convention source set, register it in the convention build, then expose
+its alias through `gradle/libs.versions.toml`. Reuse the existing configuration helpers rather than
+configuring SDK, Kotlin, Compose, Hilt, formatting, or analysis independently.

--- a/core/apk-files/AGENTS.md
+++ b/core/apk-files/AGENTS.md
@@ -1,33 +1,21 @@
 # core:apk-files Module
 
-## Purpose
-Owns temporary APK materialization and cleanup for APKs supplied through Android content URIs.
+## Purpose and Boundary
 
-## Package: `sk.styk.martin.apkanalyzer.core.apkfiles`
+Owns temporary APK materialization and cleanup for APKs received through Android content URIs. The
+package is `sk.styk.martin.apkanalyzer.core.apkfiles`.
 
-## Structure
+This module owns file lifecycle only. APK parsing and analysis belong in `core:apps`; Activities and
+ViewModels decide when ownership begins and ends.
 
-```
-TemporaryApkManager.kt       - Public task-scoped copy and release contract
-TemporaryApkManagerImpl.kt   - Copies URI streams on IO and removes cache directories for discarded tasks
-di/
-  TemporaryApkModule.kt      - Singleton Hilt binding
-```
+## Storage and Lifecycle Semantics
 
-## Storage Model
+Temporary APKs live under `cacheDir/apk-analysis/task_<taskId>/`, keeping launcher and external
+document tasks isolated. Before copying a new APK, cleanup compares those directories with live
+`ActivityManager.appTasks` so files orphaned by process death are removed after their task is gone.
 
-Temporary APKs live under `cacheDir/apk-analysis/task_<taskId>/`. Before each copy, the manager
-queries `ActivityManager.appTasks` and removes directories whose task no longer exists. Live main
-and external document tasks therefore keep independent files, while files orphaned by process
-death are removed by the next APK analysis after their task is discarded.
+Copies stream on the injected IO dispatcher and are capped at 1 GiB. Never trust a provider-reported
+size because APK intents can originate from arbitrary content providers.
 
-Copies are limited to 1 GiB while streaming. Provider-reported sizes are not trusted because an
-exported intent can receive a URI from an arbitrary content provider.
-
-Call `release(apkFilePath)` when ownership ends. Release is idempotent because both the importing
-ViewModel and app-detail ViewModel may observe the same Activity teardown.
-
-## Dependencies
-
-- `core:common` for `DispatcherProvider` and `Logger`
-- Hilt
+Call `release(apkFilePath)` when ownership ends. Release must remain idempotent because both the
+importing ViewModel and app-detail ViewModel can observe the same Activity teardown.

--- a/core/app-index/AGENTS.md
+++ b/core/app-index/AGENTS.md
@@ -1,76 +1,34 @@
 # core:app-index Module
 
-## Purpose
-Builds `attribute → apps` indexes across every installed app — target SDK, min SDK, install source,
-permission, shared UID, app category, and signing certificate (SHA-256, SHA-1, MD5, organization,
-country) — for the `feature:browse` "Browse by Attribute" screen (roadmap `CE-01`). A pure bucketing
-layer: it holds no `PackageManager` access of its own and reaches only two public `core:apps`
-repositories (`InstalledAppsRepository`, `AppSigningRepository`), never `analysis/` internals
-(`CertificateExtractor`, `InstallSourceResolver`) directly.
+## Purpose and Boundary
 
-## Package: `sk.styk.martin.apkanalyzer.core.appindex`
+Builds device-wide `attribute -> apps` indexes for `feature:browse`. The package is
+`sk.styk.martin.apkanalyzer.core.appindex`.
 
-## Structure
+This is a pure bucketing layer over public `core:apps` repositories. It owns no `PackageManager`
+access and must never reach into analysis internals.
 
-```
-AppIndexRepository.kt / Impl  - Flow of AppIndexStatus; Impl combines InstalledAppsRepository.apps()
-                                and AppSigningRepository.signing(), and holds the
-                                (List<InstalledApp>, Map<packageName, AppSigning>) -> AppAttributeIndex
-                                transform as private functions (one groupBy helper per dimension) —
-                                inlined rather than a separate object since it has exactly one caller
-model/
-  AppAttributeIndex.kt         - targetSdk / minSdk / installSource / permission / sharedUserId /
-                                 appCategory / certificateSha256 / certificateSha1 / certificateMd5 /
-                                 certificateOrganization / certificateCountry buckets, each
-                                 Map<value, List<packageName>>
-  AppIndexStatus.kt            - sealed: Loading | Data(index) - Loading before the first combined emission
-di/
-  AppIndexModule.kt            - Hilt @Binds for AppIndexRepository
-```
+## Index Semantics
 
-## Key Interface
+The index covers target SDK, minimum SDK, install source, requested permission, shared UID, app
+category, and current-signing-certificate identity and subject attributes.
 
-```kotlin
-interface AppIndexRepository {
-    fun index(): Flow<AppIndexStatus>
-}
-```
+* Apps without a shared UID are omitted from that dimension; do not create an "unshared" bucket.
+* `AppCategory.Undefined` is a real bucket because an undeclared category is meaningful.
+* Multi-signer apps appear under every current signer.
+* Certificate fingerprint dimensions use certificate hashes, not signature algorithms.
+* Organization and country come from the certificate subject, matching app-detail terminology.
 
-Recomputes whenever `InstalledAppsRepository.apps()` or `AppSigningRepository.signing()` emits — no
-separate `PackageChangesObserver` subscription. Grouping is CPU-bound, not I/O, so the combine step
-runs on `dispatcherProvider.default()` — the certificate digest/verify work itself happens upstream in
-`AppSigningRepositoryImpl`, on `dispatcherProvider.io()`. The combined result is `shareIn(appScope,
-SharingStarted.Lazily, replay = 1)`, matching `AppSigningRepositoryImpl`'s reasoning: the grouping work
-only matters once a real consumer (a browse screen) subscribes, and multiple simultaneous subscribers
-must not each redo it.
+The first dimensions reuse data already present on `InstalledApp`. Certificate grouping consumes the
+heavier `AppSigningRepository` output.
 
-## Dimensions, and why the first six are cheaper than certificate grouping
+## Execution and Lifecycle
 
-`targetSdk`, `minSdk`, `installSource`, `permission`, `sharedUserId`, `appCategory` are all already on
-`InstalledApp` — no new query. `sharedUserId` is the one dimension that legitimately drops apps: only
-those declaring `android:sharedUserId` are indexed (`bySharedUserId` `mapNotNull`s the null case away),
-matching `byPermission`'s existing "no signal, no bucket" shape rather than inventing an "unshared"
-sentinel bucket that would just be most of the device. `appCategory` keeps `AppCategory.Undefined` as
-a real, groupable bucket instead, because most third-party apps genuinely declare no category and
-that absence is itself the fact worth counting.
-The certificate hash, organization, and country indexes come from
-`AppSigningRepository`, which runs a real X.509 parse, six digest computations, and a signature-verify
-per certificate — genuinely heavier, which is why that repository is `Lazily` shared (see
-`core/apps/AGENTS.md`) rather than computed unconditionally like `InstalledAppsRepository`. A
-multi-signer app is indexed under every current signer, not an arbitrary "first" one
-(`byCertificate` `flatMap`s over `AppSigning.currentCertificates`). Fingerprint uses
-`Certificate.certificateHashSha256` per roadmap `FR-09` ("same publisher" — group by fingerprint, not
-signing algorithm); SHA-1 and MD5 are alternate identity groupings for interoperability with tools
-that use those fingerprints. Organization/country come from `Certificate.subject`, matching the
-certificate screen's existing convention for "the signer."
+Recompute from the installed-app and signing flows rather than subscribing separately to package
+changes. Run CPU-bound grouping on `DispatcherProvider.default()`.
 
-**Uses-feature grouping is still deferred** — it would need a new `PackageManager` flag
-(`GET_CONFIGURATIONS`) nothing currently requests. Unlike certificate, no other `core:apps` consumer
-needs a device-wide feature list today, so there's no general-purpose repository to build yet; add one
-the same way `AppSigningRepository` was added — in `core:apps`, not here — when a real second consumer
-appears.
+Share the combined index lazily with one replayed value. Certificate parsing and grouping should not
+run until a real browse consumer subscribes, and concurrent collectors must not duplicate the work.
 
-## Dependencies
-- `implementation(projects.core.apps)` - `InstalledAppsRepository`, `AppSigningRepository`, and their
-  models, public surface only
-- `implementation(projects.core.common)` - `AppSource`, `DispatcherProvider`
+Uses-feature grouping remains out of scope until a real consumer justifies device-wide
+`PackageManager` extraction. Add that source in `core:apps`, not in this module.

--- a/core/app-permissions/AGENTS.md
+++ b/core/app-permissions/AGENTS.md
@@ -1,47 +1,26 @@
 # core:app-permissions Module
 
-## Purpose
-Aggregates every Android permission (`android.permission.*`) requested across all apps installed on the device into a single deduplicated, sorted, human-readable list. Powers a device-wide "which apps use permission X" explorer. Depends on `core:apps` for raw installed-app/permission data.
+## Purpose and Boundary
 
-## Package: `sk.styk.martin.apkanalyzer.core.apppermissions`
+Aggregates permissions requested across all installed apps into the deduplicated, sorted,
+human-readable device-wide list consumed by permission browsing. The package is
+`sk.styk.martin.apkanalyzer.core.apppermissions`.
 
-## Structure
+This differs from `core:apps/permissions`, which models permissions declared or used by one analyzed
+app.
 
-```
-DevicePermissionsRepository.kt      - Public interface: fun permissions(): Flow<List<DevicePermission>>
-DevicePermissionsRepositoryImpl.kt  - internal @Singleton impl; builds a shared/cached flow from InstalledAppsRepository
-PermissionLabelProvider.kt          - @Singleton; resolves a permission name to a human-readable label
-model/
-  DevicePermission.kt               - data class DevicePermission(val name: String, val label: String)
-di/
-  AppPermissionsModule.kt           - Hilt @Binds module (SingletonComponent)
-res/values/                         - String resources for known permission labels (permission_label_camera, etc.)
-```
+## Permission Semantics
 
-## Key Interfaces
+The repository derives its data from the installed-app flow and shares the result lazily with one
+replayed value. All collectors must observe one cached computation, refreshed when installed-app data
+changes.
 
-```kotlin
-interface DevicePermissionsRepository {
-    fun permissions(): Flow<List<DevicePermission>>
-}
+Permission label resolution order is:
 
-class PermissionLabelProvider @Inject constructor(
-    @ApplicationContext private val context: Context,
-    private val packageManager: PackageManager,
-) {
-    fun getLabel(permissionName: String): String
-}
-```
+1. Curated localized labels for well-known Android permissions.
+2. The declaring package's platform-provided label.
+3. A humanized simple name derived from the raw permission identifier.
 
-## Notable Implementation Details
-
-- The permissions flow is built once via `.flowOn(dispatcherProvider.io()).shareIn(appScope, SharingStarted.Lazily, replay = 1)` — all collectors share one cached computation, recomputed only when the underlying installed-apps flow emits again.
-- `PermissionLabelProvider.getLabel` resolution order: (1) hardcoded map of ~80 well-known permissions via string resources, (2) `PackageManager.getPermissionInfo(name, 0).loadLabel(...)` wrapped in try/catch (many vendor permissions throw `NameNotFoundException`), (3) `createSimpleName` fallback — strips the package prefix and humanizes `SNAKE_CASE`.
-- `createSimpleName` is a manual char-by-char `StringBuilder` mutation with a subtle off-by-one: the humanizing loop starts at index 1, so the very first character is never transformed. Worth fixing carefully if touched, not obviously by design.
-- No memoization on `getLabel()` itself beyond the static known-labels map — unknown-permission lookups hit `PackageManager` again each time, though callers typically only call it once per unique permission thanks to `DevicePermissionsRepositoryImpl`'s caching.
-- `parcelize` plugin is applied in `build.gradle.kts` but nothing in this module actually uses `@Parcelize` — likely inherited boilerplate from the module template, not a real requirement.
-
-## Dependencies
-- `apkanalyzer.library` + `apkanalyzer.hilt` + `parcelize` plugins
-- `implementation(projects.core.apps)` — `InstalledAppsRepository`
-- `implementation(projects.core.common)` — `DispatcherProvider`
+Vendor and removed permissions can fail platform lookup; preserve the readable fallback rather than
+dropping those permissions. Keep raw identifiers available to callers even when a friendly label
+exists.

--- a/core/apps/AGENTS.md
+++ b/core/apps/AGENTS.md
@@ -1,222 +1,124 @@
 # core:apps Module
 
-## Purpose
-Core domain module for app analysis. Provides repositories and utilities for querying installed apps, app details, storage/usage stats, and APK analysis.
+## Purpose and Boundary
 
-## Package: `sk.styk.martin.apkanalyzer.core.apps`
+Core domain module for installed-app and APK analysis. It owns platform extraction, normalization,
+caching, and the domain models consumed by features. The package is
+`sk.styk.martin.apkanalyzer.core.apps`.
 
-## Structure
+Expose repositories and typed models, not Android framework structures. Features may interpret the
+domain data for presentation but must not repeat extraction or security policy.
 
-Package-by-domain: each concept below is a self-contained folder holding its own repository
-interface, impl, models, and (where it needs Hilt-injected internals) analysis engine — open one
-folder to understand one concept end-to-end. `di/AppsModule.kt` stays a single file with all
-bindings, grouped by the same domains.
+## Domain Package Map
 
-```
-InstalledAppsRepository.kt / Impl    - Flow of all installed apps
-AppDetailRepository.kt / Impl        - Full app detail (installed package or APK file); orchestrates
-                                        signing, permissions, components, manifest, and install-source
-PackageChangesObserver.kt / Impl     - BroadcastReceiver-based package install/uninstall listener
-AppClassificationThresholds.kt      - Constants for "large app", "recently installed", "unused" thresholds
-model/
-  InstalledApp.kt   - Basic installed app info (packageName, name, sizes, times, source, targetSdk,
-                      minSdk, sharedUserId, category)
-  AppCategory.kt    - `ApplicationInfo.category` int decoded to a domain enum (`resolveAppCategory`
-                      lives here too); `Undefined` is the untagged case, not an error
-  AppDetail.kt      - Complete app detail (info, permissions, activities, services, etc.), composing
-                      types from the domain packages below
-  AppInfo.kt        - Core app metadata, including public manifest security flags from `ApplicationInfo`
-  InstallLocation.kt - Install location enum
-signing/
-  AppSigningRepository.kt / Impl    - Flow<Map<packageName, AppSigning>> for every installed app, one
-                                      bulk GET_SIGNING_CERTIFICATES query + CertificateExtractor per
-                                      entry. Lazily shared (unlike InstalledAppsRepository's Eagerly)
-                                      since the per-cert digest/verify work only matters once a real
-                                      consumer subscribes
-  CertificateExtractor.kt / Impl (internal)    - APK signing certificate extraction
-  ApkSigningBlockAnalyzer.kt / Impl (internal) - Verifies v1 signing and coordinates scheme detection
-  ApkSigningBlockParser.kt / Impl (internal)   - Parses the raw APK Signing Block for v2/v3/v3.1 ID-value pairs
-  AppSigning.kt, Certificate.kt, CertificatePrincipal.kt, CertificateTrustLevel.kt,
-  SignatureAlgorithmAssessment.kt, SigningSchemeVersion.kt - signing domain models
-permissions/                        - APK-declared permissions (distinct from the device-wide
-                                       aggregation in :core:app-permissions)
-  Permission.kt           - Single permission: name plus `details`, which is null when the device
-                            can't resolve the permission (declaring app not installed)
-  PermissionDetails.kt    - Resolved permission details; `protectionLevel` and `protectionFlags` are
-                            domain enums, never raw `PermissionInfo` ints
-  ProtectionLevel.kt, ProtectionFlag.kt - protection domain enums
-  Permissions.kt          - Used + defined permissions container
-  UsedPermission.kt       - Permission with grant status
-  ProtectionResolvers.kt (internal) - `resolveProtectionLevel`/`resolveProtectionFlags` from raw
-                                       `PermissionInfo` ints
-components/
-  Activity.kt             - Activity component info. `isLauncher` is nullable: it is resolved from
-                            `queryIntentActivities` for an installed package, and is `null` for an
-                            APK file, where launcher resolution is unavailable — null means unknown,
-                            never "not a launcher"
-  Service.kt              - Service component info
-  BroadcastReceiver.kt    - Receiver component info
-  ComponentIntentFilter.kt - Intent filter model, incl. `ComponentIntentFilterKey`, `ComponentKind`,
-                             `IntentFilterDataRule(Type)`, `IntentFilterUriRelativeGroup`
-  ContentProvider.kt      - Provider component info, incl. `ProviderPathPermission` (`<path-permission>`
-                            entries) and the `ProviderPathMatchType` enum for `PatternMatcher`'s int type
-  ContentProviderPathPermissions.kt (internal) - `resolvePathPermissions` mapping raw `PathPermission`s
-manifest/                           - the XML-parsing engine that produces component data above
-  ManifestParser.kt / Impl           - Installed/APK AndroidManifest.xml parsing into readable namespaced XML
-                                       and component intent filters
-  ManifestXmlRenderer.kt / Impl (internal)      - Renders parsed manifest XML for display
-  ComponentManifestParser.kt / Impl (internal)  - Intent-filter extraction engine `ManifestParser` delegates to
-installsource/
-  InstallSourceChain.kt   - Installing/initiating/originating package, one nested fact on `AppInfo`
-                            rather than three flat fields — mirrors how `AppSigning` and
-                            `CertificatePrincipal` group related facts instead of flattening them
-  InstallSourceResolver.kt / Impl (internal) - Single method, `resolve()`, returning the raw
-                                       `InstallSourceChain`. `AppSource` classification (Play Store,
-                                       sideload, etc.) and `isSystemInstalledApp()` are pure functions
-                                       in `InstallSourceClassification.kt`, not resolver methods —
-                                       neither needs `PackageManager` once given the chain/flags
-                                       they're derived from
-devicefeatures/
-  DeviceFeaturesRepository.kt / Impl - What *this device* provides, for checking an app's requirements
-  DeviceFeatures.kt       - The device side of that comparison: available feature names plus the
-                            device's GL ES version. `supports()` returns `null` for unknown, never
-                            `false` — an unreadable package manager must not read as "missing"
-  Feature.kt              - Sealed: `Hardware(name)` for a `uses-feature` name, `OpenGlEs(reqGlEsVersion)`
-                            for a GL ES version requirement. A GL ES `FeatureInfo` carries a null
-                            `name` and a `reqGlEsVersion`, so the two are different kinds of fact and
-                            must not be collapsed into one string field
-  FeatureAvailability.kt  - Pairing of a `Feature` with this device's support for it
-packaging/                          - what the APK/splits actually ship
-  InstalledSplitApk.kt    - One installed split/config APK: file name, path, size, and a `SplitApkKind`
-                            (DynamicFeature/Abi/ScreenDensity/Language) classified from the file name
-                            alone
-  NativeLibraries.kt      - Every `.so` file the app ships, one `NativeLibraryFile` per (name, abi)
-                            pair read from the zip entries of the base APK and every installed split —
-                            not trusted from `primaryCpuAbi`/`secondaryCpuAbi`, which describe what the
-                            device picked, not what the APK contains. `abis` and `libraryNames` are
-                            derived (distinct/sorted) from `files`, never stored separately
-  ApkPackagingAnalysis.kt - `computeApkSize()`/`readInstalledSplits()`/`readNativeLibraries()`;
-                            `readInstalledSplits()` is what `computeApkSize()` also sums so the two
-                            never diverge on what counts as an installed split
-usagestats/
-  UsageStatsRepository.kt / Impl - App usage time/frequency stats
-storagestats/
-  StorageStatsRepository.kt / Impl - App storage size stats (requires USAGE_STATS permission)
-export/
-  AppExportManager.kt / Impl - SAF-backed base APK and full-resolution icon export
-sdkversion/
-  SdkVersionResolver.kt   - SDK version to Android name mapping
-di/                       - Hilt module bindings (single `AppsModule.kt`, grouped by domain)
-```
+The module uses package-by-domain organization. Each domain package keeps its repository or resolver,
+models, implementation, and private analysis helpers together.
 
-## Key Interfaces
+* `model/` - the small set of app-level models composed across domains.
+* `signing/` - certificates, signer history, trust, algorithms, and signing-scheme inspection.
+* `permissions/` - one app's declared and used permissions and typed protection metadata.
+* `components/` - activities, services, receivers, providers, intent filters, and path permissions.
+* `manifest/` - binary manifest parsing and readable XML rendering.
+* `installsource/` - raw installer chain and source classification.
+* `devicefeatures/` - device capabilities and app/device requirement comparison.
+* `packaging/` - installed splits, native libraries, and APK size.
+* `usagestats/` and `storagestats/` - permission-gated device statistics.
+* `export/` - APK and icon export.
+* `sdkversion/` - Android version labels.
 
-- `InstalledAppsRepository.apps(): Flow<List<InstalledApp>>` - Live list of all installed apps
-- `AppDetailRepository.details(reference: AppReference): Result<AppDetail>` - Full installed-package
-  or APK-file details
-- `DeviceFeaturesRepository.deviceFeatures(): DeviceFeatures` - Memoized once per process from a single
-  `getSystemAvailableFeatures()` call. Device features cannot change without a reboot, so there is no
-  flow, no observer, and no invalidation. Never call `hasSystemFeature` in a loop instead — that is N
-  binder calls for an answer one call already gave
-- `ManifestParser.manifest(reference: AppReference): Result<ParsedManifest>` - Readable manifest.
-  Installed packages parse the base path directly and report additional split count; opening
-  `AndroidManifest.xml` from merged resources can resolve to an arbitrary split.
-- `AppExportManager` - Writes an APK or natural-resolution icon for an `AppReference` to a
-  user-selected document URI
-- `StorageStatsRepository.isPermissionGranted: StateFlow<Boolean>` - Usage access permission state
-- `UsageStatsRepository.isPermissionGranted: StateFlow<Boolean>` - Usage stats permission state
+Keep the Hilt bindings grouped by these domains. A new independent repository family earns its own
+domain package; do not return to flat `analysis/`, `model/`, or `util/` grab-bags.
 
-## Signing Certificate Semantics
+## Repository and Cache Boundaries
 
-- `SigningInfo.apkContentsSigners` contains the current signer set. Multiple current signers are one
-  package identity and cannot use signing-key rotation.
-- For a single signer, `SigningInfo.signingCertificateHistory` is Android's verified rotation
-  lineage in oldest-to-current order; its final entry is the current certificate. Keep current and
-  past certificates as separate lists in `AppSigning` rather than attaching role flags to
-  `Certificate`.
-- Historical certificates identify keys previously trusted for the package. Do not claim they can
-  sign normal updates; update and rollback capabilities depend on Android's lineage capabilities.
-- Preserve X.509 validity as `Instant`. Convert to local dates only for display, and compare the
-  exact instants when determining validity.
-- Equal issuer and subject names mean self-issued, not necessarily self-signed. Label a certificate
-  self-signed only after its signature verifies with its own public key.
-- Assess recognized signature algorithms in the certificate domain model. The assessment covers
-  the digest only; unsupported names remain unknown, and overall security also depends on key type
-  and size. Feature ViewModels may map the typed result but must not duplicate its policy.
-- `PackageManager`'s `SigningInfo` does not expose which signing scheme(s) an APK uses.
-  `ApkSigningBlockAnalyzer` is an injected interface whose implementation reads the APK file directly
-  (`applicationInfo.sourceDir`, which `AppDetailRepositoryImpl` already sets correctly for both
-  installed packages and APK files). It verifies v1 by reading the signed manifest through
-  `JarFile`'s verifier, then locates the APK Signing Block immediately before the ZIP End Of Central
-  Directory record and reads its known v2/v3/v3.1 ID-value pairs. Every step is defensive: any
-  structural surprise or verification failure yields `null` rather than a guessed version list, per
-  this module's "never throw" rule. `AppDetailRepositoryImpl` invokes it only in the single-app flow,
-  not from the bulk `AppSigningRepositoryImpl` scan, so the extra file I/O is not paid for every
-  installed app merely to populate the device-wide certificate index.
+`InstalledAppsRepository` is the live source for installed apps. `AppDetailRepository` orchestrates
+the domain analyzers for one installed package or APK file.
+
+App-detail cache entries describe the app only. Do not fold device-dependent availability into a
+cached `AppDetail`; consumers combine app facts with device repositories separately.
+
+`PackageChangesObserver` invalidates installed-package data. APK-file inputs and device state have
+different lifecycles and must not be smuggled into that cache key.
+
+Expensive device-wide signing work is shared lazily. Single-app signing-scheme inspection stays in
+the app-detail path so merely collecting the device-wide signer index does not read every APK signing
+block.
+
+## Signing Semantics
+
+* `apkContentsSigners` is the current signer set. Multiple current signers form one package identity
+  and cannot use signing-key rotation.
+* For one current signer, `signingCertificateHistory` is Android's verified rotation lineage in
+  oldest-to-current order. Keep current and historical certificates as separate lists.
+* Historical certificates are previously trusted keys. Do not claim they can sign normal updates;
+  capabilities depend on lineage metadata Android does not expose here.
+* Preserve X.509 validity as `Instant`. Convert only for display and compare exact instants.
+* Equal issuer and subject means self-issued, not self-signed. Call a certificate self-signed only
+  after verifying its signature with its own public key.
+* Signature-algorithm assessment describes the digest only. Unsupported names stay unknown, and
+  overall security also depends on key type and size.
+* `SigningInfo` does not expose APK signing schemes. Scheme detection reads the APK directly,
+  verifies v1 through the JAR verifier, and parses recognized v2/v3/v3.1 signing-block IDs.
+* Structural ambiguity or verification failure yields unknown scheme data, never a guessed list.
 
 ## Device Requirement Semantics
 
-`AppDetail` describes an app; device availability describes a *pairing* of an app and a device. Keep
-them apart: `AppDetailRepositoryImpl` caches `AppDetail` keyed by package and invalidated by
-`PackageChangesObserver`, so folding device state into it would make cached entries depend on a
-second input the key does not mention and the invalidation does not track. Consumers inject both
-repositories and combine them while mapping to state.
+`AppDetail` describes what an app requires; device features describe what this device provides.
+Consumers combine the two while mapping UI state.
 
-`NativeLibraries` follows the same split: it holds only what the APK ships (ABIs, `.so` filenames).
-`Build.SUPPORTED_ABIS` is read where it's consumed (see `GeneralInfoViewModel`), not folded into the
-cached model — it's a plain static field, not an expensive call, so it doesn't warrant a repository
-the way `DeviceFeaturesRepository` does for `getSystemAvailableFeatures()`.
+Device feature discovery is memoized because the platform feature set cannot change without reboot.
+Read the complete set once rather than calling `hasSystemFeature` repeatedly.
 
-## Component Intent Filters
+Hardware feature names and OpenGL ES versions are different domain variants. Device support can be
+available, unavailable, or unknown; a failed device query must not become "missing."
 
-- `PackageInfo` exposes component metadata but not its declared intent filters.
-- `queryIntentActivities` and the other `queryIntent*` APIs only return filters that match an intent
-  the caller already knows, so they cannot enumerate an app's entry points.
-- `ManifestParser.componentIntentFilters()` reads the base manifest and every installed split manifest
-  with Android's public binary XML resource parser. It normalizes relative component class names before
-  joining filters back to `PackageInfo` components. Component kind is part of the key because Android
-  permits different component types to share the same class name.
-- Every filter preserves its actions, categories, data rules, priority, order, and link-verification
-  request. Multiple `<data>` tags accumulate as rules on one filter, matching Android's semantics.
-  `host` and `port` are the one exception: Android pairs them per `<data>` tag into a single
-  authority match, so they are combined into one `Host` rule (`host:port`) instead of two
-  independently flattened rules — otherwise two `<data>` tags with different host/port combinations
-  would render as an ambiguous cross-product. A `port` without a `host` is dropped, matching
-  Android, which ignores it.
-- Reading every installed split manifest is required, not best-effort: if any split manifest cannot
-  be read, `componentIntentFilters()` fails for the whole package rather than silently returning
-  filters from only the splits it could read. Partial results would understate a component's real
-  entry points and read as "no intent filters" to callers that only check `Result.isSuccess`.
+Native-library data follows the same boundary: the cached app model records what the APK ships.
+Compare it with `Build.SUPPORTED_ABIS` at the consuming layer.
 
-## External Entry Semantics
+## Manifest and Component Semantics
 
-- These rules support the Components screen's technical filter. They are not a risk verdict and do
-  not feed the hub — that needs a deliberate rule set, not just accurate raw data.
-- Exported alone is not a finding. Launcher activities are expected to be exported and are excluded.
-- An activity is unguarded only when launcher status is known to be false and no permission is required.
-- Services and receivers are unguarded when exported without a required permission.
-- An exported provider is unguarded when either its top-level read or write permission is missing, or
-  any `<path-permission>` entry opens a path without one — see Content Provider Path Permissions.
-- APK activities have unknown launcher status. The technical `Unprotected` filter includes exported
-  activities without permission guards and may therefore include the launcher activity; the hub
-  does not interpret this as a finding.
+`PackageInfo` does not enumerate declared intent filters. Query APIs only return filters matching an
+intent the caller already knows, so manifest parsing is required.
 
-## Content Provider Path Permissions
+Parse the base manifest and every installed split manifest. Normalize relative component class names
+before joining filters to `PackageInfo` components, and include component kind in the key because
+different kinds may share a class name.
 
-- `ProviderInfo.pathPermissions` is populated by `PackageManager` whenever `GET_PROVIDERS` is
-  queried — unlike intent filters, no manifest parsing is needed, and the flag was already in use.
-  `resolvePathPermissions()` in `components/ContentProviderPathPermissions.kt` maps it to
-  `ProviderPathPermission`, and `PathPermission`'s
-  `type` int becomes the typed `ProviderPathMatchType` enum.
-- A `<path-permission>` can carve out access that the provider's top-level `readPermission` /
-  `writePermission` does not grant: an entry with neither permission set opens that specific path
-  regardless of what the provider otherwise requires. `ContentProvider.hasUnguardedPathPermission`
-  captures exactly that unambiguous case — it does not attempt to resolve full path-matching
-  precedence when multiple `<path-permission>` entries could overlap.
-- `isExternallyReachableWithoutPermission` folds this in: a provider is reachable without permission
-  if the top level is open **or** any path permission is. It deliberately does not flip the other
-  way — a blank top-level permission still leaves any path not covered by a `<path-permission>` open,
-  so path permissions can only add exposure to the verdict, never resolve it into "guarded."
+Preserve actions, categories, data rules, priority, order, and link-verification requests. Multiple
+`<data>` elements accumulate within one filter. Host and port are one authority rule; flattening them
+independently creates invalid cross-products. Ignore a port without a host, matching Android.
 
-## Dependencies
-- `api(projects.core.common)` - exposes common models and DispatcherProvider
+Split parsing is all-or-nothing. If any required split manifest fails, return failure rather than a
+partial result that callers could misread as "no filters."
+
+## External Reachability Semantics
+
+These are technical facts for component filtering, not a general security verdict.
+
+* Exported alone is not a finding.
+* Launcher activities are expected to be exported and are excluded from the installed-app
+  "unprotected" classification.
+* An installed activity is unguarded only when launcher status is known to be false and no permission
+  is required.
+* Services and receivers are unguarded when exported without a required permission.
+* A provider is unguarded when top-level read or write access is open or any path permission opens a
+  path.
+* APK-file activities have unknown launcher status. Their technical filter may include the launcher;
+  features must not promote that uncertainty into a finding.
+
+`ProviderInfo.pathPermissions` is already available when providers are queried. Model each path,
+match type, and optional read/write permission. A path entry with neither permission opens that path.
+
+Path permissions can add exposure but cannot prove an otherwise open provider is guarded: uncovered
+paths remain subject to the top-level permission.
+
+## Packaging Semantics
+
+Compute installed APK size from the same split list exposed to consumers so totals and breakdowns
+cannot diverge.
+
+Read native libraries from base and split ZIP entries. Keep one file record per library name and ABI;
+derive distinct ABI and library-name summaries rather than storing competing copies.
+
+Install-source models preserve the installing, initiating, and originating chain. Source
+classification is a pure function over that chain and app flags, not another platform resolver call.

--- a/core/common/AGENTS.md
+++ b/core/common/AGENTS.md
@@ -1,52 +1,30 @@
 # core:common Module
 
-## Purpose
-Foundation module with shared utilities depended on by nearly all other modules. Provides coroutine infrastructure, logging, persistence, resources, and shared models.
+## Purpose and Boundary
 
-## Package: `sk.styk.martin.apkanalyzer.core.common`
+Foundation module for infrastructure and models shared across otherwise independent domains. The
+package is `sk.styk.martin.apkanalyzer.core.common`.
 
-## Structure
+Keep this module small and dependency-safe. Feature-specific policy, UI components, and app-analysis
+logic do not belong here.
 
-```
-coroutines/
-  DispatcherProvider.kt   - Injectable dispatcher provider (main, default, io, unconfined)
-  Flows.kt                - Flow utility extensions
-  RunCatching.kt          - Result capture for suspend code that rethrows cancellation
-logger/
-  Logger.kt               - Timber + Firebase Crashlytics logging wrapper (object)
-resources/
-  ResourcesManager.kt     - Android resources access (strings, colors, dimensions)
-settings/
-  PersistenceRepository.kt        - Interface for DataStore preferences
-  DataStorePersistenceRepository.kt - Implementation
-  PersistenceModule.kt             - Hilt module
-  Key.kt                           - Preference key definitions (includes ColorAppScheme)
-model/
-  AppReference.kt         - Installed-package or APK-file reference shared across analysis and UI
-  AppSource.kt            - Enum: GooglePlay, SamsungGalaxyStore, AmazonAppstore, HuaweiAppGallery,
-                            XiaomiGetApps, FDroid, AuroraStore, Sideloaded, LocalInstall,
-                            SystemPreinstalled, Unknown. `isSideloaded` groups Sideloaded/LocalInstall/
-                            Unknown — the "not from a store, not system" cluster the Filter and
-                            App detail screens key their "Sideloaded" quick filter/badge off of
-  AppSize.kt              - Value class for file sizes with formatting
-clipboard/                - Clipboard access utilities
-digest/                   - Hash/digest utilities
-util/                     - General Android and formatting utilities
-```
+## Package Map
 
-## Key Exports
+* `coroutines/` - injectable dispatchers, flow helpers, and cancellation-safe result capture.
+* `logger/` - the repository logging facade.
+* `settings/` - generic typed DataStore persistence and preference keys.
+* `model/` - genuinely cross-module value types such as app references, source classification, and
+  file sizes.
+* `resources/`, `clipboard/`, and `digest/` - shared platform adapters and focused utilities.
 
-- `DispatcherProvider` - Inject in ViewModels/Repositories for coroutine dispatching
-- `Logger` - Static logging: `Logger.d("Tag", "msg")`, `Logger.e("Tag", throwable, "msg")`
-- `ResourcesManager` - Injectable Android resources access
-- `PersistenceRepository` - DataStore preferences abstraction
-- `AppSource` - App install source classification
-- `AppReference` - Type-safe reference to an installed package or an APK file
-- `AppSize` - File size value with display formatting
-- `ColorAppScheme` - Day/Night/FollowSystem enum
+## Durable Contracts
 
-## Dependencies
-- Firebase Crashlytics (for Logger)
-- Timber
-- DataStore Preferences
-- Hilt
+* Inject `DispatcherProvider`; never hardcode a dispatcher.
+* Cancellation-safe result helpers must rethrow coroutine cancellation rather than convert it into
+  a failure value.
+* Use `Logger`, never Timber or Crashlytics directly outside this module.
+* `AppReference` is the shared type-safe distinction between an installed package and an APK file.
+* `AppSource.isSideloaded` intentionally groups sideloaded, local-install, and unknown sources while
+  excluding recognized stores and system-preinstalled apps.
+* Add preference keys to the typed persistence contract rather than creating feature-local
+  DataStore instances.

--- a/core/navigation/AGENTS.md
+++ b/core/navigation/AGENTS.md
@@ -1,42 +1,23 @@
 # core:navigation Module
 
 ## Purpose
-Provides the custom Navigation 3 infrastructure for multi-stack (bottom-nav style) navigation.
 
-## Package: `sk.styk.martin.apkanalyzer.core.navigation`
+Provides the Navigation 3 infrastructure for independent bottom-navigation stacks. The package is
+`sk.styk.martin.apkanalyzer.core.navigation`.
 
-## Key Classes
+## Navigation Model
 
-### `NavigationState`
-Manages a top-level stack (for bottom nav tabs) and per-tab sub-stacks.
-- `currentTopLevelKey: NavKey` - Currently active top-level tab
-- `currentKey: NavKey` - Currently visible screen (deepest in current sub-stack)
-- `topLevelKeys: Set<NavKey>` - All registered top-level keys
-- `currentSubStack: NavBackStack<NavKey>` - Stack for the current tab
+`NavigationState` owns one stack for top-level history and one sub-stack per top-level key.
+Switching tabs must preserve each tab's sub-stack.
 
-### `rememberNavigationState(startKey: NavKey, topLevelKeys: List<NavKey>): NavigationState`
-Composable factory. Creates one `NavBackStack` per top-level key + one top-level stack.
+`Navigator.navigate()` has three distinct behaviors:
 
-### `NavigationState.toEntries(entryProvider: (NavKey) -> NavEntry<NavKey>): SnapshotStateList<NavEntry<NavKey>>`
-Converts all sub-stacks into decorated nav entries for use with `NavDisplay`.
+* A different top-level key switches to that stack.
+* The current top-level key resets its sub-stack.
+* A non-top-level key is pushed onto the current sub-stack.
 
-### `Navigator`
-Imperative navigation controller wrapping `NavigationState`.
-- `navigate(key: NavKey)` - Smart routing: top-level switch, same-tab reset, or sub-stack push.
-- `goBack()` - Pop current sub-stack, go back to the previous top-level tab, or invoke the host's
-  `onBackAtRoot` callback from the start destination.
+Back navigation first pops the current sub-stack, then returns to the previous top-level stack. At
+the start destination root it invokes the host-provided root-back callback.
 
-## Usage Pattern
-```kotlin
-val navigationState = rememberNavigationState(startKey = AppsNavKey, topLevelKeys = TOP_LEVEL_KEYS)
-val navigator = remember { Navigator(navigationState) }
-
-NavDisplay(
-    entries = navigationState.toEntries(entryProvider),
-    onBack = navigator::goBack,
-)
-```
-
-## Dependencies
-- `apkanalyzer.library` + `apkanalyzer.compose` plugins
-- Navigation 3 runtime + UI, lifecycle-viewmodel-navigation3
+Construct state with the complete top-level key set, retain the `Navigator`, and convert state
+through `toEntries()` for `NavDisplay`. Do not reproduce stack management in a feature or app host.

--- a/core/ui-library/AGENTS.md
+++ b/core/ui-library/AGENTS.md
@@ -1,91 +1,31 @@
 # core:ui-library Module
 
-## Purpose
-Design system module providing all reusable Compose UI components, theme, icons, animations, and modifiers. **Feature modules must never import `androidx.compose.material3` — they consume it only through the wrappers here.** (`app` is the one exception: it uses material3 directly for `Scaffold` and theme plumbing in `ApkAnalyzerActivity.kt`/`ApkAnalyzerApp.kt`.)
+## Purpose and Boundary
 
-## Package: `sk.styk.martin.apkanalyzer.core.uilibrary`
+The shared Compose design system: theme, icons, animation metadata, reusable components, modifiers,
+and lazy-list helpers. The package is `sk.styk.martin.apkanalyzer.core.uilibrary`.
 
-## Structure
+Feature modules must not import Material3 directly. Wrap new Material3 usage here before consuming it
+from a feature. The `app` module is the only exception for shell-level `Scaffold` and theme plumbing.
 
-```
-theme/
-  Theme.kt          - ApkAnalyzerTheme, AppTheme (colors + typography access)
-  Color.kt          - ApkAnalyzerColorPalette, Light/Dark color definitions
-  Typography.kt     - ApkAnalyzerTypography, font setup
-  Shapes.kt         - Shape definitions
-components/          - See the component inventory below
-icons/
-  ApkAnalyzerIcons.kt - Icon constants (Apps, Permissions, Statistics, etc.)
-  app/PackageIconFetcher.kt, PackageIconModule.kt - Coil fetcher for `AppReference` icons
-animation/
-  NavEntryTransitions.kt - bottomEntryMetadata(), slideFromEndEntryMetadata()
-lazylist/
-  ItemsIndexedWithPosition.kt - LazyList item helper carrying first/middle/last position
-modifier/
-  CardModifier.kt, CollapsingHeader.kt, CollapsingToolbar.kt, Shimmer.kt,
-  SharedTransitionModifier.kt (LocalSharedTransitionScope)
-util/
-  Lerp.kt
-```
+## Package Map
 
-## Component Inventory
+* `theme/` - `ApkAnalyzerTheme`, `AppTheme`, colors, typography, and shapes.
+* `components/` - reusable UI primitives and composed controls.
+* `icons/` - `ApkAnalyzerIcons` and app-icon loading.
+* `animation/` - Navigation 3 transition metadata.
+* `modifier/` and `lazylist/` - shared interaction, layout, and list behavior.
 
-One file per component in `components/`. **The composable's name does not always match its file
-name** — check here before calling one:
+Search `components/` by composable name before adding or calling a component. The notable naming
+exception is `InactiveSearchBar`, which lives in `SearchBarInactive.kt`.
 
-| Composable | File |
-|---|---|
-| `AppIcon` | `AppIcon.kt` |
-| `BottomSheet` | `BottomSheet.kt` |
-| `Button`, `TextButton` | `Button.kt` |
-| `Checkbox` | `Checkbox.kt` |
-| `Chip`, `OutlinedChip` | `Chip.kt` |
-| `DateRangePickerDialog` | `DateRangePickerDialog.kt` |
-| `HashBox` | `HashBox.kt` |
-| `Icon` | `Icon.kt` |
-| `IconButton` | `IconButton.kt` |
-| `LabeledHashBox` | `LabeledHashBox.kt` |
-| `LoadingSpinner` | `LoadingSpinner.kt` |
-| `MultiSelectorChip` | `MultiSelectorChip.kt` |
-| `NavigationBar` (+ `NavigationBarItem` data class) | `NavigationBar.kt` |
-| `RangeSlider` | `RangeSlider.kt` |
-| `SearchBarActive` | `SearchBarActive.kt` |
-| **`InactiveSearchBar`** — note the inverted name | `SearchBarInactive.kt` |
-| `SelectorChip` | `SelectorChip.kt` |
-| `SkeletonBox` | `SkeletonBox.kt` |
-| `Switch` | `Switch.kt` |
-| `Tag` | `Tag.kt` |
-| `Text` | `Text.kt` |
-| `Toolbar` | `Toolbar.kt` |
+## Component Rules
 
-## Key Exports
-
-- `ApkAnalyzerTheme(isDarkTheme: Boolean, content: @Composable () -> Unit)` - Root theme wrapper
-- `AppTheme.colors` - Current color palette
-- `AppTheme.typography` - Current typography styles
-- `ApkAnalyzerIcons` - Icon constants object
-- `NavigationBar` / `NavigationBarItem` - Bottom nav implementation
-- `LocalSharedTransitionScope` - CompositionLocal for shared element transitions
-
-## Dependencies
-
-- `androidx.compose.material3`
-- `androidx.compose.material:material-icons-extended`
-- `kotlinx-collections-immutable`
-- `coil-compose`, `coil-core`
-- `navigation3-ui`
-- `projects.core.common`
-
-## Rules
-
-- All new Material3 component usage must be wrapped here before use in features.
-- Components should accept theme-consistent defaults.
-- Every component file must include `@Preview` functions.
-- When a styled status `Chip` is interactive, use its `onClick`/`onLongClick` overload so the shared
-  component owns semantics and a shape-clipped ripple. Do not add `Modifier.clickable` to the
-  non-interactive overload at a feature call site.
-- `Chip` and `Tag` are not interchangeable. `Chip` is for selectable/interactive filter chips
-  (larger touch target, `labelLarge`/`labelMedium` text). `Tag` is a small non-interactive inline
-  badge for a fact on a list row (`labelSmall`, tighter padding) — e.g. Exported, Launcher, a
-  permission flag. Reach for `Tag` first when labeling a row; a second private copy of either shape
-  belongs here, not in a feature module.
+* Components accept theme-consistent defaults and every component file includes private previews.
+* Feature colors and typography come from `AppTheme`; icons come from `ApkAnalyzerIcons`.
+* Interactive status `Chip` usage goes through the component's click and long-click overload so the
+  shared component owns semantics and its shape-clipped ripple.
+* `Chip` is an interactive selector with a full touch target. `Tag` is a compact, non-interactive
+  inline fact on a row. Do not use them interchangeably.
+* A second copy of a shared shape, control, loading state, or interaction pattern belongs here rather
+  than in another feature.

--- a/core/user-preferences/AGENTS.md
+++ b/core/user-preferences/AGENTS.md
@@ -1,48 +1,26 @@
 # core:user-preferences Module
 
-## Purpose
-Two small, independent DataStore-backed repositories for lightweight user-facing state: recently-viewed apps (an opt-in MRU list of packages resolved back to full `InstalledApp` objects) and search query history (a raw-string MRU list). Both are thin wrappers over `core:common`'s `PersistenceRepository` (DataStore).
+## Purpose and Boundary
 
-## Package: `sk.styk.martin.apkanalyzer.core.userpreferences`
+Owns lightweight user-facing history backed by `core:common` persistence. The package is
+`sk.styk.martin.apkanalyzer.core.userpreferences`.
 
-## Structure
+Recently viewed apps and search history are independent repository families. Keep their public
+contracts separate even though both use most-recently-used ordering.
 
-```
-RecentlyViewedAppsRepository.kt      - Public interface: recents(), addRecent(packageName), hasRecents()
-RecentlyViewedAppsRepositoryImpl.kt  - internal impl; joins persisted recent package names with live InstalledApp data, gated by an enabled toggle
-SearchHistoryRepository.kt           - Public interface: queries(), addQuery(query), removeQuery(query), clearAll()
-SearchHistoryRepositoryImpl.kt       - internal impl; simple MRU list persisted via PersistenceRepository
-di/
-  UserPreferencesModule.kt           - Hilt @Binds module (SingletonComponent), binds both repositories, @Singleton scope
-```
+## Recently Viewed Semantics
 
-## Key Interfaces
+Recently viewed apps are opt-in. Disabling the preference switches the exposed flow to an empty list
+immediately.
 
-```kotlin
-interface RecentlyViewedAppsRepository {
-    fun recents(): Flow<List<InstalledApp>>
-    suspend fun addRecent(packageName: String)
-    suspend fun hasRecents(): Boolean
-}
+Persist package names, then resolve them against the live installed-app list. Packages that are no
+longer installed disappear from reads without rewriting persisted history. Preserve this behavior
+unless the storage migration and cleanup policy are changed deliberately.
 
-interface SearchHistoryRepository {
-    fun queries(): Flow<List<String>>
-    suspend fun addQuery(query: String)
-    suspend fun removeQuery(query: String)
-    suspend fun clearAll()
-}
-```
+Adding a recent item moves it to the front, removes duplicates, and caps the list at eight.
 
-## Notable Implementation Details
+## Search History Semantics
 
-- `RecentlyViewedAppsRepositoryImpl.recents()` is gated by `Key.RecentlyViewedAppsEnabled`: disabled → always `flowOf(emptyList())`; enabled → `combine`s the persisted package-name list with `installedAppsRepository.apps()` and `mapNotNull`s away any package that's no longer installed. This **silently self-prunes uninstalled apps at read time without ever writing back** to the persisted key — the underlying stored list can grow stale with uninstalled package names that just get filtered on every read.
-- `flatMapLatest` on the enabled flag means toggling the preference live-switches between empty and combined flows reactively.
-- `addRecent`/`addQuery` both hand-roll the same "move-to-front, dedupe, cap length" MRU logic independently (`MAX_RECENTS = 8` vs. `MAX_HISTORY = 15`). If a third such repository is ever added, factor this into a shared helper in `core:common` instead of copying it a third time.
-- Both `*Impl` classes are `internal`; only interfaces are public, bound via Hilt `@Binds`.
-- No `shareIn`/`stateIn` caching on either flow (unlike `core:app-permissions`) — each collector independently re-triggers DataStore reads/combine.
-- Underlying keys live in `core:common`'s `Key.kt`, not here: `Key.RecentlyViewedApps: Key<List<String>>`, `Key.RecentlyViewedAppsEnabled: Key<Boolean>`, `Key.SearchHistory: Key<List<String>>`.
-
-## Dependencies
-- `apkanalyzer.library` + `apkanalyzer.hilt` plugins (no `parcelize` — no Parcelable models here)
-- `implementation(projects.core.apps)` — `InstalledAppsRepository`, `InstalledApp`
-- `implementation(projects.core.common)` — `PersistenceRepository`, `Key`
+Search history stores raw query strings in most-recently-used order. Adding a query moves it to the
+front, removes duplicates, and caps the list at fifteen. Removal and clearing update the persisted
+list rather than maintaining feature-local state.

--- a/feature/app-detail/AGENTS.md
+++ b/feature/app-detail/AGENTS.md
@@ -1,278 +1,147 @@
 # feature:app-detail Module
 
 ## Purpose
-Displays detailed information about a single app (installed package or APK file). Shows general info, permissions, components, certificates, features, with sub-navigation to detail sections.
 
-## Sub-modules
-- `api` - Contains `AppDetailNavKey(detailInput: AppDetailInput)` and `AppDetailInput` sealed interface
-- `impl` - Full implementation
+Displays detailed analysis for an installed package or APK file: general information, permissions,
+components, certificates, device requirements, manifest, split APKs, and native libraries.
 
-## Package: `sk.styk.martin.apkanalyzer.feature.appdetail.impl`
+The API module owns the cross-feature navigation input and distinguishes installed packages from APK
+files. Implementation code uses the package
+`sk.styk.martin.apkanalyzer.feature.appdetail.impl`.
 
-## API Module Key Types
+## Package Map
 
-```kotlin
-@Serializable
-data class AppDetailNavKey(val detailInput: AppDetailInput) : NavKey
+* The root implementation package owns the hub State/Action/Event/ViewModel and input adapters.
+* `components/` owns interaction and loading/error UI shared across detail sections.
+* `insight/` owns the feature-level "Worth knowing" policy.
+* `generalinfo/`, `permissions/`, `appcomponents/`, `certificates/`, `requirements/`, `manifest/`,
+  `splitapks/`, and `nativelibraries/` each own one detail destination.
+* `navigation/` owns the feature entry provider and internal destination keys.
 
-@Serializable
-sealed interface AppDetailInput {
-    @Serializable data class InstalledPackage(val packageName: String) : AppDetailInput
-    @Serializable data class ApkFile(
-        val apkFilePath: String,
-        val lifetime: ApkFileLifetime = ApkFileLifetime.Persistent,
-    ) : AppDetailInput
-}
-```
+Each destination keeps its own State/Action/Event/ViewModel set. Runtime navigation inputs use
+assisted injection and seed ViewModel state exactly once.
 
-## Impl Structure
+## Cross-Cutting Interaction Rules
 
-```
-navigation/
-  AppDetailEntryProvider.kt  - appDetailEntries(navigator)
-  GeneralInfoNavKey.kt       - Internal nav key for general info sub-screen
-  PermissionsNavKey.kt       - Internal nav key for the permissions sub-screen
-  ComponentsNavKey.kt        - Internal nav key for the components sub-screen
-  CertificatesNavKey.kt      - Internal nav key for the certificates sub-screen
-  RequirementsNavKey.kt      - Internal nav key for the device requirements sub-screen
-  ManifestNavKey.kt          - Internal nav key for the readable Android manifest
-  SplitApksNavKey.kt         - Internal nav key for the split APK files sub-screen
-  NativeLibrariesNavKey.kt   - Internal nav key for the native library files sub-screen
-AppDetailScreen.kt           - Main detail screen Composable
-AppDetailViewModel.kt        - Uses @HiltViewModel with AssistedFactory for AppDetailInput
-AppDetailState.kt            - Loading/Loaded/Error states with full app detail data
-AppDetailAction.kt           - User actions (retry, view manifest, export, navigate sections)
-AppDetailEvent.kt            - Navigation/system events
-AppDetailInputAdapters.kt    - Maps the navigation DTO to shared `AppReference`
-components/
-  AppDetailBadge.kt          - Badge classification (Sideloaded, DangerousPermissions, Unused, Large, System, etc.)
-  AppDetailToolbar.kt        - Collapsing toolbar for the hub
-  InfoRowItem.kt             - InfoRow + InfoRowItem + RationaleBottomSheet, shared by every sub-screen
-  SectionScaffold.kt         - SectionLoading + SectionError, the Loading/Error branch every sub-screen shares
-  DetailField.kt             - The labelled, tap-to-copy field every item bottom sheet is built from.
-                               Use it; do not add a private copy — there were three before it was extracted
-  SplitApkExportBottomSheet.kt - Persistent explanation after exporting only the base of a split app
-insight/
-  AppDetailInsight.kt          - Feature-owned "Worth knowing" finding model, plus the `SensitiveAccess` enum
-  AppDetailInsightEvaluator.kt - Pure policy evaluator that turns an `AppDetail` into a list of insights
-generalinfo/                 - General info sub-screen
-permissions/                 - Permissions sub-screen (see below)
-appcomponents/               - Components sub-screen (see below). Named `appcomponents`, not
-                               `components`, because `components/` already holds shared UI pieces.
-certificates/                - Signing certificate detail sub-screen
-requirements/                - Device requirements (uses-feature) sub-screen (see below)
-manifest/                    - Searchable readable Android manifest for installed and APK inputs
-splitapks/                   - Split APK files sub-screen (see below)
-nativelibraries/             - Native library files sub-screen (see below)
-```
+Every detail list row follows **tap = explain, long-press = copy**. If a row has no explanation yet,
+add the missing sheet rather than disabling its tap affordance.
 
-Each sub-screen directory carries its own State/Action/Event/ViewModel/Screen set, same MVI shape
-as the hub.
+Use the shared detail-field and section loading/error components. Do not create private copies in a
+sub-screen.
 
-### `permissions/`
+Initial scopes, filters, or focused items belong in assisted constructor state or saveable UI state,
+not a `LaunchedEffect` that can reapply after configuration change and overwrite a user's choice.
 
-```
-PermissionsScreen.kt              - Pinned toolbar, collapsing filter header, sectioned list
-PermissionDetailBottomSheet.kt    - The item sheet: every raw field for one permission, tap a field to copy
-PermissionResources.kt            - Enum -> @StringRes / icon mapping, kept out of the screen,
-                                    incl. `grantExplanationRes` (protection level x grant state)
-PermissionsViewModel.kt           - Assisted-injected; combines a loaded source with the active narrowing
-PermissionsState.kt               - Loading/Error/Loaded plus PermissionItem, PermissionSection,
-                                    PermissionScope / GrantState enums, and multi-select filter state
-PermissionsAction.kt              - Retry, ChangeQuery, SelectScope, property filter toggles, ClearNarrowing, CopyValue
-PermissionsEvent.kt               - ShowCopiedFeedback
-PermissionDescriptionProvider.kt  - @Singleton; curated string -> system loadDescription -> declaring package
-```
+When a verdict and icon describe the same fact, derive both from one predicate.
 
-Narrowing (query, scope, property filters) lives in the ViewModel, not the Composable — the screen
-receives only the already-filtered sections. Scope is a single-choice chip that opens a bottom sheet
-rather than a tab row, and it renders only when the app defines permissions of its own. Protection
-level and grant state use multi-choice selector chips whose empty state applies no filter. Grant
-pills and the grant-state selector render only in `InstalledPackage` mode.
+## Hub and Insight Policy
 
-The sheet explains *why* a permission has its grant state — the answer differs per protection level
-(you allowed it / signing key match / system rules / automatic at install), so `grantExplanationRes`
-keys on protection level x grant state and replaces the generic protection-level explanation. It
-falls back to that generic sentence in `ApkFile` mode, where there is no grant state. A signature
-permission is granted exactly when the keys match, so no certificate comparison is needed; the
-`Privileged` flag is the one case that softens the wording. `PermissionItem.isSelfDeclared` marks
-permissions the analysed app declares itself, which is the common source of granted signature
-permissions.
+The hub presents neutral app facts separately from the deliberately narrow "Worth knowing" policy.
+The insight evaluator currently covers debug access, granted high-impact permissions, questionable
+signing validity or trust, sideloading, and materially old target SDK levels.
 
-### `appcomponents/`
+Do not promote raw component exposure, merely requested dangerous permissions, backup, or cleartext
+flags into findings without an explicit product rule. Camera and microphone remain contextual facts;
+high-impact access is limited to background location, messages, call history, contacts, and calendar.
 
-```
-ComponentsScreen.kt               - Pinned toolbar, collapsing filter header, sectioned list
-ComponentDetailBottomSheet.kt     - The item sheet, per component type
-IntentFiltersScreen.kt            - Searchable filters for one component; each row summarizes one
-                                    filter and opens its full structured detail sheet
-IntentFiltersViewModel.kt         - Assisted-injected with the app input and component class name
-IntentFilterDetailBottomSheet.kt  - Full actions, categories, URI/content rules, and matching metadata
-ComponentResources.kt             - Enum -> @StringRes / icon mapping
-ComponentsViewModel.kt            - Assisted-injected with the initial scope and filters
-ComponentsState.kt                - Loading/Error/Loaded plus ComponentItem, ComponentDetails,
-                                    ComponentScope / ComponentFilter / ComponentType / ComponentFlag
-ComponentsAction.kt / ComponentsEvent.kt
-```
+Badge and filter predicates reuse typed policy from `core:apps`; features must not recreate platform
+classification rules.
 
-One screen for all four component types; the scope selector carries the type, so the hub's four
-component rows deep-link with their scope preselected. Under scope `All` the list is sectioned by
-type. Exported items sort first. `isGuarded` folds a provider's read/write permissions, its
-`<path-permission>` entries, and the other types' single `permission` into one flag, so
-`isUnprotected` (exported and unguarded) means the same thing everywhere. The component sheet shows
-every declared intent filter as the requests, links, and content that can reach that component, plus
-— for providers — every `<path-permission>` entry with its path, match type explanation, and
-per-path read/write permission (`components_detail_section_path_permissions`); a path entry with
-neither permission set is what makes an otherwise-guarded provider `isUnprotected`. It shows only a
-filter count and links to a searchable full-screen list; filter counts do not appear on component
-rows because quantity is not a risk signal. A manifest parsing failure remains explicit in the
-component sheet but does not fail the rest of app detail. Path permissions are extracted and drive
-the Components screen's own filter now, but exposure still does not feed the hub's "Worth knowing"
-card — that needs a deliberate rule, not just accurate raw data.
-`isLaunchable` is deliberately *not* `isUnprotected`: it is exported-and-unguarded (which is exactly
-"we are allowed to start it") in `InstalledPackage` mode, for activities and receivers only. Launcher
-activities are the most launchable thing there is, so reusing `isUnprotected` would hide the run
-button precisely where it is most useful. Services are excluded because background-start restrictions
-make `startService` fail or no-op from a backgrounded app, and providers have nothing to start.
-**A successful `startActivity` only means the intent was accepted** — the target may finish itself
-immediately when it needs extras, so the confirmation says a request was sent, never that something
-opened.
+## Permission Screen Semantics
 
-Launcher activities are excluded from `isUnprotected`: they are exported with no permission guard by
-definition, so warning about them is a false positive that devalues the real ones. They are excluded
-from the `Unprotected` filter for the same reason, and the sheet explains why being exported is
-expected there rather than claiming a permission guards it. APK-file analysis cannot resolve
-launcher status, so its technical `Unprotected` filter may include the launcher; this state does not
-feed the hub's findings.
+Narrowing lives in the ViewModel. The UI receives already-filtered, sectioned data.
 
-**The initial scope and filters are `@Assisted` constructor parameters, not a `LaunchedEffect`.**
-They seed the ViewModel's `narrowing` flow exactly once at construction; the ViewModel survives
-configuration change, so a rotation cannot re-apply them over a choice the user has since made. The
-same trap applies to `PermissionsScreen`'s `focusedPermission`, which is why the open sheet is keyed
-by `rememberSaveable` name rather than restored by an effect.
+* Scope is single-choice and appears only when the app declares permissions.
+* Protection and grant filters are multi-choice; an empty selection means no filtering.
+* Grant state appears only for installed packages.
+* A permission the app declares itself is tracked explicitly because that explains many granted
+  signature permissions.
+* Grant explanations depend on both protection level and grant state. APK-file mode has no grant
+  state and falls back to a protection-level explanation.
 
-### `certificates/`
+Permission rows and their detail sheets expose typed domain values and localized explanations, never
+raw Android protection integers.
 
-The certificate screen shows current signing certificates first. A separate Signing history
-section follows only when Android provides a verified rotation chain; previous keys are displayed
-newest-to-oldest and the original key is identified explicitly. Certificate fingerprints are
-always visible in SHA-256, SHA-1, MD5 order; public-key fingerprints use the same shared `HashBox`
-component but remain collapsed until requested. Signing multiplicity and key-rotation data come
-from the explicit current and past certificate lists in `AppDetail.signing`, and the "Current
-signers" fact uses `AppSigning.hasMultipleSigners` directly rather than re-deriving it from the
-certificate list size, so there is one predicate for that fact. The SCHEME row, adjacent to
-ALGORITHM in the first current-certificate card, shows `AppSigning.signingSchemeVersions`
-(`core:apps`'s `ApkSigningBlockAnalyzer` interface, roadmap `FR-36`) and is omitted entirely when that list is
-null — an unparseable or ambiguous signing block never renders a version list, per the module's
-"omit rather than guess" rule for this fact.
+## Component Screen Semantics
 
-### `requirements/`
+One screen handles activities, services, receivers, and providers. Scope selects the type; "All"
+sections by type. Exported items sort first.
 
-```
-RequirementsScreen.kt             - Pinned toolbar, miss summary, required/optional sections
-RequirementResources.kt           - Feature name -> @StringRes / icon maps, raw-name fallback
-RequirementsViewModel.kt          - Assisted-injected; combines AppDetail with DeviceFeaturesRepository
-RequirementsState.kt              - Loading/Error/Loaded plus RequirementSection, RequirementItem
-                                    (Hardware / OpenGlEs) and RequirementAvailability
-RequirementsAction.kt / RequirementsEvent.kt
-```
+`isUnprotected` means exported and unguarded, with these rules:
 
-The required/optional split is the point of the data, so it is the section structure rather than a
-filter. **Only misses are marked** — a column of green ticks is noise, so `Available` renders no
-marker and a device whose features could not be read yields `Unknown`, which also renders nothing.
-Missing optional requirements are worded more softly than missing required ones: missing an optional
-feature is by definition fine and only explains why part of the app does nothing.
+* Launcher activities are excluded for installed packages because their exported state is expected.
+* Other activities require known non-launcher status and no permission guard.
+* Services and receivers require no permission guard.
+* Providers are unguarded when top-level read or write access is open or a path permission opens a
+  path.
+* APK-file launcher status is unknown, so its technical filter may include the launcher. Do not turn
+  that uncertainty into a hub finding.
 
-OpenGL ES is a version comparison, not a set lookup, so its miss names both sides ("Needs 3.1 · this
-device has 3.0") and its raw identifier is the hex the manifest's `android:glEsVersion` actually
-contains. The check runs in **both** analysis modes: the platform does not enforce `uses-feature` at
-install time, so a sideloaded app can sit on a device that cannot satisfy its own requirements.
+`isLaunchable` is a different predicate. It means an installed activity or receiver can receive the
+requested launch intent. Do not derive it from `isUnprotected`: launcher activities are expected to
+be launchable. Services and providers are excluded.
 
-There is no search and no scope selector. The `Libraries` scope from the design doc needs
-`<uses-library>` extraction (roadmap `FR-44`), which does not exist yet.
+A successful `startActivity` means Android accepted the request, not that the target stayed open.
+User-facing confirmation must not claim an app or screen opened.
 
-### `splitapks/`
+Component details show complete intent-filter structure and provider path permissions. A manifest
+parsing failure remains explicit in the sheet but does not fail the rest of app detail.
 
-```
-SplitApksScreen.kt              - Pinned toolbar, collapsing search header, flat list sorted by kind
-SplitApkDetailBottomSheet.kt    - The item sheet: type, identifier, file name, size, full path
-SplitApkResources.kt            - SplitApkKind -> icon/label mapping, plus the ABI/density lookup
-                                   tables and the `java.util.Locale`-backed language display name
-SplitApksViewModel.kt           - Assisted-injected; combines the loaded split list with the active
-                                   search query
-SplitApksState.kt               - Loading/Error/Loaded plus search query and item list
-SplitApksAction.kt / SplitApksEvent.kt
-```
+## Certificate Screen Semantics
 
-One tap down from General Info's "Split APKs" row (`core:apps`'s `readInstalledSplits()` backs both).
-Every installed split/config APK is classified by file-name convention alone: AGP only ever splits a
-config APK along ABI, screen density, or language, so a `split_config.<qualifier>` file whose
-qualifier isn't a known ABI or density code is a language split by elimination, and anything without
-that prefix is a dynamic feature module. Friendly ABI/density names come from a fixed lookup table;
-language qualifiers resolve through `java.util.Locale`, falling back to the raw qualifier when it
-can't be parsed. This is best-effort labeling for a Storage-adjacent screen, not a verdict — an
-unrecognized qualifier degrades to its raw string rather than guessing.
+Show current signing certificates first. Show verified rotation history separately,
+newest-to-oldest, and identify the original key.
 
-### `nativelibraries/`
+Fingerprints remain visible in SHA-256, SHA-1, then MD5 order. Public-key fingerprints may be
+collapsed but use the shared hash component.
 
-```
-NativeLibrariesScreen.kt            - Pinned toolbar, collapsing search header, list grouped by
-                                       library name
-NativeLibraryDetailBottomSheet.kt   - The item sheet: device support, built-for ABIs, total size,
-                                       and a per-ABI breakdown (size + which APK it's bundled in)
-NativeLibrariesViewModel.kt         - Assisted-injected; groups `AppDetail.nativeLibraries.files`
-                                       (one row per (name, abi) pair) into one list item per distinct
-                                       library name, then combines with the active search query
-NativeLibrariesState.kt             - Loading/Error/Loaded plus `NativeLibraryItem` (grouped) and
-                                       `NativeLibraryVariant` (one ABI's copy of that library)
-NativeLibrariesAction.kt / NativeLibrariesEvent.kt
-```
+Use the domain's current-signer multiplicity and signing-scheme values directly. Do not re-derive
+them from displayed certificate counts. Omit signing-scheme UI when analysis returns unknown; never
+guess.
 
-One tap down from General Info's "Native library files" row (`core:apps`'s `readNativeLibraries()`
-backs both — see `core/apps/AGENTS.md`). The grouping mirrors the row it replaces: General Info has
-always counted a library once even when the same file ships for multiple processor architectures, so
-the full list keeps that grouping and pushes the per-architecture detail (size, which APK it's
-bundled in) into the item sheet rather than flattening it into one row per architecture. Device
-compatibility is computed the same way `GeneralInfoViewModel`'s app-wide
-`isNativeLibraryDeviceIncompatible` is (against `Build.SUPPORTED_ABIS`), just per library instead of
-per app — a library whose ABIs don't intersect the device's is tagged **only** on the row that misses,
-following the same "only misses are marked" convention as `requirements/`.
+## Device Requirements Semantics
 
-## Key Patterns
-- Uses **Assisted Injection** (`@HiltViewModel(assistedFactory = ...)`) because the ViewModel requires `AppDetailInput` at creation time.
-- `AppDetailState.Loaded` is a large data class with all detail fields (no nested loading).
-- Badge computation uses `AppClassificationThresholds` from `core:apps`.
-- Sub-screens follow the `GeneralInfoScreen` idiom: **tap = explain, long-press = copy**.
-- "Worth knowing" excludes component exposure and merely requested dangerous permissions. Component
-  intent filters are available in the component detail sheet, but path-permission evidence is still
-  missing, so the hub does not yet interpret exported components. It surfaces debug access, actually
-  granted high-impact access, debug or not-yet-valid signing, and targets at least four API levels
-  behind the device. Backup and cleartext flags remain neutral facts in General information rather
-  than findings.
-- Granted high-impact access is deliberately narrower than every dangerous permission: background
-  location, messages, call history, contacts, and calendar. Camera and microphone stay in the
-  permission preview because they are common and need app-purpose context before they become a
-  useful finding. Special-access and service capabilities remain out until their grant state is
-  extracted reliably.
-- APK export writes the installed base APK through `ACTION_CREATE_DOCUMENT` and explicitly reports
-  when split APKs mean the result is not a complete install package. APK-file mode hides this
-  redundant action.
-- Icon export supports installed packages and APK files at natural resolution through
-  `ACTION_CREATE_DOCUMENT`.
-- Installed manifest viewing targets the base APK directly. Merged resources can resolve
-  `AndroidManifest.xml` from an arbitrary feature split. The screen reports additional installed
-  split manifests instead of pretending the base document is a merged manifest.
+Keep required and optional features as the section structure rather than adding a scope filter.
+Mark only unavailable requirements. Available and unknown requirements render no success marker.
 
-## Design Doc
+Missing optional requirements use softer wording because they do not prevent installation.
+
+OpenGL ES support is a version comparison, not a feature-name lookup. When unavailable, show both
+required and device versions. Evaluate requirements for installed packages and APK files because
+sideloading can bypass store compatibility checks.
+
+## Split APK Semantics
+
+Show a searchable flat list sorted by split kind. Classification uses installed split filename
+conventions:
+
+* Recognized configuration qualifiers map to ABI or screen density.
+* Other `split_config.<qualifier>` values are treated as language qualifiers.
+* Values without that prefix are dynamic feature modules.
+
+Friendly labels are best effort. Unknown qualifiers fall back to their raw value rather than being
+guessed into another category.
+
+Exporting only the installed base APK is not a complete package when splits exist. Keep that
+limitation explicit after export.
+
+## Native Library Semantics
+
+Group the list by library name, matching the app-level count. Put ABI-specific copies, sizes, and
+containing APKs in the detail sheet rather than flattening them into duplicate rows.
+
+Compare each library's shipped ABIs with `Build.SUPPORTED_ABIS` at the feature layer. Mark only
+incompatible libraries, following the requirements screen's "only misses are marked" convention.
+
+## Manifest and Export Semantics
+
+Installed manifest viewing targets the base APK. Merged resource lookup can resolve an arbitrary
+split, so report additional split manifests rather than presenting the base document as merged.
+
+APK and icon export use system document creation. APK-file mode hides redundant APK export.
+Temporary APK ownership must be released on all terminal lifecycle paths.
+
+## Product Reference
 
 [`docs/product/features/app-detail.md`](../../docs/product/features/app-detail.md) is the approved
-design for the remaining sub-screens (Components, Certificates, Requirements, hub rework). Read it
-before adding one.
-
-## Dependencies
-- `core:apk-files` (TemporaryApkManager)
-- `core:apps` (AppDetailRepository)
-- `core:app-permissions` (PermissionLabelProvider)
-- `core:user-preferences` (RecentlyViewedAppsRepository)
-- `kotlinx-collections-immutable`
-- `coil-compose`
+design reference for remaining app-detail work.

--- a/feature/apps/AGENTS.md
+++ b/feature/apps/AGENTS.md
@@ -1,72 +1,38 @@
 # feature:apps Module
 
 ## Purpose
-The primary feature — displays the list of installed apps with filtering, sorting, searching, and recently-viewed apps. This is the start destination of the app.
 
-## Sub-modules
-- `api` - Contains `AppsNavKey` (top-level destination)
-- `impl` - Full implementation
+The start destination for browsing installed apps, searching, filtering, sorting, opening APK files,
+and navigating to app details or settings.
 
-## Package: `sk.styk.martin.apkanalyzer.feature.apps.impl`
+The API module exposes only the top-level navigation key. Implementation code uses the package
+`sk.styk.martin.apkanalyzer.feature.apps.impl`.
 
-## Structure
+## Package Map
 
-```
-navigation/
-  AppEntryProvider.kt      - appEntries(navigator) - registers AppsNavKey, AppSearchNavKey, AppFilterNavKey, PermissionFilterNavKey
-  AppFilterNavKey.kt       - Internal nav key for filter screen
-  AppSearchNavKey.kt       - Internal nav key for search screen
-  PermissionFilterNavKey.kt - Internal nav key for permission filter
-list/
-  AppsScreen.kt            - Main app list Composable
-  AppsViewModel.kt         - @HiltViewModel, combines installed apps + filter + sort + recents
-  AppsState.kt             - AppsState, AppListState, RecentsState, AppListItem, SortType
-  AppsAction.kt            - User actions (sort, click, filter, search, settings)
-  AppsEvent.kt             - Navigation events
-search/
-  AppSearchScreen.kt       - Search overlay screen
-  AppSearchState/Action/Event/ViewModel.kt - Own State/Action/Event/ViewModel, same MVI shape as list/
-  domain/
-    SearchAppsUseCase.kt   - Applies search query to app list
-filter/
-  FilterScreen.kt          - Filter bottom sheet / screen
-  FilterState/Action/Event/ViewModel.kt - Own State/Action/Event/ViewModel, same MVI shape as list/
-  domain/
-    AppFilterRepository.kt - In-memory filter state management
-    AppFilterState.kt      - Filter criteria data class
-    FilterAppsUseCase.kt   - Applies filter to app list
-    PermissionFilterCoordinator.kt, PermissionPreset.kt, QuickFilter.kt, UnusedAppsPeriod.kt - Supporting filter domain types
-  permission/
-    PermissionFilterScreen.kt - Permission-based filtering
-    PermissionFilterState/Action/Event/ViewModel.kt - Own State/Action/Event/ViewModel
-components/
-  apkfilepicker/                     - Reusable APK document-picker button with its own MVI ViewModel and temporary-file ownership
-  PermissionRationaleBottomSheet.kt - Defines AppDataPermission (sealed interface: UsageAccess, StorageAccess — NOT an enum) + the rationale bottom sheet UI
-  AppsSkeletons.kt         - Loading skeleton placeholders
-  appitem/AppListItemRow.kt - Single app row in the list
-  quickfilter/QuickFilterRow*.kt - Quick-filter chip row
-  (other shared components)
-```
+* `list/` - the installed-app list and recently viewed section.
+* `search/` - app search and search-history interaction.
+* `filter/` - in-memory filter state, quick filters, and permission selection.
+* `components/` - feature-owned reusable UI, including APK document selection and app rows.
+* `navigation/` - the top-level and internal Navigation 3 destinations.
 
-Every sub-screen (`list/`, `search/`, `filter/`, `filter/permission/`) follows the same
-State/Action/Event/ViewModel MVI shape as the top-level `AppsViewModel` — not just a single
-screen with helper composables.
+Each user-visible destination owns its State/Action/Event/ViewModel set. Do not centralize search,
+filter, and permission-filter state into the list ViewModel.
 
-## Key Dependencies
-- `core:apk-files` (TemporaryApkManager)
-- `core:apps` (InstalledAppsRepository, StorageStatsRepository, UsageStatsRepository)
-- `core:user-preferences` (RecentlyViewedAppsRepository)
-- `core:app-permissions` (for permission filter)
-- `feature:settings:api` (SettingsNavKey for navigation)
-- `feature:app-detail:api` (AppDetailNavKey, AppDetailInput for navigation)
-- `kotlinx-collections-immutable`
-- `coil-compose`
+## Navigation Topology
 
-## Navigation Flow
-```
-AppsNavKey → AppSearchNavKey (fade out transition)
-AppsNavKey → AppFilterNavKey (bottom entry)
-AppFilterNavKey → PermissionFilterNavKey (slide from end)
-AppsNavKey → AppDetailNavKey (via navigator)
-AppsNavKey → SettingsNavKey (via navigator)
-```
+The apps destination opens search and filter internally. Filter opens permission selection. App
+details and settings are cross-feature destinations and must use their API modules.
+
+Register all internal destinations through this feature's entry provider, then register that provider
+once in the app host.
+
+## State and Ownership Rules
+
+* Filtering and sorting happen before the UI receives list state.
+* Filter state is an in-memory domain repository shared by the feature's filter surfaces.
+* Recently viewed data remains optional and comes from `core:user-preferences`.
+* The APK picker owns temporary-file acquisition until ownership transfers to app detail. Preserve
+  release behavior for cancellation, failed navigation, and Activity teardown.
+* Usage and storage permission rationale state is modeled by distinct sealed variants because the
+  system settings destinations and explanations differ.

--- a/feature/browse/AGENTS.md
+++ b/feature/browse/AGENTS.md
@@ -1,76 +1,36 @@
 # feature:browse Module
 
 ## Purpose
-Bottom-navigation top-level destination for "Browse by Attribute" (tab label "Browse") — roadmap
-`CE-05`: pick a dimension, see its bucket counts, tap a bucket to see the apps in it. Three depths,
-one screen each: hub (dimension cards) → options (bucket list for the chosen dimension) → apps
-(the apps in the tapped bucket) → `feature:app-detail`. Replaces the former `feature:permissions` and
-`feature:statistics` stub tabs, per `docs/product/shipped.md` §1.1b's module consolidation note.
 
-## Sub-modules
-- `api` — Contains `BrowseNavKey` (top-level destination) and the "Browse" string resource used as
-  the bottom-nav tab label
-- `impl` — Full implementation
+Top-level "Browse by attribute" destination. Users choose a dimension, choose one of its buckets, then
+view the live apps in that bucket before navigating to app detail.
 
-## Package: `sk.styk.martin.apkanalyzer.feature.browse.impl`
+The API module exposes the top-level navigation key and tab label. Implementation code uses the
+package `sk.styk.martin.apkanalyzer.feature.browse.impl`.
 
-## API Module Key Types
+## Package Map
 
-```kotlin
-@Serializable
-object BrowseNavKey : NavKey
-```
+* The root implementation package owns dimension models, the hub, shared labeling, and bucket
+  normalization.
+* `options/` owns searchable bucket lists and dimension-specific row presentation.
+* `apps/` owns the searchable app list for one bucket.
+* `navigation/` owns internal option and bucket destinations.
 
-## Impl Structure
+## Data and Navigation Semantics
 
-```
-model/
-  BrowseDimension.kt        - @Serializable enum: Permission, SigningCertificate, TargetSdk, MinSdk, InstallSource, SharedUserId, AppCategory
-domain/
-  BrowseBuckets.kt           - AppAttributeIndex.bucketsFor(dimension, subAttribute):
-                                Map<String, List<PackageName>>, normalizing every dimension's key type
-                                (Int, AppSource, String?) to String. Certificate identity can use
-                                SHA-256, SHA-1, or MD5. UNKNOWN_SIGNER_KEY is the sentinel for a null
-                                certificate organization
-  BrowseDimensionLabeler.kt  - @Inject; resolves a dimension+key pair to a friendly label and an
-                                optional raw identifier. Wraps PermissionLabelProvider (core:app-permissions)
-                                and SdkVersionResolver (core:apps) for the two dimensions that need a
-                                real lookup; the enum-backed dimensions (install source, app category,
-                                unknown signer) resolve directly from this module's own strings.xml via
-                                Context.getString — deliberately not through Compose stringResource,
-                                since this runs outside a @Composable in the ViewModel/domain layer.
-                                Shared UID has no friendlier form than the declared string itself, so its
-                                label is the raw key with no lookup at all. Each enum-backed dimension's
-                                mapping is a separate private function (see `categoryLabel`), not one
-                                growing `when` in `label()` — Detekt's cyclomatic-complexity limit is why
-BrowseDimensionResources.kt  - Composable-only per-dimension icon/title/subtitle, shared by all three screens
-BrowseState.kt / BrowseAction.kt / BrowseEvent.kt / BrowseViewModel.kt / BrowseScreen.kt
-                              - Hub: dimension cards with a top-labels preview row and an option count,
-                                sourced straight from AppIndexRepository.index() + InstalledAppsRepository.apps()
-options/                      - Shared bucket-list shell (search + sorted-by-count rows) with typed
-                                option models and dimension-specific row content; certificate hash
-                                rows show the complete fingerprint in a monospaced HashBox
-apps/                         - Apps in one tapped bucket (search + app rows), re-derives the bucket's
-                                package set live from the index rather than carrying it through the NavKey
-navigation/
-  BrowseEntryProvider.kt      - browseEntries(navigator): registers BrowseNavKey, BrowseOptionsNavKey,
-                                BrowseAppsNavKey; the apps screen navigates out to AppDetailNavKey
-  BrowseOptionsNavKey.kt      - Internal: dimension
-  BrowseAppsNavKey.kt         - Internal: dimension, bucketKey, bucketLabel
-```
+The navigation depth is hub -> options -> apps -> app detail. Internal keys carry the dimension and
+raw bucket identity, not a package list.
 
-None of the three screens have an error state — `AppIndexStatus` is `Loading | Data`, never a failure,
-since it is pure bucketing over flows that already can't fail. Loading is the only non-loaded state
-each ViewModel exposes.
+The apps screen recombines the live index with installed apps. Uninstalling an app while viewing a
+bucket must update the list, and navigation state must remain small.
 
-The apps screen does not carry the bucket's package list through the NavKey. It re-combines
-`AppIndexRepository.index()` with `InstalledAppsRepository.apps()` using the dimension and raw bucket
-key alone, so the list stays live (uninstalling an app while viewing its bucket updates the screen)
-and the NavKey stays small.
+`AppIndexStatus` has loading and data states only because indexing is pure bucketing over upstream
+flows whose public contracts do not fail. Do not invent an error state without first introducing a
+real failure source.
 
-## Dependencies
-- `api`: `apkanalyzer.feature.api` plugin, no explicit dependencies
-- `impl`: `apkanalyzer.feature.impl` plugin, `api(projects.feature.browse.api)`,
-  `implementation(projects.feature.appDetail.api)`, `implementation(projects.core.appIndex)`,
-  `implementation(projects.core.apps)`, `implementation(projects.core.appPermissions)`,
-  `implementation(projects.core.common)`, `kotlinx-collections-immutable`
+Normalize dimension keys for navigation, but preserve the raw key separately from the friendly
+label. Permission and SDK labels use core resolvers; enum-backed dimensions use this feature's
+localized resources outside Compose.
+
+Certificate identity supports SHA-256, SHA-1, and MD5 bucket views. Unknown certificate subject
+attributes use an explicit sentinel rather than a nullable navigation parameter.

--- a/feature/settings/AGENTS.md
+++ b/feature/settings/AGENTS.md
@@ -1,57 +1,22 @@
 # feature:settings Module
 
 ## Purpose
-Settings screen: color scheme (theme) selection and a toggle for the "recently viewed apps" feature. A secondary (non-top-level) destination reached by explicit navigation — currently triggered from `feature:apps` — not from the bottom nav bar.
 
-## Sub-modules
-- `api` — Contains `SettingsNavKey` only, no string resources (tab label strings live in impl here, unlike `feature:permissions`/`feature:statistics` where the label lives in `api`)
-- `impl` — Full implementation
+Secondary destination for color-scheme selection and the recently viewed apps preference. It is
+reached through explicit navigation rather than the bottom navigation bar.
 
-## Package: `sk.styk.martin.apkanalyzer.feature.settings.impl`
+The API module exposes only the navigation key. Implementation code uses the package
+`sk.styk.martin.apkanalyzer.feature.settings.impl`.
 
-## API Module Key Types
+## State and Navigation Rules
 
-```kotlin
-@Serializable
-data object SettingsNavKey : NavKey
-```
-Note: `data object`, unlike `feature:permissions`/`feature:statistics` which use plain `object`.
+Settings follows the standard State/Action/Event/ViewModel pattern. Back is both an Action and a
+one-shot Event: the ViewModel translates user intent, while the screen invokes the host callback.
+Never inject or call `Navigator` from the ViewModel.
 
-## Impl Structure
+This feature has no repository of its own. It observes and saves typed keys through
+`core:common`'s `PersistenceRepository`. Keep persistence out of Composables and do not duplicate
+preference state in the app module.
 
-```
-navigation/
-  SettingsEntryProvider.kt  - settingsEntries(navigator: Navigator): EntryProviderScope<NavKey> extension; registers SettingsNavKey -> SettingsScreen(onBack = { navigator.goBack() })
-SettingsAction.kt           - sealed interface: ColorSchemeSelected, RecentlyViewedAppsToggled, NavigateBack
-SettingsEvent.kt            - sealed interface: NavigateBack (one-shot)
-SettingsState.kt            - @Immutable data class: colorScheme, recentlyViewedAppsEnabled
-SettingsViewModel.kt        - @HiltViewModel
-SettingsScreen.kt           - SettingsScreen (stateful), SettingsContent (stateless), AppearanceSection, AppsSection, 2 @Preview functions
-res/values/strings.xml      - settings_title, settings_appearance, settings_color_scheme(_day/night/follow_system), settings_apps_section, settings_recently_viewed_toggle
-```
-
-## ViewModel
-
-```kotlin
-@HiltViewModel
-class SettingsViewModel @Inject constructor(
-    private val persistenceRepository: PersistenceRepository,  // core:common
-) : ViewModel() {
-    val state: StateFlow<SettingsState>   // combine(observe(Key.ColorScheme), observe(Key.RecentlyViewedAppsEnabled))
-    val events: Flow<SettingsEvent>       // Channel(BUFFERED).receiveAsFlow()
-    fun onAction(action: SettingsAction)
-}
-```
-
-`PersistenceRepository` (`core:common`): `fun <T> observe(key: Key<T>): Flow<T>`, `suspend fun <T> get/save(key: Key<T>, value: T)`.
-
-## Key Patterns
-
-- Standard State/Action/Event MVI shape, same as `feature:apps`/`feature:app-detail`.
-- `NavigateBack` is modeled as **both** an `Action` (user pressed back) and an `Event` (ViewModel translates it into a one-shot navigation signal the screen collects to call `onBack()`) rather than the entry provider calling `navigator.goBack()` directly from a UI callback — this keeps the ViewModel decoupled from `Navigator`. Follow this pattern for any new feature needing a back action.
-- No repository/use-case of its own — delegates entirely to `core:common`'s generic key-value `PersistenceRepository`.
-- Entry provider needs a `Navigator` parameter (unlike `feature:permissions`/`feature:statistics`) because Settings needs to pop back.
-
-## Dependencies
-- `api`: `apkanalyzer.feature.api` plugin, no dependencies block
-- `impl`: `apkanalyzer.feature.impl` plugin, `api(projects.feature.settings.api)`, `implementation(projects.core.common)`
+Color scheme and recently viewed state are combined into one immutable screen state so both update
+reactively.


### PR DESCRIPTION
The repository's agent guidance had grown into exhaustive source inventories and copied implementation details that were costly to load and easy to make stale. This change focuses the context on durable information that cannot be inferred cheaply and makes the expected engineering workflow explicit.

## Summary

- Define a mandatory investigation, planning, diff inspection, self-review, and verification workflow in the root guidance.
- Replace module-level file inventories and copied interfaces with package-level maps, architectural boundaries, and non-obvious behavioral contracts.
- Codify what belongs in scoped `AGENTS.md` files so ordinary source additions and renames do not require documentation updates.
- Remove the stale root claim that `feature:browse` is a stub.

## Validation

- `.\gradlew.bat validateAgentContext`
- `.\gradlew.bat spotlessApply`