### PR TITLE
Docs: redesign README and add contribution/security guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# Contributing to ApkAnalyzer
+
+Thanks for wanting to help. This is a live app with over 2 million downloads, so changes are held to
+a production bar — but the bar is documented, not implied.
+
+By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Before you write code
+
+**Read [`AGENTS.md`](AGENTS.md).** It's the canonical engineering reference: module boundaries,
+MVVM/DI/navigation conventions, Compose rules, naming, and where a given change belongs. Then read
+the `AGENTS.md` of every module you touch — each one documents its own package map and rules.
+
+**Check the [roadmap](docs/product/roadmap.md).** Open scope is tracked there with stable IDs, and
+finished or deliberately retired work is in [`shipped.md`](docs/product/shipped.md). If your idea is
+already retired, the reasoning is recorded — worth reading before re-proposing it.
+
+**Open an issue first for anything non-trivial.** Bug fixes and small improvements can go straight
+to a PR. New features, new modules, new dependencies, or architectural changes should be discussed
+in an issue first so nobody builds something that doesn't fit.
+
+## Setting up
+
+```bash
+git clone https://github.com/MartinStyk/AndroidApkAnalyzer.git
+cd AndroidApkAnalyzer
+./gradlew assembleDebug
+```
+
+Android Studio (latest stable) is the only prerequisite — the Gradle setup provisions a matching JDK
+itself. The [`setup-local-tools`](.claude/skills/setup-local-tools/SKILL.md) skill covers headless
+setup and optional tooling.
+
+## The rules that matter most
+
+These come from [`AGENTS.md`](AGENTS.md); they're the ones PRs most often trip over.
+
+* **Kotlin, Compose, Hilt, coroutines.** No XML layouts, no `Thread`/`Executor`/`runBlocking`, no
+  alternative DI framework.
+* **No new dependencies without asking.** [`gradle/libs.versions.toml`](gradle/libs.versions.toml)
+  is the only place coordinates and versions live.
+* **No comments or KDoc.** Names and structure carry the meaning. This is deliberate and enforced in
+  review.
+* **No hardcoded user-facing strings.** Use `stringResource` backed by the owning module's
+  `strings.xml`.
+* **Feature modules never import `androidx.compose.material3`.** Use the wrappers in
+  [`core:ui-library`](core/ui-library/AGENTS.md); add one there first if it doesn't exist.
+* **Never hardcode SDK levels or the JVM toolchain** in a module's `build.gradle.kts` — they come
+  from `build-logic`.
+* **Don't add tests or test dependencies** unless the issue explicitly asks. There is no test
+  infrastructure here yet, by choice.
+
+Recurring tasks have step-by-step procedures in [`.claude/skills/`](.claude/skills) — creating a
+feature module, creating a core module, adding a UI component, wiring navigation, fixing formatting,
+running the app on a device. Use them instead of copying an existing file and hoping.
+
+## Before you open a PR
+
+```bash
+./gradlew spotlessApply    # required — the only gate you must run locally
+```
+
+Then, if you want to pre-empt CI:
+
+```bash
+./gradlew spotlessCheck detektDebug :build-logic:convention:detektMain lintDebug :app:assembleDebug
+```
+
+While iterating, a single-module compile is much faster:
+`./gradlew :feature:apps:impl:compileDebugKotlin`.
+
+Two things no gate catches, so check them by hand:
+
+* **Unused imports** — Spotless won't flag them.
+* **Layout correctness** — a clean compile proves nothing about a Compose screen. For any visual
+  change, run it on a device (see the [`run-app`](.claude/skills/run-app/SKILL.md) skill) and look
+  at it.
+
+## Pull requests
+
+* Target `develop`. Releases are cut from tags on it.
+* Keep the change focused. Unrelated refactors, formatting churn, and drive-by fixes make review
+  slower and are usually asked to be split out.
+* Describe **what changed and why**, and link the issue or roadmap ID it addresses. Include a
+  screenshot or screen recording for anything visual.
+* Commits are authored by you as a human contributor. Don't add AI co-author trailers — see the
+  [`git-commit-author`](.claude/skills/git-commit-author/SKILL.md) skill.
+* Expect review comments about architecture and scope. They're about fit with the codebase, not
+  about you.
+
+## Reporting bugs
+
+Include the app version, Android version and device, the app you were inspecting if relevant, what
+you expected, what happened, and steps to reproduce. A screenshot usually saves a round trip.
+
+**Do not file security vulnerabilities as public issues** — see [`SECURITY.md`](SECURITY.md).
+
+## Translations
+
+Strings live in each module's `res/values/strings.xml`, with translations in the matching
+`values-<locale>` folders — the app currently ships English and Japanese. A PR that only touches
+string resources is always welcome and needs no prior issue.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+[GNU General Public License v3.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -4,33 +4,90 @@
 [![Release](https://github.com/MartinStyk/AndroidApkAnalyzer/actions/workflows/release.yml/badge.svg)](https://github.com/MartinStyk/AndroidApkAnalyzer/actions/workflows/release.yml)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.4.10-blue.svg?logo=kotlin)](gradle/libs.versions.toml)
+[![API](https://img.shields.io/badge/API-28%2B-brightgreen.svg?logo=android)](build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/utils/AndroidSdk.kt)
+[![Google Play](https://img.shields.io/badge/Google%20Play-2M%2B%20downloads-34A853.svg?logo=googleplay&logoColor=white)](https://play.google.com/store/apps/details?id=sk.styk.martin.apkanalyzer)
 
 <img src="app/src/main/res/mipmap-xxhdpi/ic_launcher.png" width="72" align="left" alt="Apk Analyzer icon" />
 
 **Detailed reports of the applications on your device — 📱**
 
-Apk Analyzer is the *most downloaded APK analysis app* on Google Play. It inspects installed apps
-and `.apk` files straight from device storage — no root required. It's open source and completely
-ad-free.
+Apk Analyzer is the *most downloaded APK analysis app* on Google Play, with over 2 million
+downloads. It inspects installed apps and `.apk` files straight from device storage — no root
+required. It's open source, ad-free, and does its analysis on your device.
+
+Shipping since 2017, now rebuilt as a multi-module Jetpack Compose app.
 
 <a href='https://play.google.com/store/apps/details?id=sk.styk.martin.apkanalyzer'><img alt='Get it on Google Play' height="60" src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png'/></a>
 
 <br clear="left"/>
 
+## Table of contents
+
+- [What it does](#what-it-does)
+- [Why it exists](#why-it-exists)
+- [Privacy and permissions](#privacy-and-permissions)
+- [Tech stack](#tech-stack)
+- [Architecture](#architecture)
+- [Getting started](#getting-started)
+- [Repository layout](#repository-layout)
+- [CI and releases](#ci-and-releases)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [Support](#support)
+- [License](#license)
+
 ## What it does
 
-**App reports** — naming and version data, target/minimum Android version, install and update
-dates, signing certificate details, requested permissions with descriptions, activities with
-launch options, services/broadcast receivers/content providers, required and optional hardware
-features, and a full readable export of `AndroidManifest.xml`. Reports are available even for
-`.apk` files you haven't installed yet, and app data (including the icon) can be saved to and
-shared from device storage.
+**Inspect one app — everything Android knows about it, in one report.**
 
-**Permissions** — which permissions are requested across all apps on your device, which apps
-request a given permission, and each permission's protection level.
+| Group | What you get |
+|---|---|
+| Identity | Package and app name, version name and code, app category, install and update dates |
+| Compatibility | Target and minimum Android version, required and optional hardware features |
+| Origin | Full install-source chain — which store or app actually installed it |
+| Signing | Certificate details, issuer and subject, validity, fingerprints, signing-scheme versions |
+| Permissions | Requested and declared permissions with plain-language descriptions and protection levels |
+| Components | Activities, services, receivers and providers with intent filters, exported state, path permissions, and launch options |
+| Packaging | Native libraries and ABIs, split APKs, shared UID group, manifest security flags, storage size |
+| Manifest | The complete `AndroidManifest.xml`, readable |
 
-**Statistics** — Android version and signing-scheme distribution across your installed apps,
-average permission/activity counts, and other collection-wide insights.
+**Browse by attribute.** Turn the question around and start from the attribute instead of the app:
+which apps request a given permission, which are signed by a given certificate, what targets each
+Android version, where each app came from, which share a UID, how apps spread across categories.
+
+**Analyze `.apk` files.** Open an `.apk` from another app or pick one from storage and get the same
+full report for something you haven't installed.
+
+**On-device AI summary.** A short, factual, plain-language read on what an app is and what its
+permissions and components imply — generated locally with ML Kit's GenAI prompt API. The app data
+never leaves the device.
+
+**Export and share.** Export or share the APK itself, save the app icon, copy or share a text
+summary, and launch an app's components directly.
+
+**Requirements:** Android 9 (API 28) or newer. The AI summary additionally needs a device that
+supports on-device generative AI; everything else works everywhere.
+
+## Why it exists
+
+Android tells you very little about the software you already run. Apk Analyzer surfaces the whole
+manifest-level truth about every installed app in a form a human can read — no root, no ads, no
+paywall on the raw data. Raw facts stay free by design; see the
+[roadmap](docs/product/roadmap.md) for where interpretation features are heading.
+
+## Privacy and permissions
+
+App analysis runs entirely on device. The app declares exactly two sensitive permissions, both
+needed for the core feature:
+
+| Permission | Why |
+|---|---|
+| `QUERY_ALL_PACKAGES` | Read the list and details of installed apps — this is what the app is for |
+| `PACKAGE_USAGE_STATS` | Optional. Powers last-used times and storage size breakdowns; granted by you in system settings |
+
+App-analysis data is processed on device. Network use is limited to Firebase telemetry (Analytics,
+Crashlytics, Performance) and ML Kit downloading the on-device AI model. See
+[`PRIVACY_POLICY.MD`](PRIVACY_POLICY.MD).
 
 ## Tech stack
 
@@ -40,38 +97,91 @@ average permission/activity counts, and other collection-wide insights.
 | UI | Jetpack Compose only — no XML layouts |
 | DI | Hilt |
 | Navigation | Navigation 3 (`androidx.navigation3`) |
+| Persistence | Room, DataStore Preferences |
+| On-device AI | ML Kit GenAI Prompt API |
+| Images | Coil 3 |
 | Build | Gradle version catalog + custom convention plugins (`build-logic/`) |
-| Backend services | Firebase (Analytics, Crashlytics, Performance) |
-| Formatting | Spotless (ktlint + compose-rules-ktlint) |
+| Backend services | Firebase (Analytics, Crashlytics, Performance, App Distribution) |
+| Static analysis | Spotless (ktlint + compose-rules-ktlint), Detekt, Android Lint, LeakCanary in debug |
+| Min / target SDK | 28 / 37 |
 
 Exact versions live in [`gradle/libs.versions.toml`](gradle/libs.versions.toml) — that file is the
 single source of truth; nothing pins a version elsewhere.
 
 ## Architecture
 
-A multi-module Gradle project with one strict dependency direction:
+A multi-module Gradle project with one strict dependency direction: `app` → `feature/*/impl` →
+`feature/*/api` + `core/*`, and `core/*` never looks back at a feature.
 
-```
-app                          → wires everything together (Hilt graph, nav host, Activity)
-├── core/*                   → domain & infra: apps, app-permissions, app-index,
-│                               common, navigation, ui-library, user-preferences
-└── feature/<name>/{api,impl}
-    ├── api                  → NavKey only, depends on nothing
-    └── impl                 → screen + ViewModel, depends on its own api + needed core modules
+```mermaid
+graph TD
+    app[":app<br/>Activities, nav host, Hilt graph"]
+    fimpl["feature/&lt;name&gt;/impl<br/>screens + ViewModels"]
+    fapi["feature/&lt;name&gt;/api<br/>NavKeys only"]
+    core["core/*<br/>domain, data, design system"]
+
+    app --> fimpl
+    app --> core
+    fimpl --> fapi
+    fimpl --> core
+    core --> core
 ```
 
-Rules: `feature/*/api` depends on nothing; `feature/*/impl` depends on its own `api` plus whatever
-`core/*` modules it needs; `core/*` modules may depend on other `core/*` modules but never on
-`feature/*`; `app` depends on everything. Every module — including `app` itself — has its own
-`AGENTS.md` documenting its purpose, structure, and key types; start there when working inside a
-specific module instead of re-deriving it from scratch.
+Rules:
+
+* `feature/*/api` depends on nothing — it holds only `@Serializable` NavKeys and a tab label, so any
+  feature can navigate to another without touching its implementation.
+* `feature/*/impl` depends on its own `api` plus whichever `core` modules it needs. Never on another
+  feature's `impl`.
+* `core/*` may depend on other `core` modules, **never** on a `feature`.
+* `app` is wiring only: Activities, nav host, and app-scoped Hilt bindings. No feature logic.
+
+### How the code reads
+
+The same shapes repeat everywhere, so an unfamiliar file is rarely a surprise:
+
+* **One ViewModel shape.** A single `StateFlow<State>` and a single `onAction(Action)` with a `when`
+  dispatch. No other public methods. One-shot signals (navigation, toasts, intents) go out as
+  `Event`s over a `Channel`, never as state.
+* **One data-layer shape.** A public `interface` plus an `internal` `Impl`, bound with Hilt and
+  scoped `@Singleton`. Interface methods never throw — they return `Result<T>`, a nullable, or an
+  empty collection. Dispatchers are injected, never hardcoded.
+* **A design system, not scattered Material.** Feature modules don't import `androidx.compose.material3`
+  at all; they use the wrappers, theme and icons in [`core:ui-library`](core/ui-library/AGENTS.md).
+* **No comments.** Naming and structure carry the intent — deliberately, and enforced in review.
+* **One source of versions.** [`gradle/libs.versions.toml`](gradle/libs.versions.toml) for
+  dependencies, `build-logic` for SDK levels and the JVM toolchain. Nothing is pinned in a module.
+* **Documented decisions.** Every module carries an `AGENTS.md` explaining its boundary and package
+  map, and product decisions — including the ones deliberately retired — live in
+  [`docs/`](docs/product/README.md).
+
+### Modules
+
+| Module | Owns |
+|---|---|
+| [`core:apps`](core/apps/AGENTS.md) | Installed-app and APK analysis: extraction, normalization, caching, domain models |
+| [`core:apk-files`](core/apk-files/AGENTS.md) | Temporary materialization and cleanup of APKs received via content URIs |
+| [`core:app-index`](core/app-index/AGENTS.md) | Device-wide `attribute → apps` indexes behind Browse |
+| [`core:app-permissions`](core/app-permissions/AGENTS.md) | The deduplicated device-wide permission list |
+| [`core:ai-insights`](core/ai-insights/AGENTS.md) | On-device AI features and the ML Kit engine wrapper |
+| [`core:user-preferences`](core/user-preferences/AGENTS.md) | Recently viewed apps and search history |
+| [`core:navigation`](core/navigation/AGENTS.md) | Navigation 3 infrastructure for independent bottom-nav stacks |
+| [`core:ui-library`](core/ui-library/AGENTS.md) | The design system: theme, icons, components, animation metadata |
+| [`core:common`](core/common/AGENTS.md) | Dispatchers, logging, and models shared across domains |
+| [`feature:apps`](feature/apps/AGENTS.md) | The installed-app list: search, filter, sort |
+| [`feature:app-detail`](feature/app-detail/AGENTS.md) | The full report for one app or APK |
+| [`feature:browse`](feature/browse/AGENTS.md) | Browse by attribute |
+| [`feature:settings`](feature/settings/AGENTS.md) | Theme and app settings |
+
+Every module — including [`app`](app/AGENTS.md) — has its own `AGENTS.md` documenting its purpose,
+package map, and key types. Start there when working inside a module instead of re-deriving it.
 
 ## Getting started
 
-**Prerequisites:** Android Studio (latest stable). That's genuinely it — this project's Gradle
-setup auto-provisions a matching JDK on first build, and Android Studio's own SDK Manager covers
-the Android SDK. Run the `/setup-local-tools` skill for the full breakdown (including CLI-only /
-headless setup, and optional tools like the Firebase CLI and GitHub CLI).
+**Prerequisites:** Android Studio (latest stable). That's genuinely it — the Gradle setup
+auto-provisions a matching JDK on first build, and Android Studio's SDK Manager covers the Android
+SDK. The [`setup-local-tools`](.claude/skills/setup-local-tools/SKILL.md) skill has the full
+breakdown, including headless/CLI-only setup and optional tools.
 
 ```bash
 git clone https://github.com/MartinStyk/AndroidApkAnalyzer.git
@@ -79,27 +189,73 @@ cd AndroidApkAnalyzer
 ./gradlew assembleDebug   # first build downloads Gradle, the JDK, and all dependencies
 ```
 
-`app/google-services.json` is already committed (a real Firebase project config, required for the
-`:app` module's Firebase plugins to compile) — nothing to fetch or configure before your first
-build.
+`app/google-services.json` is committed, so the Firebase Gradle plugins compile out of the box with
+nothing to configure. CI replaces it with a freshly fetched config at build time.
 
 **Common tasks:**
 
 ```bash
-./gradlew installDebug       # build + install the debug build on a connected device/emulator
-./gradlew spotlessApply      # auto-fix formatting — run before every commit
-./gradlew spotlessCheck      # formatting check (what CI runs)
-./gradlew lintDebug          # Android lint
-./gradlew validateAgentContext # verify shared Claude/Copilot context
+./gradlew installDebug          # build + install debug on a connected device/emulator
+./gradlew spotlessApply         # auto-fix formatting — run before every commit
+./gradlew :feature:apps:impl:compileDebugKotlin   # fast single-module check while iterating
+./gradlew spotlessCheck detektDebug lintDebug :app:assembleDebug   # what CI gates on
+./gradlew validateAgentContext  # verify the shared Claude/Copilot context files
 ```
+
+Version name and code come from Gradle properties (`-Pversion.name=`, `-Pversion.code=`) and default
+to a local `dev` build.
+
+## Repository layout
+
+```
+app/           Activities, nav host, app-scoped Hilt bindings — wiring only
+core/          Domain, data, and design-system modules
+feature/       One api + impl pair per feature area
+build-logic/   Convention plugins; SDK levels and the JVM toolchain live here
+config/        Detekt and static-analysis configuration
+docs/          Product roadmap, feature design docs, technical decision records
+.claude/       Task skills shared by Claude and Copilot
+gradle/        Version catalog and wrapper
+```
+
+## CI and releases
+
+Every push and PR to `develop` runs `spotlessCheck`, Detekt, Android Lint (results uploaded as
+SARIF), and builds a debug APK that is attached to the run as an artifact. Pushes to `develop` also
+go out to internal testers via Firebase App Distribution.
+
+Tagging `MAJOR.MINOR.PATCH` runs the release workflow: it verifies against the release variant,
+builds and signs an AAB and APK, derives `versionCode` from the tag, publishes a GitHub release with
+the tag annotation as notes, uploads the AAB to the Play Store beta track with its mapping file, and
+distributes the APK to internal testers.
+
+## Documentation
+
+| Doc | What it covers |
+|---|---|
+| [`AGENTS.md`](AGENTS.md) | Engineering conventions — the canonical contributor reference |
+| [`docs/product/roadmap.md`](docs/product/roadmap.md) | Open scope and sequencing, with stable IDs |
+| [`docs/product/shipped.md`](docs/product/shipped.md) | What has shipped or been deliberately retired |
+| [`docs/product/features/`](docs/product/README.md) | One design doc per feature, written before it's built |
+| [`docs/technical/`](docs/technical/README.md) | Cross-cutting engineering decisions and audits |
+| [`.claude/skills/`](.claude/skills) | Step-by-step procedures for recurring tasks |
 
 ## Contributing
 
-Read [`AGENTS.md`](AGENTS.md) first — it documents module boundaries, navigation/DI/MVVM
-conventions, naming rules, where changes belong, and the
-[shared Claude/Copilot context](AGENTS.md#shared-ai-context).
+Contributions are welcome. Start with [`CONTRIBUTING.md`](CONTRIBUTING.md) for the workflow, then
+[`AGENTS.md`](AGENTS.md) for module boundaries and conventions. By participating you agree to the
+[Code of Conduct](CODE_OF_CONDUCT.md).
 
-Run `./gradlew spotlessApply spotlessCheck assembleDebug` before opening a PR.
+Good first contributions: a **translation** (the app currently ships English and Japanese, and a PR
+touching only `strings.xml` files needs no prior discussion), or anything marked open in the
+[roadmap](docs/product/roadmap.md).
+
+## Support
+
+* **Bugs and feature requests** — [open an issue](https://github.com/MartinStyk/AndroidApkAnalyzer/issues)
+* **Security vulnerabilities** — see [`SECURITY.md`](SECURITY.md); please don't file a public issue
+* **Using the app** — the [Play Store listing](https://play.google.com/store/apps/details?id=sk.styk.martin.apkanalyzer)
+  is the place for reviews and general feedback
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest release on Google Play is supported. Fixes ship in a new release rather than as
+patches to older versions.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security vulnerability.**
+
+Report it privately through
+[GitHub's private vulnerability reporting](https://github.com/MartinStyk/AndroidApkAnalyzer/security/advisories/new),
+or by email to **martin.styk@gmail.com** with `SECURITY` in the subject.
+
+Please include:
+
+* what the issue is and what an attacker could achieve
+* the app version and Android version you reproduced it on
+* steps to reproduce, ideally with a sample APK or app that triggers it
+* any relevant logs or a crash trace
+
+You can expect an acknowledgement within a few days and an assessment shortly after. Once a fix is
+released you'll be credited in the release notes unless you'd rather not be.
+
+## Scope
+
+This app reads and parses untrusted input: arbitrary `.apk` files chosen by the user or handed over
+by another app, and metadata from every installed package. The areas most worth scrutiny:
+
+* **APK parsing and manifest extraction** — [`core:apps`](core/apps/AGENTS.md)
+* **Temporary APK file handling and cleanup** — [`core:apk-files`](core/apk-files/AGENTS.md)
+* **Exported components and the incoming `VIEW`/`SEND` intent surface** — the `app` module
+* **Export and share flows**, including `FileProvider` URI exposure
+* **The on-device AI path**, where app-derived data is fed into a prompt —
+  [`core:ai-insights`](core/ai-insights/AGENTS.md)
+
+Out of scope: reports that require a rooted or already-compromised device, findings in third-party
+dependencies without a demonstrated impact on this app, and the two sensitive permissions the app
+declares by design (`QUERY_ALL_PACKAGES` and `PACKAGE_USAGE_STATS`) — both are documented in the
+[README](README.md#privacy-and-permissions).
+
+## Data handling
+
+App analysis runs on device. The app contains no networking code of its own; network access comes
+only from Firebase (Analytics, Crashlytics, Performance) and from ML Kit downloading the on-device
+AI model. See [`PRIVACY_POLICY.MD`](PRIVACY_POLICY.MD).


### PR DESCRIPTION
## Why
The repository needed public-facing documentation that reflects the same production quality and architectural clarity as the codebase. The previous README had solid content but was less scannable and missed standard open-source entry points for contributors and security reporting.

## What changed
- Reworked `README.md` into a clearer structure for users and contributors:
  - stronger project positioning and status badges
  - table of contents
  - scannable feature coverage and requirements
  - architecture and module map aligned with current multi-module layout
  - setup, CI/release flow, documentation index, support links
  - refined privacy wording around on-device analysis and limited network use
- Added `CONTRIBUTING.md` with:
  - contributor workflow and expectations
  - required local checks and fast iteration command
  - PR guidance and reporting expectations
- Added `SECURITY.md` with:
  - private vulnerability reporting path
  - supported version policy
  - security scope and data-handling notes

## Notes for reviewers
- Docs-only change; no app/runtime behavior changes.
- The README intentionally points to `AGENTS.md` and module-level `AGENTS.md` as canonical architecture context.