### PR TITLE
Update stable KSP and Compose BOM versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Kotlin
 kotlin = "2.4.10"
-ksp = "2.3.10"
+ksp = "2.3.11"
 kotlinx-collections-immutable = "0.5.1"
 
 # Android
@@ -13,7 +13,7 @@ lifecycle = "2.11.0"
 datastore = "1.2.1"
 
 # Compose
-compose-bom = "2026.06.01"
+compose-bom = "2026.08.00"
 compose-foundation = "1.11.4"
 
 # Navigation


### PR DESCRIPTION
This keeps dependency maintenance moving while avoiding pre-release risk on the develop branch.

## What changed
- Bumped `ksp` from `2.3.10` to `2.3.11`
- Bumped `compose-bom` from `2026.06.01` to `2026.08.00`

## Notes
- Only stable versions were updated.
- RC and alpha candidates were intentionally left unchanged.