### PR TITLE
Add dark-mode nav pill border and fix Settings row heights

### DIFF
--- a/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/NavigationBar.kt
+++ b/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/NavigationBar.kt
@@ -13,6 +13,7 @@ import androidx.compose.animation.scaleOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.AnchoredDraggableDefaults
 import androidx.compose.foundation.gestures.AnchoredDraggableState
 import androidx.compose.foundation.gestures.DraggableAnchors
@@ -75,6 +76,7 @@ private val NavigationPillItemSpacing: Dp = 8.dp
 private val NavigationPillItemHorizontalPadding: Dp = 16.dp
 private val NavigationPillIconSize: Dp = 20.dp
 private val NavigationPillElevation: Dp = 8.dp
+private val NavigationPillBorderWidth: Dp = 1.dp
 
 val navigationBarContentPadding: Dp = NavigationPillHeight + NavigationPillMargin
 
@@ -156,6 +158,7 @@ private fun NavigationPill(
             .height(NavigationPillHeight)
             .shadow(elevation = NavigationPillElevation, shape = CircleShape)
             .background(color = AppTheme.colors.surfaceVariant, shape = CircleShape)
+            .border(width = NavigationPillBorderWidth, color = AppTheme.colors.pillBorder, shape = CircleShape)
             .padding(NavigationPillItemPadding)
             .onSizeChanged { size ->
                 val itemWidth = size.width.toFloat() / items.size

--- a/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/theme/Color.kt
+++ b/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/theme/Color.kt
@@ -40,6 +40,7 @@ data class ApkAnalyzerColorPalette(
     val aiAccentContainer: Color,
 
     val shadow: Color,
+    val pillBorder: Color,
 )
 
 internal val LightApkAnalyzerColors = ApkAnalyzerColorPalette(
@@ -69,6 +70,7 @@ internal val LightApkAnalyzerColors = ApkAnalyzerColorPalette(
     aiAccent = Color(0xFF7C4DFF),
     aiAccentContainer = Color(0xFFEDE7FE),
     shadow = Color(0x1A000000),
+    pillBorder = Color.Transparent,
 )
 
 internal val DarkApkAnalyzerColors = ApkAnalyzerColorPalette(
@@ -98,6 +100,7 @@ internal val DarkApkAnalyzerColors = ApkAnalyzerColorPalette(
     aiAccent = Color(0xFFB39DFF),
     aiAccentContainer = Color(0xFF2E2251),
     shadow = Color(0x00000000),
+    pillBorder = Color(0xFF2C2C2E),
 )
 
 internal fun lightColorScheme(colors: ApkAnalyzerColorPalette) = lightColorScheme(

--- a/feature/settings/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/settings/impl/SettingsScreen.kt
+++ b/feature/settings/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/settings/impl/SettingsScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -38,6 +39,8 @@ import sk.styk.martin.apkanalyzer.core.uilibrary.modifier.card
 import sk.styk.martin.apkanalyzer.core.uilibrary.modifier.sharedBounds
 import sk.styk.martin.apkanalyzer.core.uilibrary.theme.ApkAnalyzerTheme
 import sk.styk.martin.apkanalyzer.core.uilibrary.theme.AppTheme
+
+private val SettingsRowMinHeight = 48.dp
 
 @Composable
 fun SettingsScreen(
@@ -167,7 +170,8 @@ private fun AppsSection(
             modifier = Modifier
                 .fillMaxWidth()
                 .card()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+                .heightIn(min = SettingsRowMinHeight),
         ) {
             val recentlyViewedLabel = stringResource(R.string.settings_recently_viewed_toggle)
             Text(
@@ -206,7 +210,8 @@ private fun LanguageSection(
                 .fillMaxWidth()
                 .card()
                 .clickable(onClick = onOpenLanguageSettings)
-                .padding(horizontal = 16.dp, vertical = 12.dp),
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+                .heightIn(min = SettingsRowMinHeight),
         ) {
             Text(
                 text = appLanguageLabel,


### PR DESCRIPTION
## Why

Follow-up from a color/contrast review of the app: in dark mode the floating bottom nav pill had no visible edge against the pure-black background (the palette's `shadow` field is fully transparent there), so it looked like it was floating in a void. Separately, in Settings, the Language row was visibly shorter than the Recently viewed apps row above it.

## What changed

**Nav pill dark-mode separation**
- Added a new `pillBorder` color to `ApkAnalyzerColorPalette`: `Color.Transparent` in light theme, a subtle `#2C2C2E` gray in dark theme (just brighter than pure black, in the spirit of the existing `shadow` field's per-theme pattern).
- Applied it as a single 1dp border on the pill's outer container only (not on the selected-segment indicator).
- Deliberately avoided a border/stroke on the indicator itself: an earlier version of this change added borders more broadly, but the app doesn't use strokes anywhere else, and its existing "selected" idiom (see `Chip.kt`) is already pale-container + saturated-content-color, not border-driven. This keeps the fix scoped to the one spot with an actual visibility gap in dark mode.

**Settings row height consistency**
- The Language row (Text + chevron icon) and Recently viewed apps row (Text + Switch) only matched height by coincidence, because Material3's `Switch` enforces a 48dp touch target. Extracted that as an explicit `SettingsRowMinHeight = 48.dp` constraint applied to both rows, so they stay visually consistent regardless of trailing content.

## Notes for reviewers

Verified on a physical device (both Day and Night app-level themes, independent of system dark mode) - the pill now has a subtle hairline in dark mode and is pixel-identical to before in light mode; the two Settings cards now render at the same height.