### PR TITLE
Sync shimmer animation phase across skeleton placeholders

### DIFF
--- a/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/modifier/Shimmer.kt
+++ b/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/modifier/Shimmer.kt
@@ -7,6 +7,8 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
@@ -15,18 +17,16 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import sk.styk.martin.apkanalyzer.core.uilibrary.theme.AppTheme
 
+private val LocalShimmerProgress = compositionLocalOf<Float?> { null }
+
+@Composable
+fun ShimmerGroup(content: @Composable () -> Unit) {
+    CompositionLocalProvider(LocalShimmerProgress provides rememberShimmerTransitionProgress(), content = content)
+}
+
 @Composable
 fun Modifier.shimmer(surfaceColor: Color = AppTheme.colors.surface, highlightColor: Color = AppTheme.colors.surfaceVariant): Modifier {
-    val transition = rememberInfiniteTransition(label = "shimmer")
-    val progress by transition.animateFloat(
-        initialValue = 0f,
-        targetValue = 1f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 1200, easing = LinearEasing),
-            repeatMode = RepeatMode.Restart,
-        ),
-        label = "shimmer_progress",
-    )
+    val progress = LocalShimmerProgress.current ?: rememberShimmerTransitionProgress()
 
     return drawWithContent {
         drawContent()
@@ -42,4 +42,19 @@ fun Modifier.shimmer(surfaceColor: Color = AppTheme.colors.surface, highlightCol
         )
         drawRect(brush = brush, size = size)
     }
+}
+
+@Composable
+private fun rememberShimmerTransitionProgress(): Float {
+    val transition = rememberInfiniteTransition(label = "shimmer")
+    val progress by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1200, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart,
+        ),
+        label = "shimmer_progress",
+    )
+    return progress
 }

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/list/AppsScreen.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/list/AppsScreen.kt
@@ -55,6 +55,7 @@ import sk.styk.martin.apkanalyzer.core.uilibrary.components.Text
 import sk.styk.martin.apkanalyzer.core.uilibrary.components.navigationBarContentPadding
 import sk.styk.martin.apkanalyzer.core.uilibrary.icons.ApkAnalyzerIcons
 import sk.styk.martin.apkanalyzer.core.uilibrary.lazylist.itemsPositioned
+import sk.styk.martin.apkanalyzer.core.uilibrary.modifier.ShimmerGroup
 import sk.styk.martin.apkanalyzer.core.uilibrary.modifier.card
 import sk.styk.martin.apkanalyzer.core.uilibrary.modifier.collapsingHeader
 import sk.styk.martin.apkanalyzer.core.uilibrary.modifier.collapsingHeaderContainer
@@ -167,31 +168,33 @@ private fun AppsContent(
             lazyListState.scrollToItem(0)
         }
 
-        LazyColumn(
-            state = lazyListState,
-            contentPadding = PaddingValues(
-                start = 16.dp,
-                end = 16.dp,
-                bottom = navigationBarContentPadding + 16.dp,
-            ),
-            modifier = Modifier
-                .fillMaxWidth()
-                .offset { collapsingState.contentOffset },
-        ) {
-            recentsSectionItems(
-                recents = state.recents,
-                sortType = state.sortType,
-                onAppClicked = { onAction(AppsAction.AppClicked(it)) },
-            )
+        ShimmerGroup {
+            LazyColumn(
+                state = lazyListState,
+                contentPadding = PaddingValues(
+                    start = 16.dp,
+                    end = 16.dp,
+                    bottom = navigationBarContentPadding + 16.dp,
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .offset { collapsingState.contentOffset },
+            ) {
+                recentsSectionItems(
+                    recents = state.recents,
+                    sortType = state.sortType,
+                    onAppClicked = { onAction(AppsAction.AppClicked(it)) },
+                )
 
-            appsSectionItems(
-                apps = state.apps,
-                isFiltering = state.activeFilter.isActive,
-                sortType = state.sortType,
-                onAppClicked = { onAction(AppsAction.AppClicked(it)) },
-                onClearFilters = { onAction(AppsAction.ClearAllFilters) },
-                onShowSort = { showSortSheet = true },
-            )
+                appsSectionItems(
+                    apps = state.apps,
+                    isFiltering = state.activeFilter.isActive,
+                    sortType = state.sortType,
+                    onAppClicked = { onAction(AppsAction.AppClicked(it)) },
+                    onClearFilters = { onAction(AppsAction.ClearAllFilters) },
+                    onShowSort = { showSortSheet = true },
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Why

`Modifier.shimmer()` started its own independent `rememberInfiniteTransition` on every call. On screens with multiple skeleton placeholders in the same list (e.g. the 8-row installed apps skeleton and the recents row skeleton in `AppsScreen`), each shimmer sweep animated out of phase with its neighbors instead of moving together, which looked less polished than a single coherent wave.

## Approach

- Added `LocalShimmerProgress`, a `CompositionLocal<Float?>`, plus a `ShimmerGroup(content)` composable in `core:ui-library` that drives one shared animated progress value via a single `rememberInfiniteTransition`.
- `Modifier.shimmer()` now reads `LocalShimmerProgress.current` when available and only falls back to creating its own transition when used standalone (previews, single-row skeletons like `AiSummaryCard`/`BrowseScreen`), so no other call sites needed changes.
- Wrapped the apps list `LazyColumn` in `AppsScreen` with `ShimmerGroup`, so the recents skeleton row and all 8 installed-app skeleton rows now sweep in unison.

## Notes for review

- `ShimmerGroup` wraps the `LazyColumn` unconditionally (not just while loading) per review feedback, keeping the call site simple; the extra idle `rememberInfiniteTransition` while the list is fully loaded is negligible.
- No other skeleton call sites (`AiSummaryCard`, `BrowseScreen`) needed changes since `shimmer()` falls back to its own transition outside a `ShimmerGroup`.