### PR TITLE
Replace bottom app bar with a floating pill navigation bar

### DIFF
--- a/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/NavigationBar.kt
+++ b/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/NavigationBar.kt
@@ -2,6 +2,7 @@ package sk.styk.martin.apkanalyzer.core.uilibrary.components
 
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.FastOutLinearInEasing
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.tween
@@ -11,24 +12,71 @@ import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.AnchoredDraggableDefaults
+import androidx.compose.foundation.gestures.AnchoredDraggableState
+import androidx.compose.foundation.gestures.DraggableAnchors
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.anchoredDraggable
+import androidx.compose.foundation.gestures.animateTo
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.BottomAppBar
-import androidx.compose.material3.Icon
-import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.navigation3.runtime.NavKey
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.launch
+import sk.styk.martin.apkanalyzer.core.uilibrary.R
 import sk.styk.martin.apkanalyzer.core.uilibrary.animation.NAV_DURATION_STANDARD
+import sk.styk.martin.apkanalyzer.core.uilibrary.icons.ApkAnalyzerIcons
+import sk.styk.martin.apkanalyzer.core.uilibrary.theme.ApkAnalyzerTheme
+import sk.styk.martin.apkanalyzer.core.uilibrary.theme.AppTheme
+import kotlin.math.roundToInt
 
