### PR TITLE
Fix recently-viewed/search-history crash on SQLite < 3.24

### DIFF
--- a/core/user-preferences/src/main/kotlin/sk/styk/martin/apkanalyzer/core/userpreferences/recentlyviewed/RecentlyViewedAppDao.kt
+++ b/core/user-preferences/src/main/kotlin/sk/styk/martin/apkanalyzer/core/userpreferences/recentlyviewed/RecentlyViewedAppDao.kt
@@ -2,6 +2,8 @@ package sk.styk.martin.apkanalyzer.core.userpreferences.recentlyviewed
 
 import androidx.room.Dao
 import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Upsert
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -9,14 +11,17 @@ internal interface RecentlyViewedAppDao {
     @Query("SELECT packageName FROM recently_viewed_apps ORDER BY lastViewedAt DESC LIMIT :limit")
     fun observeRecentPackageNames(limit: Int): Flow<List<String>>
 
-    @Query(
-        """
-        INSERT INTO recently_viewed_apps (packageName, viewCount, lastViewedAt)
-        VALUES (:packageName, 1, :timestamp)
-        ON CONFLICT(packageName) DO UPDATE SET viewCount = viewCount + 1, lastViewedAt = :timestamp
-        """,
-    )
-    suspend fun recordView(packageName: String, timestamp: Long)
+    @Transaction
+    suspend fun recordView(packageName: String, timestamp: Long) {
+        val currentViewCount = getViewCount(packageName) ?: 0
+        upsert(RecentlyViewedAppEntity(packageName = packageName, viewCount = currentViewCount + 1, lastViewedAt = timestamp))
+    }
+
+    @Query("SELECT viewCount FROM recently_viewed_apps WHERE packageName = :packageName")
+    suspend fun getViewCount(packageName: String): Int?
+
+    @Upsert
+    suspend fun upsert(entity: RecentlyViewedAppEntity)
 
     @Query("SELECT COUNT(*) FROM recently_viewed_apps")
     suspend fun count(): Int

--- a/core/user-preferences/src/main/kotlin/sk/styk/martin/apkanalyzer/core/userpreferences/searchhistory/SearchHistoryDao.kt
+++ b/core/user-preferences/src/main/kotlin/sk/styk/martin/apkanalyzer/core/userpreferences/searchhistory/SearchHistoryDao.kt
@@ -2,6 +2,8 @@ package sk.styk.martin.apkanalyzer.core.userpreferences.searchhistory
 
 import androidx.room.Dao
 import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Upsert
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -9,21 +11,28 @@ internal interface SearchHistoryDao {
     @Query("SELECT * FROM search_history ORDER BY lastSearchedAt DESC LIMIT :limit")
     fun observeRecent(limit: Int): Flow<List<SearchHistoryEntity>>
 
-    @Query(
-        """
-        INSERT INTO search_history (packageName, query, searchCount, lastSearchedAt)
-        VALUES (:packageName, :query, 1, :timestamp)
-        ON CONFLICT(packageName) DO UPDATE SET
-            query = :query,
-            searchCount = searchCount + 1,
-            lastSearchedAt = :timestamp
-        """,
-    )
+    @Transaction
     suspend fun recordSearch(
         packageName: String,
         query: String,
         timestamp: Long,
-    )
+    ) {
+        val currentSearchCount = getSearchCount(packageName) ?: 0
+        upsert(
+            SearchHistoryEntity(
+                packageName = packageName,
+                query = query,
+                searchCount = currentSearchCount + 1,
+                lastSearchedAt = timestamp,
+            ),
+        )
+    }
+
+    @Query("SELECT searchCount FROM search_history WHERE packageName = :packageName")
+    suspend fun getSearchCount(packageName: String): Int?
+
+    @Upsert
+    suspend fun upsert(entity: SearchHistoryEntity)
 
     @Query("DELETE FROM search_history WHERE packageName = :packageName")
     suspend fun deletePackage(packageName: String)


### PR DESCRIPTION
## Summary
- `RecentlyViewedAppDao.recordView` and `SearchHistoryDao.recordSearch` used raw SQL `INSERT ... ON CONFLICT ... DO UPDATE`, which requires SQLite's native UPSERT support (3.24+).
- minSdk is 28 (Android 9), which ships SQLite 3.22 — that statement fails to even compile there, throwing `SQLiteException: near "ON": syntax error` on every recorded view/search and crashing the app (observed for `com.wildberries.ru`, but affects any app on API 28).
- Replaced both with a `@Transaction` default DAO method that reads the current count and writes the incremented row via Room's `@Upsert` (which falls back to insert-then-update internally, not native SQL UPSERT). The `@Transaction` keeps the read+write a single atomic unit.

## Test plan
- [x] `./gradlew :core:user-preferences:compileDebugKotlin` — Room/KSP generates the DAO impls correctly
- [x] `./gradlew spotlessApply`
- [ ] Manually verify recently-viewed and search-history recording on an API 28 device/emulator