### PR TITLE
Sync system bar icon appearance with selected app theme

### DIFF
--- a/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/ApkAnalyzerThemeHost.kt
+++ b/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/ApkAnalyzerThemeHost.kt
@@ -1,10 +1,14 @@
 package sk.styk.martin.apkanalyzer.ui
 
+import androidx.activity.compose.LocalActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.view.WindowCompat
 import sk.styk.martin.apkanalyzer.core.common.settings.ColorAppScheme
 import sk.styk.martin.apkanalyzer.core.uilibrary.theme.ApkAnalyzerTheme
 
@@ -19,6 +23,7 @@ internal fun ApkAnalyzerThemeHost(state: ApkAnalyzerState, content: @Composable 
             ColorAppScheme.FollowSystem -> isSystemInDarkTheme()
         }
     }
+    SyncSystemBarsWithTheme(isDarkTheme = isDarkTheme)
     val nightMode = when (state) {
         ApkAnalyzerState.Loading -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
 
@@ -32,6 +37,20 @@ internal fun ApkAnalyzerThemeHost(state: ApkAnalyzerState, content: @Composable 
         AppCompatDelegate.setDefaultNightMode(nightMode)
     }
     ApkAnalyzerTheme(isDarkTheme = isDarkTheme, content = content)
+}
+
+@Composable
+private fun SyncSystemBarsWithTheme(isDarkTheme: Boolean) {
+    val view = LocalView.current
+    val activity = LocalActivity.current
+    if (view.isInEditMode || activity == null) return
+
+    DisposableEffect(activity, isDarkTheme) {
+        val insetsController = WindowCompat.getInsetsController(activity.window, view)
+        insetsController.isAppearanceLightStatusBars = !isDarkTheme
+        insetsController.isAppearanceLightNavigationBars = !isDarkTheme
+        onDispose {}
+    }
 }
 
 @Preview


### PR DESCRIPTION
The app-level Day/Night setting updated Compose colors, but system bar icon appearance could stay tied to the previous mode. This made top bar icons look wrong after switching theme.

## What changed
- Added `SyncSystemBarsWithTheme(isDarkTheme)` in `ApkAnalyzerThemeHost`.
- Applied status and navigation bar icon appearance from the current app theme via `WindowCompat.getInsetsController(...)`.
- Used `DisposableEffect(activity, isDarkTheme)` so updates run when the activity or theme mode changes.
- Used `LocalActivity.current` with preview/null guards to keep this safe in non-activity contexts.

## Notes
- Scope is intentionally limited to system bar icon appearance sync; no feature-level UI behavior changed.