### PR TITLE
Fix Play Developer API OAuth scope in promote-release.yml

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           credentials_json: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
           token_format: access_token
+          access_token_scopes: 'https://www.googleapis.com/auth/androidpublisher'
 
       - name: Determine promotion source track
         id: source
@@ -63,9 +64,15 @@ jobs:
             exit 1
           fi
 
+          if [ "$FROM_TRACK" = "production" ]; then
+            TRACK_ARGS=(--update production)
+          else
+            TRACK_ARGS=(--from-track "$FROM_TRACK" --promote-track production)
+          fi
+
           if [ "$ROLLOUT_PERCENTAGE" -eq 100 ]; then
-            ./gradlew :app:promoteArtifact --from-track "$FROM_TRACK" --promote-track production --release-status completed
+            ./gradlew :app:promoteArtifact "${TRACK_ARGS[@]}" --release-status completed
           else
             USER_FRACTION=$(awk "BEGIN { printf \"%.2f\", $ROLLOUT_PERCENTAGE / 100 }")
-            ./gradlew :app:promoteArtifact --from-track "$FROM_TRACK" --promote-track production --release-status inProgress --user-fraction "$USER_FRACTION"
+            ./gradlew :app:promoteArtifact "${TRACK_ARGS[@]}" --release-status inProgress --user-fraction "$USER_FRACTION"
           fi


### PR DESCRIPTION
## Summary

Follow-up to #165, which merged before this commit made it in.

- `google-github-actions/auth` defaults `access_token_scopes` to `https://www.googleapis.com/auth/cloud-platform`. The Android Publisher API is a legacy scope-checked API (not IAM-based like most GCP services) and rejects that scope — it needs `https://www.googleapis.com/auth/androidpublisher` specifically. Without this, every `curl` call in the "Determine promotion source track" step would fail with 403, breaking `promote-release.yml` on first real use.
- Switch the same-track (adjust an in-progress production rollout) case to Gradle Play Publisher's `--update` flag instead of `--from-track production --promote-track production`. Functionally identical — confirmed via the plugin's own `--help` text ("This is the same as using 'from-track' and 'track' with the same value") and the maintainer's comment on [Triple-T/gradle-play-publisher#515](https://github.com/Triple-T/gradle-play-publisher/issues/515) — this just makes the intent explicit.

## Test plan

- [x] `./gradlew help --task promoteArtifact` confirms `--update` accepts a track argument
- [x] `./gradlew :app:promoteArtifact --update production --release-status completed` (no credentials) resolves and fails cleanly on "No credentials specified", same as the previous form — confirms the CLI combination is valid
- [ ] First real `promote-release.yml` run against the live Play Console (untested end-to-end, same as #165)