### PR TITLE
Fix detekt failure in core common review module

### DIFF
--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/review/InAppReviewLauncherImpl.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/review/InAppReviewLauncherImpl.kt
@@ -5,12 +5,9 @@ import com.google.android.play.core.review.ReviewInfo
 import com.google.android.play.core.review.ReviewManager
 import kotlinx.coroutines.suspendCancellableCoroutine
 import sk.styk.martin.apkanalyzer.core.common.coroutines.runCatchingCancellable
-import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import javax.inject.Inject
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
-
-private const val TAG = "InAppReviewLauncher"
 
 internal class InAppReviewLauncherImpl @Inject constructor(
     private val reviewManager: ReviewManager,

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/review/ReviewEligibilityTrackerImpl.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/review/ReviewEligibilityTrackerImpl.kt
@@ -8,13 +8,11 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
-import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.settings.Key
 import sk.styk.martin.apkanalyzer.core.common.settings.PersistenceRepository
 import javax.inject.Inject
 import javax.inject.Singleton
 
-private const val TAG = "ReviewEligibilityTracker"
 private const val QUALIFIED_SESSION_THRESHOLD = 2
 
 @Singleton

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/review/ReviewModule.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/review/ReviewModule.kt
@@ -13,15 +13,15 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-internal abstract class ReviewModule {
+internal interface ReviewModule {
 
     @Binds
     @Singleton
-    abstract fun bindReviewEligibilityTracker(impl: ReviewEligibilityTrackerImpl): ReviewEligibilityTracker
+    fun bindReviewEligibilityTracker(impl: ReviewEligibilityTrackerImpl): ReviewEligibilityTracker
 
     @Binds
     @Singleton
-    abstract fun bindInAppReviewLauncher(impl: InAppReviewLauncherImpl): InAppReviewLauncher
+    fun bindInAppReviewLauncher(impl: InAppReviewLauncherImpl): InAppReviewLauncher
 
     companion object {
         @Provides


### PR DESCRIPTION
## Why
`develop` CI started failing in the `verify` job because `:core:common:detektDebug` reported three issues, blocking the workflow.

## What changed
- Removed unused `TAG` top-level properties and unused `Logger` imports in review implementations.
- Refactored `ReviewModule` from an abstract class to an interface, keeping the same `@Binds` contracts and companion `@Provides` factory.

## Notes for reviewers
This is a cleanup-only change to satisfy detekt; runtime behavior of the review flow wiring stays the same.