-val navigationBarContentPadding: Dp = 80.dp
+private val NavigationPillHeight: Dp = 56.dp
+private val NavigationPillMargin: Dp = 16.dp
+private val NavigationPillItemPadding: Dp = 4.dp
+private val NavigationPillItemSpacing: Dp = 8.dp
+private val NavigationPillItemHorizontalPadding: Dp = 16.dp
+private val NavigationPillIconSize: Dp = 20.dp
+private val NavigationPillElevation: Dp = 8.dp
+
+val navigationBarContentPadding: Dp = NavigationPillHeight + NavigationPillMargin
 
 @Stable
 data class NavigationBarItem(
@@ -46,25 +94,105 @@ fun NavigationBar(
     onSelectKey: (NavKey) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    BottomAppBarVisibility(
+    NavigationBarVisibility(
         isVisible = isVisible,
         modifier = modifier.fillMaxWidth(),
     ) {
-        BottomAppBar {
-            items.forEach { item ->
-                val isSelected = item.navKey == selectedKey
-                NavigationBarItem(
-                    selected = isSelected,
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(
+                    start = NavigationPillMargin,
+                    end = NavigationPillMargin,
+                    bottom = NavigationPillMargin,
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            NavigationPill(
+                items = items,
+                selectedKey = selectedKey,
+                onSelectKey = onSelectKey,
+            )
+        }
+    }
+}
+
+@Composable
+private fun NavigationPill(
+    items: ImmutableList<NavigationBarItem>,
+    selectedKey: NavKey,
+    onSelectKey: (NavKey) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val dragState = remember {
+        AnchoredDraggableState(
+            initialValue = items.indexOfFirst { it.navKey == selectedKey }.coerceAtLeast(0),
+        )
+    }
+    val flingBehavior = AnchoredDraggableDefaults.flingBehavior(dragState)
+    val currentSelectedKey by rememberUpdatedState(selectedKey)
+    val currentOnSelectKey by rememberUpdatedState(onSelectKey)
+
+    LaunchedEffect(items) {
+        launch {
+            snapshotFlow { items.indexOfFirst { it.navKey == currentSelectedKey }.coerceAtLeast(0) }
+                .drop(1)
+                .collect { dragState.animateTo(it) }
+        }
+        snapshotFlow { dragState.settledValue }
+            .drop(1)
+            .collect { settledIndex ->
+                val settledKey = items.getOrNull(settledIndex)?.navKey
+                if (settledKey != null && settledKey != currentSelectedKey) {
+                    currentOnSelectKey(settledKey)
+                }
+            }
+    }
+
+    Box(
+        modifier = modifier
+            .width(IntrinsicSize.Max)
+            .height(NavigationPillHeight)
+            .shadow(elevation = NavigationPillElevation, shape = CircleShape)
+            .background(color = AppTheme.colors.surfaceVariant, shape = CircleShape)
+            .padding(NavigationPillItemPadding)
+            .onSizeChanged { size ->
+                val itemWidth = size.width.toFloat() / items.size
+                dragState.updateAnchors(
+                    DraggableAnchors {
+                        items.indices.forEach { index -> index at index * itemWidth }
+                    },
+                )
+            }
+            .anchoredDraggable(
+                state = dragState,
+                orientation = Orientation.Horizontal,
+                flingBehavior = flingBehavior,
+            )
+            .selectableGroup(),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(1f / items.size)
+                .fillMaxHeight()
+                .offset {
+                    val offset = dragState.offset
+                    IntOffset(x = if (offset.isNaN()) 0 else offset.roundToInt(), y = 0)
+                }
+                .background(color = AppTheme.colors.primaryContainer, shape = CircleShape),
+        )
+
+        val activeIndex = dragState.targetValue
+        Row(modifier = Modifier.fillMaxSize()) {
+            items.forEachIndexed { index, item ->
+                NavigationPillItem(
+                    item = item,
+                    isSelected = index == activeIndex,
                     onClick = { onSelectKey(item.navKey) },
-                    icon = {
-                        Icon(
-                            imageVector = if (isSelected) item.selectedIcon else item.unselectedIcon,
-                            contentDescription = stringResource(id = item.title),
-                        )
-                    },
-                    label = {
-                        Text(stringResource(item.title))
-                    },
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight(),
                 )
             }
         }
@@ -72,7 +200,46 @@ fun NavigationBar(
 }
 
 @Composable
-private fun BottomAppBarVisibility(
+private fun NavigationPillItem(
+    item: NavigationBarItem,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val contentColor by animateColorAsState(
+        targetValue = if (isSelected) AppTheme.colors.primary else AppTheme.colors.onSurfaceVariant,
+        animationSpec = tween(durationMillis = NAV_DURATION_STANDARD),
+    )
+
+    Row(
+        modifier = modifier
+            .clip(CircleShape)
+            .selectable(
+                selected = isSelected,
+                role = Role.Tab,
+                onClick = onClick,
+            )
+            .padding(horizontal = NavigationPillItemHorizontalPadding),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(NavigationPillItemSpacing, Alignment.CenterHorizontally),
+    ) {
+        Icon(
+            imageVector = if (isSelected) item.selectedIcon else item.unselectedIcon,
+            tint = contentColor,
+            modifier = Modifier.size(NavigationPillIconSize),
+        )
+        Text(
+            text = stringResource(item.title),
+            style = AppTheme.typography.labelLarge,
+            color = contentColor,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@Composable
+private fun NavigationBarVisibility(
     isVisible: Boolean,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
@@ -120,5 +287,50 @@ private fun BottomAppBarVisibility(
         ),
     ) {
         content()
+    }
+}
+
+private data object PreviewAppsKey : NavKey
+
+private data object PreviewBrowseKey : NavKey
+
+private val previewItems = persistentListOf(
+    NavigationBarItem(
+        navKey = PreviewAppsKey,
+        selectedIcon = ApkAnalyzerIcons.Apps,
+        unselectedIcon = ApkAnalyzerIcons.AppsBorder,
+        title = R.string.content_description_back,
+    ),
+    NavigationBarItem(
+        navKey = PreviewBrowseKey,
+        selectedIcon = ApkAnalyzerIcons.Browse,
+        unselectedIcon = ApkAnalyzerIcons.BrowseBorder,
+        title = R.string.content_description_selected,
+    ),
+)
+
+@Preview
+@Composable
+private fun NavigationBarFirstSelectedPreview() {
+    ApkAnalyzerTheme {
+        NavigationBar(
+            items = previewItems,
+            selectedKey = PreviewAppsKey,
+            isVisible = true,
+            onSelectKey = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun NavigationBarSecondSelectedPreview() {
+    ApkAnalyzerTheme {
+        NavigationBar(
+            items = previewItems,
+            selectedKey = PreviewBrowseKey,
+            isVisible = true,
+            onSelectKey = {},
+        )
     }
 }

--- a/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/icons/ApkAnalyzerIcons.kt
+++ b/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/icons/ApkAnalyzerIcons.kt
@@ -6,7 +6,7 @@ import androidx.compose.material.icons.automirrored.rounded.DirectionsRun
 import androidx.compose.material.icons.automirrored.rounded.InsertDriveFile
 import androidx.compose.material.icons.automirrored.rounded.VolumeUp
 import androidx.compose.material.icons.outlined.Apps
-import androidx.compose.material.icons.outlined.Category
+import androidx.compose.material.icons.outlined.Explore
 import androidx.compose.material.icons.outlined.InsertChart
 import androidx.compose.material.icons.outlined.Security
 import androidx.compose.material.icons.rounded.Android
@@ -18,7 +18,6 @@ import androidx.compose.material.icons.rounded.ArrowUpward
 import androidx.compose.material.icons.rounded.AutoAwesome
 import androidx.compose.material.icons.rounded.Bluetooth
 import androidx.compose.material.icons.rounded.CalendarToday
-import androidx.compose.material.icons.rounded.Category
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.ChevronRight
 import androidx.compose.material.icons.rounded.Clear
@@ -83,8 +82,8 @@ data object ApkAnalyzerIcons {
     val ActivityRecognition = Icons.AutoMirrored.Rounded.DirectionsRun
     val AiSparkle = Icons.Rounded.AutoAwesome
     val Bluetooth = Icons.Rounded.Bluetooth
-    val Browse = Icons.Rounded.Category
-    val BrowseBorder = Icons.Outlined.Category
+    val Browse = Icons.Rounded.Explore
+    val BrowseBorder = Icons.Outlined.Explore
     val Calendar = Icons.Rounded.CalendarToday
     val Camera = Icons.Rounded.PhotoCamera
     val Check = Icons.Rounded.Check


### PR DESCRIPTION
## Why

The Material `BottomAppBar` spent 80dp plus the navigation bar insets (roughly 104dp of screen height) to show two destinations. On a list-heavy screen like Apps that is a lot of permanently occupied space for very little information. The two icons also had nearly identical silhouettes: `Apps` was a 3x3 dot grid and `Browse` was `Category`, a cluster of shapes, so at a glance neither one read as distinct.

## What changed

`BottomAppBar` is replaced with a floating segmented pill. It is 56dp tall with a 16dp margin, sized to its content rather than the screen width, and it floats over the content instead of reserving a band at the bottom. `navigationBarContentPadding` is now derived from the pill height and margin instead of being a hardcoded 80dp that ignored insets.

![Floating pill navigation bar in both states](https://github.com/user-attachments/assets/4c468a34-7a9b-4c34-8c99-6ce90ef33462)

Selection is a single sliding indicator rather than a per item background, so switching tabs animates the indicator across instead of cross fading two separate backgrounds. The indicator is also draggable: `Modifier.anchoredDraggable` with `AnchoredDraggableDefaults.flingBehavior` gives the standard Android settling behaviour, the same one Material sheets and pagers use. A fling above 125 dp/s advances to the next tab regardless of distance, and a slower gesture falls back to a 50% positional threshold, so a short drag springs back.

`ApkAnalyzerIcons.Browse` / `BrowseBorder` move from `Category` to `Explore`, which gives the compass a clearly different outline from the Apps grid.

## Notes for review

- Both indicators of "which tab is active" come from one source: the label colours read `AnchoredDraggableState.targetValue`, the same value that decides where the drag settles, so they cannot disagree mid gesture.
- The drag offset is only read inside `Modifier.offset { }`, which runs in the placement phase, so dragging re-places the indicator without recomposing. The only recomposition during a gesture is `targetValue` flipping at the midpoint, which drives the label colour crossfade.
- Selection is synced in both directions through `snapshotFlow` rather than a guard on `settledValue`. That was deliberate: a cancelled `animateTo` leaves `settledValue` stale, so a guard on it could strand the indicator away from the selected tab if the user tapped twice quickly.
- `NavigationBar.kt` previously had no `@Preview` functions; it has them now for both selected states.
- Verified on a physical device in light and dark mode: tap in both directions, slow 30% and 40% drags spring back, a fast 40% flick advances, a slow 70% drag advances, and content bottom padding clears the pill on both the Apps and Browse screens.