### PR TITLE
Add animated splash screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
 
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.appcompat)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.process)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
         <activity
             android:name=".ui.ApkAnalyzerActivity"
             android:exported="true"
+            android:theme="@style/Theme.App.Starting"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -33,6 +34,7 @@
             android:documentLaunchMode="always"
             android:excludeFromRecents="true"
             android:exported="true"
+            android:theme="@style/Theme.App.Starting"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/AnimatedSplashScreen.kt
+++ b/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/AnimatedSplashScreen.kt
@@ -1,0 +1,45 @@
+package sk.styk.martin.apkanalyzer.ui
+
+import android.animation.AnimatorSet
+import android.animation.ObjectAnimator
+import android.view.View
+import android.view.animation.PathInterpolator
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.core.animation.doOnEnd
+import androidx.core.splashscreen.SplashScreen
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+
+private const val SPLASH_EXIT_ANIMATION_DURATION_MS = 250L
+private val materialFastOutLinearIn = PathInterpolator(0.4f, 0f, 1f, 1f)
+
+internal fun ComponentActivity.installAnimatedSplashScreen(): SplashScreen {
+    val splashScreen = installSplashScreen()
+    splashScreen.setKeepOnScreenCondition { true }
+    splashScreen.setOnExitAnimationListener { splashScreenView ->
+        val zoomIconOutX = ObjectAnimator.ofFloat(splashScreenView.iconView, View.SCALE_X, 1f, 1.4f)
+        val zoomIconOutY = ObjectAnimator.ofFloat(splashScreenView.iconView, View.SCALE_Y, 1f, 1.4f)
+        val fadeIconOut = ObjectAnimator.ofFloat(splashScreenView.iconView, View.ALPHA, 1f, 0f)
+        val fadeBackgroundOut = ObjectAnimator.ofFloat(splashScreenView.view, View.ALPHA, 1f, 0f)
+        AnimatorSet().apply {
+            playTogether(zoomIconOutX, zoomIconOutY, fadeIconOut, fadeBackgroundOut)
+            duration = SPLASH_EXIT_ANIMATION_DURATION_MS
+            interpolator = materialFastOutLinearIn
+            doOnEnd { splashScreenView.remove() }
+            start()
+        }
+    }
+    return splashScreen
+}
+
+@Composable
+internal fun SplashScreen.KeepOnScreenWhile(condition: Boolean) {
+    val currentCondition by rememberUpdatedState(condition)
+    DisposableEffect(this) {
+        setKeepOnScreenCondition { currentCondition }
+        onDispose {}
+    }
+}

--- a/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/ApkAnalyzerActivity.kt
+++ b/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/ApkAnalyzerActivity.kt
@@ -20,10 +20,13 @@ class ApkAnalyzerActivity : ComponentActivity() {
     lateinit var inAppReviewLauncher: InAppReviewLauncher
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        val splashScreen = installAnimatedSplashScreen()
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
         setContent {
             val state by viewModel.state.collectAsStateWithLifecycle()
+            splashScreen.KeepOnScreenWhile(state is ApkAnalyzerState.Loading)
             LaunchedEffect(Unit) {
                 viewModel.events.collect { event ->
                     when (event) {

--- a/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/externalapk/ExternalApkActivity.kt
+++ b/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/externalapk/ExternalApkActivity.kt
@@ -10,14 +10,18 @@ import androidx.activity.viewModels
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dagger.hilt.android.AndroidEntryPoint
+import sk.styk.martin.apkanalyzer.ui.ApkAnalyzerState
 import sk.styk.martin.apkanalyzer.ui.ApkAnalyzerThemeHost
 import sk.styk.martin.apkanalyzer.ui.ApkAnalyzerViewModel
+import sk.styk.martin.apkanalyzer.ui.KeepOnScreenWhile
+import sk.styk.martin.apkanalyzer.ui.installAnimatedSplashScreen
 
 @AndroidEntryPoint
 class ExternalApkActivity : ComponentActivity() {
     private val appViewModel: ApkAnalyzerViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        val splashScreen = installAnimatedSplashScreen()
         super.onCreate(savedInstanceState)
         val sourceUri = intent.externalApkUri()
         if (sourceUri == null) {
@@ -28,6 +32,7 @@ class ExternalApkActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             val appState by appViewModel.state.collectAsStateWithLifecycle()
+            splashScreen.KeepOnScreenWhile(appState is ApkAnalyzerState.Loading)
             ApkAnalyzerThemeHost(state = appState) {
                 ExternalApkApp(
                     sourceUri = sourceUri,

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="splash_background">#FF161618</color>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="splash_background">#FFFFFFFF</color>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="AppTheme" parent="android:Theme.Material.Light.NoActionBar" />
+
+    <style name="Theme.App.Starting" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@color/splash_background</item>
+        <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
+        <item name="postSplashScreenTheme">@style/AppTheme</item>
+    </style>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ kotlinx-collections-immutable = "0.5.1"
 # Android
 agp = "9.3.1"
 core-ktx = "1.19.0"
+core-splashscreen = "1.2.0"
 appcompat = "1.8.0"
 activity = "1.13.0"
 lifecycle = "2.11.0"
@@ -51,6 +52,7 @@ triplet-play = "4.1.1"
 [libraries]
 # AndroidX Core
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }
+androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "core-splashscreen" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }


### PR DESCRIPTION
## Summary
- Adds an animated splash screen via the Splash Screen API: white surface background, the self-contained app icon on top, and a Material fast-out-linear-in zoom-and-fade exit into the app content.
- Splash stays on screen until the persisted color scheme finishes loading (`ApkAnalyzerState.Loading`).
- Install/exit-animation/keep-on-screen logic is shared between `ApkAnalyzerActivity` and `ExternalApkActivity` via a single `installAnimatedSplashScreen()` / `SplashScreen.KeepOnScreenWhile()` helper.

Closes #193

## Test plan
- [x] `./gradlew :app:compileDebugKotlin`
- [x] `./gradlew spotlessApply`
- [x] `./gradlew :app:assembleDebug`
- [x] Installed and launched on a physical device (SM-S942B), verified splash renders and transitions into the app with no crash, and no title-bar regression on either activity