### PR TITLE
Add Crashlytics triage and fix skills

### DIFF
--- a/.claude/skills/fix-crash/SKILL.md
+++ b/.claude/skills/fix-crash/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: fix-crash
+description: Use to fix a specific production crash or non-fatal — pulling its Crashlytics data, finding the linked GitHub issue, root-causing it, reproducing it, fixing it, and verifying the fix without breaking stored-data compatibility. Triggered by phrases like "fix this crash", "fix issue #42", "root cause this crash", "why does this crash happen", "reproduce this crash", "fix the Crashlytics issue".
+---
+
+# Skill: Root-Cause, Reproduce, and Fix a Production Crash
+
+> Takes one Crashlytics issue (or the GitHub issue tracking it) from symptom to a verified fix,
+> without breaking users whose stored data was written by an older release.
+
+Finding *which* crashes to work on is a different skill: `triage-crashes`. This one fixes a single
+known crash. Read `triage-crashes` for how the Crashlytics MCP bridge works — this skill uses the
+same `scripts/crashlytics.js` and the same appId.
+
+## Step 1 — Resolve the crash and its GitHub issue
+
+You may be given a Crashlytics issue id, a console URL, a GitHub issue number, or a description.
+Get to a `(crashlyticsIssueId, githubIssueNumber)` pair, where either may be absent:
+
+| Given | Do |
+|---|---|
+| Crashlytics id or console URL | `crashlytics_list_notes` for a `github.com/.../issues/<n>` link; if none, `gh issue list --state all --limit 200 --search "<id>"` |
+| GitHub issue number | `gh issue view <n> --comments` and find the Crashlytics id in the body or comments |
+| A description only | Run the `triage-crashes` report queries and match on the exception and frame |
+
+The Crashlytics id is the join key in both directions — issues filed by `triage-crashes` carry it in
+their body and a note pointing back. If you find a GitHub issue with no Crashlytics note, add the
+note now with `crashlytics_create_note`.
+
+If **no** GitHub issue exists, file one with `create_issue` (label `bug`) using the `triage-crashes`
+body format before starting work, so the fix has something to close.
+
+## Step 2 — Pull everything the platform knows
+
+```json
+[
+  { "name": "crashlytics_get_issue", "arguments": { "appId": "1:636588470688:android:c27a676c8deb5eb0", "issueId": "<id>" } },
+  { "name": "crashlytics_list_events", "arguments": { "appId": "...", "pageSize": 5, "filter": { "issueId": "<id>" } } },
+  { "name": "crashlytics_get_report", "arguments": { "appId": "...", "report": "topAndroidDevices", "pageSize": 10, "filter": { "issueId": "<id>" } } },
+  { "name": "crashlytics_get_report", "arguments": { "appId": "...", "report": "topOperatingSystems", "pageSize": 10, "filter": { "issueId": "<id>" } } },
+  { "name": "crashlytics_get_report", "arguments": { "appId": "...", "report": "topVersions", "pageSize": 10, "filter": { "issueId": "<id>" } } }
+]
+```
+
+Read **several** events, not just one. One stack tells you where it broke; several tell you what the
+occurrences share. Look at each event's breadcrumbs, custom keys, and device state.
+
+The distribution is evidence, and it usually names the root cause on its own:
+
+| Pattern | What it means |
+|---|---|
+| One OS version, or everything below/above an API level | An API availability or behaviour change — check the `minSdk`/`targetSdk` guard around that call |
+| One manufacturer | An OEM-modified framework; often needs a defensive path, not a "correct" fix |
+| Starts exactly at one app version | A regression — `git log` between that tag and the previous one |
+| Spread evenly across everything | Logic or state bug, not environmental |
+
+`firstSeenVersion` plus `git log <prev-tag>..<that-tag>` is the fastest route to a regression's cause.
+
+## Step 3 — Root cause it in this repo
+
+Find the deepest `sk.styk.martin.apkanalyzer.*` frame, map its package to a module (see `AGENTS.md`),
+read that module's `AGENTS.md`, then read the actual code. Then state the root cause as one sentence
+naming the specific condition — "`ON CONFLICT` upsert syntax requires SQLite 3.24, which is absent
+below API 30", not "a database error".
+
+Do not start editing until you can state that sentence. If the evidence doesn't support one, say so
+and pull more events rather than guessing.
+
+Watch for these, which this codebase has actually produced:
+
+* A framework symbol that doesn't exist on older API levels (`NoSuchMethodError`, `NoSuchFieldError`)
+  — the compile-time SDK has it, the runtime device doesn't.
+* Raw SQL in a Room `@Query` using syntax newer than the device's bundled SQLite.
+* A `LazyColumn` item key that isn't unique across the whole list.
+* A `SecurityException` from a package the caller can't inspect on newer Android.
+
+## Step 4 — Reproduce before fixing
+
+An unreproduced fix is a guess. Reproduce in the cheapest way that actually exercises the failure:
+
+1. **Match the environment.** If the distribution points at an API level, start an emulator at that
+   exact level — a fix verified only on your daily driver proves nothing about an API-29 crash. Use
+   the `run-app` skill to build, install and launch, and `navigate-app-adb` to drive to the screen.
+2. **Reach the state.** Breadcrumbs and custom keys on the event tell you what the user did. For a
+   crash needing specific stored data, seed it via the app's own flows, or with `adb shell` against
+   the app's database — never by adding production code that fabricates the state.
+3. **Confirm the same stack.** `adb logcat` must show the *same* exception at the *same* frame. A
+   different crash on the same screen is a different bug.
+
+If it genuinely can't be reproduced locally (OEM-specific, a device you don't have), say so
+explicitly, and compensate: write the fix so the failing path is provably impossible (a version
+guard, a supported API) rather than probabilistically better, and prove the guard with the API level
+you *can* run.
+
+Never add a debug hook, test-only flag, or logging to production code to force a repro. Remove any
+temporary scaffolding before finishing.
+
+## Step 5 — Fix it
+
+Follow `AGENTS.md` and the module's own `AGENTS.md`. Beyond those:
+
+* Fix the cause, not the symptom. A `try/catch` around a crash that leaves the feature silently
+  broken is not a fix — `AGENTS.md` forbids hiding errors behind broad exception handling. Catching
+  is only correct when the exception is genuinely expected and the app has a real answer for it.
+* Prefer the platform-supported API over a version-guarded fork when one exists.
+* If the same broken pattern appears elsewhere, fix every occurrence — grep for it. Shipping a fix
+  for one of three identical DAOs means two more crash reports next release.
+
+## Step 6 — Do not break stored data
+
+**Mandatory whenever the fix touches persistence** — Room entities, DAOs, migrations, DataStore,
+SharedPreferences, or any serialized model. Users upgrade in place; their existing data was written
+by the old code.
+
+* **Schema change** → a Room migration is required. Never bump `version` without one, and never
+  resort to `fallbackToDestructiveMigration` — that silently deletes user data.
+* **A migration already shipped** → it is immutable. Users have run it. Add a new one; never edit it.
+* **Entity/serialized model field change** → adding a nullable field with a default is safe. Removing
+  or renaming a field, or narrowing a type, breaks old rows — migrate them.
+* **DataStore / preferences key change** → old keys persist. Either keep reading the old key, or
+  migrate the value on first read. Silently ignoring it resets the user's settings.
+* **Query-only fix** (this is the common case) → confirm the new SQL reads the *existing* schema
+  correctly, including rows written before the fix.
+
+Then verify with an actual upgrade, not a clean install: install the previous release, use the app
+enough to write data, install the fixed build over it **without uninstalling**, and confirm the old
+data still reads correctly and the crash is gone. `adb install -r` preserves data; `adb uninstall`
+destroys the evidence and turns this check into theatre.
+
+## Step 7 — Verify
+
+1. Re-run the repro from Step 4 on the same emulator/API level. The crash must be gone and the
+   feature must actually work — not just not crash.
+2. Check the neighbouring paths the change touched.
+3. Build: `./gradlew :<module>:compileDebugKotlin`, then `./gradlew spotlessApply` before committing.
+4. Check by hand for imports left behind by deleted code — `spotlessCheck` doesn't flag those.
+5. For any visual change, look at it on a device; a clean compile proves nothing about layout.
+
+## Step 8 — Close the loop
+
+* Commit referencing the GitHub issue (`Fixes #<n>`). Author as the human user only — see the
+  `git-commit-author` skill.
+* Comment on the GitHub issue with the root cause, how it was reproduced, what the fix does, and how
+  it was verified — including the upgrade check if persistence was touched.
+* Add a Crashlytics note recording the fix and the commit/PR.
+* **Do not** close the Crashlytics issue with `crashlytics_update_issue`. It is fixed when a release
+  containing the fix stops producing events, which you can't know yet. Note it and move on.
+
+## Verification
+
+- [ ] Crashlytics issue and GitHub issue are linked in both directions
+- [ ] Multiple events read, not just one sample
+- [ ] Device/OS/version distribution examined for the environmental pattern
+- [ ] Root cause stated in one sentence naming the specific condition
+- [ ] Reproduced on an environment matching the crash — or the inability stated explicitly, with a
+      guard-based fix compensating
+- [ ] Fix addresses the cause; no exception swallowed to silence it
+- [ ] Grepped for the same pattern elsewhere and fixed every occurrence
+- [ ] Persistence changes carry a migration; existing keys/fields still read
+- [ ] Verified by upgrading over the previous release, not by a clean install
+- [ ] Crash gone on re-run and the feature actually works
+- [ ] `spotlessApply` run; no orphaned imports
+- [ ] GitHub issue commented, Crashlytics note added, Crashlytics state left alone

--- a/.claude/skills/fix-crash/SKILL.md
+++ b/.claude/skills/fix-crash/SKILL.md
@@ -49,7 +49,7 @@ The distribution is evidence, and it usually names the root cause on its own:
 
 | Pattern | What it means |
 |---|---|
-| One OS version, or everything below/above an API level | An API availability or behaviour change — check the `minSdk`/`targetSdk` guard around that call |
+| One OS version, or everything below/above an API level | An API availability or behaviour change — check the runtime SDK guard around that call or use a backward-compatible API |
 | One manufacturer | An OEM-modified framework; often needs a defensive path, not a "correct" fix |
 | Starts exactly at one app version | A regression — `git log` between that tag and the previous one |
 | Spread evenly across everything | Logic or state bug, not environmental |

--- a/.claude/skills/triage-crashes/SKILL.md
+++ b/.claude/skills/triage-crashes/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: triage-crashes
+description: Use to review production Crashlytics crashes and non-fatals for the latest release and file a GitHub issue for each one that isn't tracked yet. Triggered by phrases like "triage crashes", "check production crashes", "look at Crashlytics", "any new crashes", "review non-fatals", "file issues for the latest release crashes", "what's crashing in production".
+---
+
+# Skill: Triage Production Crashes and Non-Fatals
+
+> Reads Crashlytics for the latest released version, decides which issues are worth tracking, and
+> files one GitHub `bug` issue per untracked issue — linking both directions so the same crash is
+> never filed twice.
+
+Fixing a crash is a **different** skill: `fix-crash`. This skill only triages and files.
+
+## How Crashlytics is read
+
+There is no Crashlytics REST API and `firebase crashlytics:*` only *uploads* symbols. Read access
+comes from the Firebase CLI's MCP server, driven by `scripts/crashlytics.js` in this skill folder:
+
+```powershell
+node .claude\skills\triage-crashes\scripts\crashlytics.js . <calls.json>
+```
+
+`<calls.json>` is an array of `{ "name": ..., "arguments": ... }` tool calls run in order. Write it
+to the session artifacts folder, not the repo. Batch several calls into one file — each invocation
+pays the CLI's startup cost.
+
+Constants for this project:
+
+| Thing | Value |
+|---|---|
+| Firebase project | `apkanalyzer-f79a3` |
+| `appId` (free flavour, the one that gets traffic) | `1:636588470688:android:c27a676c8deb5eb0` |
+| `appId` (premium — only if the user asks) | `1:636588470688:android:89ea2fd0c34abd89` |
+
+Available tools: `crashlytics_get_report`, `crashlytics_get_issue`, `crashlytics_list_events`,
+`crashlytics_batch_get_events`, `crashlytics_list_notes`, `crashlytics_create_note`,
+`crashlytics_delete_note`, `crashlytics_update_issue`.
+
+If a call fails with `PRECONDITION_FAILED: ... requires an active project`, prepend
+`{ "name": "firebase_update_environment", "arguments": { "active_project": "apkanalyzer-f79a3" } }`
+to the calls file. If it fails on auth, ask the user to run `firebase login` — never try to
+re-authenticate on their behalf.
+
+## Step 1 — Determine the latest released version
+
+**Do not** use the `topVersions` report to pick "latest" — it sorts by event count, so a popular old
+version outranks a fresh release. Get the version from git instead:
+
+```powershell
+git tag --sort=-v:refname | Select-Object -First 1
+```
+
+Release tags are `MAJOR.MINOR.PATCH`; `.github/workflows/release.yml` computes
+`versionCode = MAJOR * 10000 + MINOR * 100 + PATCH`. Crashlytics wants the combined
+`versionDisplayNames` format — tag `4.0.0` → `"4.0.0 (40000)"`.
+
+Confirm that display name actually appears in a `topVersions` report before filtering on it; if it
+doesn't, the release has no events yet (say so and stop) or the tag/versionCode assumption broke.
+
+Bare numeric tags (`58`, `57`) are the pre-4.0 scheme — ignore them when resolving "latest".
+
+## Step 2 — Pull the issue list
+
+Two reports, run separately so fatals and non-fatals stay distinguishable:
+
+```json
+[
+  { "name": "crashlytics_get_report",
+    "arguments": { "appId": "1:636588470688:android:c27a676c8deb5eb0", "report": "topIssues", "pageSize": 25,
+      "filter": { "versionDisplayNames": ["4.0.0 (40000)"], "issueErrorTypes": ["FATAL"] } } },
+  { "name": "crashlytics_get_report",
+    "arguments": { "appId": "1:636588470688:android:c27a676c8deb5eb0", "report": "topIssues", "pageSize": 25,
+      "filter": { "versionDisplayNames": ["4.0.0 (40000)"], "issueErrorTypes": ["NON_FATAL"] } } }
+]
+```
+
+Also run `ANR` unless the user narrowed the scope — an ANR is a production defect like any other.
+
+The default window is the last 7 days. For a wider one pass both `intervalStartTime` and
+`intervalEndTime` (max 90 days). Skip issues whose `state` is not `OPEN` — closed/muted issues were
+already judged by a human.
+
+Each group gives you `issue.id`, `title`, `subtitle`, `errorType`, `state`, `signals`,
+`firstSeenVersion`, `lastSeenVersion`, a console `uri`, a `sampleEvent`, and per-window
+`eventsCount` / `impactedUsersCount`.
+
+## Step 3 — Skip anything already tracked
+
+Check **both** directions before filing. An issue is already tracked if either is true:
+
+1. A Crashlytics note references a GitHub issue —
+   `crashlytics_list_notes` with the `issueId`, look for `github.com/MartinStyk/apk-analyzer/issues/`.
+2. A GitHub issue references the Crashlytics issue id —
+   `gh issue list --state all --limit 200 --search "<crashlytics-issue-id>"`.
+
+The Crashlytics issue id is the durable key. Never dedupe on the title: Crashlytics titles are
+derived from the top frame and change when the code moves.
+
+When an issue is already tracked but the *note* is missing (i.e. only direction 2 matched),
+backfill the note — that keeps the console usable for whoever looks there first.
+
+## Step 4 — Decide whether it deserves an issue
+
+| Kind | Rule |
+|---|---|
+| `FATAL` | Always file. A crash in a shipped release is always worth tracking. |
+| `ANR` | Always file. |
+| `NON_FATAL` | Judgement call — see below. |
+
+Non-fatals split three ways, and **all three get an issue**; only the framing differs:
+
+* **Worth fixing** — a real defect the app swallowed (a caught exception that leaves a broken or
+  empty screen, a failed parse of a valid APK, a permission path that silently no-ops). File it as a
+  normal bug.
+* **Wrong / misreported** — the code reports a non-fatal for something that isn't actually a fault
+  (an expected `SecurityException` from a restricted package, a user-cancelled operation, an
+  expected null on an OS version). File it, and make the issue about **removing or downgrading the
+  report** — a noisy non-fatal hides the real ones. Say plainly in the body that the recommendation
+  is to stop reporting it, and why.
+* **Unnecessary / not actionable** — fires only on a rooted device, an ancient OEM ROM, an OS bug
+  with no app-side remedy. File it recommending the report be dropped or the condition handled
+  quietly, and state what evidence led there (use the top devices / top OS reports).
+
+Never silently discard a non-fatal. If it isn't worth fixing, that judgement *is* the issue.
+
+## Step 5 — Gather detail before writing the issue
+
+An issue with only a title and a link is not worth filing. For each one, pull:
+
+```json
+[
+  { "name": "crashlytics_get_issue", "arguments": { "appId": "...", "issueId": "<id>" } },
+  { "name": "crashlytics_batch_get_events", "arguments": { "appId": "...", "names": ["<sampleEvent>"] } },
+  { "name": "crashlytics_get_report",
+    "arguments": { "appId": "...", "report": "topAndroidDevices", "pageSize": 5, "filter": { "issueId": "<id>" } } },
+  { "name": "crashlytics_get_report",
+    "arguments": { "appId": "...", "report": "topOperatingSystems", "pageSize": 5, "filter": { "issueId": "<id>" } } }
+]
+```
+
+Then map the top stack frame onto this repo. The frames are package-qualified
+(`sk.styk.martin.apkanalyzer.core.userpreferences.searchhistory.SearchHistoryDao_Impl`), so the
+owning module follows directly from the package — see the module/package mapping in `AGENTS.md`.
+Read the actual source of the top app frame before writing the issue; a triage issue that names the
+wrong file wastes more time than no issue.
+
+Ignore framework-only frames when locating the owner — find the deepest
+`sk.styk.martin.apkanalyzer.*` frame.
+
+## Step 6 — File the GitHub issue
+
+Use the `create_issue` tool (not `gh issue create`) so the user gets the confirmation card. Label
+it `bug`. If the crash is clearly scoped to one feature module and a matching scoped label exists
+(`gh label list`), add that too — but don't invent labels.
+
+Title: `<Exception type> in <the thing the user was doing>` — concrete and human, e.g.
+`SQLiteException when recording a recently viewed app`. Not the raw Crashlytics title, which is a
+class name.
+
+Body:
+
+```markdown
+## What happens
+<Plain-language description of what a user experiences. No class names in this paragraph.>
+
+## Impact
+- Version: 4.0.0 (40000)  •  first seen: <firstSeenVersion>
+- <N> events, <M> impacted users (last 7 days)
+- Top devices: <...>  •  Top OS: <...>
+
+## Exception
+```
+<exception type and message, then the trimmed stack — app frames plus enough framework
+context to be meaningful>
+```
+
+## Where it comes from
+<The owning module and file, and what the code is doing at that frame.>
+
+## Suspected cause
+<Only if the evidence supports one. If it doesn't, write "Not yet determined" — a wrong
+guess in a triage issue is worse than none.>
+
+---
+Crashlytics issue `<crashlytics-issue-id>`
+<console uri>
+```
+
+Keep the "What happens" section in the user-facing voice described in `AGENTS.md` — active, present
+tense, no internal identifiers.
+
+For a **non-fatal you judged wrong or unnecessary**, replace "Suspected cause" with a
+`## Recommendation` section that states whether to remove the report, downgrade it, or handle the
+condition quietly, and why.
+
+## Step 7 — Link back to Crashlytics
+
+Immediately after the issue is created, write the note so the next triage run skips it:
+
+```json
+[
+  { "name": "crashlytics_create_note",
+    "arguments": { "appId": "...", "issueId": "<id>",
+      "note": "Tracked in https://github.com/MartinStyk/apk-analyzer/issues/<number>" } }
+]
+```
+
+A filed issue without its note is an incomplete triage — the next run will file a duplicate.
+
+## Step 8 — Report
+
+Summarise as a table: Crashlytics id (short), kind, events/users, the decision (filed / already
+tracked / recommended-for-removal), and the GitHub issue number. Call out anything you deliberately
+did not file and why.
+
+Never mark a Crashlytics issue closed with `crashlytics_update_issue` during triage — closing it is
+the `fix-crash` skill's job, after the fix actually ships.
+
+## Verification
+
+- [ ] Latest version came from git tags, not the `topVersions` ordering
+- [ ] That version display name was confirmed present in Crashlytics
+- [ ] Fatals, non-fatals, and ANRs were all queried
+- [ ] Every issue was checked against both Crashlytics notes and GitHub search before filing
+- [ ] Each non-fatal got an explicit fix / wrong / unnecessary judgement, and an issue either way
+- [ ] Every filed issue names a real file in this repo, verified by reading it
+- [ ] Every filed issue carries the Crashlytics issue id and console link
+- [ ] Every filed issue has a matching Crashlytics note pointing back at it
+- [ ] No Crashlytics issue state was changed

--- a/.claude/skills/triage-crashes/SKILL.md
+++ b/.claude/skills/triage-crashes/SKILL.md
@@ -47,7 +47,7 @@ re-authenticate on their behalf.
 version outranks a fresh release. Get the version from git instead:
 
 ```powershell
-git tag --sort=-v:refname | Select-Object -First 1
+git tag --sort=-v:refname | Where-Object { $_ -match '^\d+\.\d+\.\d+$' } | Select-Object -First 1
 ```
 
 Release tags are `MAJOR.MINOR.PATCH`; `.github/workflows/release.yml` computes

--- a/.claude/skills/triage-crashes/scripts/crashlytics.js
+++ b/.claude/skills/triage-crashes/scripts/crashlytics.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// Bridges the Firebase MCP server's Crashlytics tools to the command line.
+//
+//   node crashlytics.js <repo-root> <calls.json>
+//
+// <calls.json> is an array of { "name": "<tool>", "arguments": { ... } } objects,
+// executed in order against one long-lived `firebase experimental:mcp` process.
+
+const { spawn } = require('child_process');
+const fs = require('fs');
+
+const cwd = process.argv[2];
+const callsFile = process.argv[3];
+
+if (!cwd || !callsFile) {
+  console.error('usage: node crashlytics.js <repo-root> <calls.json>');
+  process.exit(2);
+}
+
+const calls = JSON.parse(fs.readFileSync(callsFile, 'utf8'));
+const isWindows = process.platform === 'win32';
+const child = isWindows
+  ? spawn(process.env.ComSpec || 'cmd.exe', ['/c', 'firebase', 'experimental:mcp', '--only', 'crashlytics'], { cwd })
+  : spawn('firebase', ['experimental:mcp', '--only', 'crashlytics'], { cwd });
+
+let failed = false;
+let buffer = '';
+let index = 0;
+
+const sendNextCall = () => {
+  if (index >= calls.length) {
+    child.kill();
+    process.exit(failed ? 1 : 0);
+  }
+  const call = calls[index];
+  console.log('\n===== ' + call.name + ' ' + JSON.stringify(call.arguments || {}));
+  child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id: 100 + index, method: 'tools/call', params: call }) + '\n');
+};
+
+child.stdout.on('data', (chunk) => {
+  buffer += chunk.toString();
+  let newline;
+  while ((newline = buffer.indexOf('\n')) >= 0) {
+    const line = buffer.slice(0, newline).trim();
+    buffer = buffer.slice(newline + 1);
+    if (!line) continue;
+
+    let message;
+    try {
+      message = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    if (message.id === 1) {
+      child.stdin.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n');
+      sendNextCall();
+    } else if (message.id >= 100) {
+      const result = message.result || message.error;
+      if (message.error || (result && result.isError)) failed = true;
+      const text = result && result.content
+        ? result.content.map((part) => part.text).join('\n')
+        : JSON.stringify(result, null, 2);
+      console.log(text);
+      index++;
+      sendNextCall();
+    }
+  }
+});
+
+child.stderr.on('data', (chunk) => process.stderr.write(chunk));
+child.on('error', (error) => {
+  console.error('failed to start the Firebase CLI: ' + error.message);
+  process.exit(2);
+});
+
+child.stdin.write(JSON.stringify({
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'crashlytics-skill', version: '1' } },
+}) + '\n');
+
+setTimeout(() => {
+  console.error('timed out waiting for the Firebase MCP server');
+  child.kill();
+  process.exit(2);
+}, 180000);

--- a/.claude/skills/triage-crashes/scripts/crashlytics.js
+++ b/.claude/skills/triage-crashes/scripts/crashlytics.js
@@ -1,10 +1,4 @@
 #!/usr/bin/env node
-// Bridges the Firebase MCP server's Crashlytics tools to the command line.
-//
-//   node crashlytics.js <repo-root> <calls.json>
-//
-// <calls.json> is an array of { "name": "<tool>", "arguments": { ... } } objects,
-// executed in order against one long-lived `firebase experimental:mcp` process.
 
 const { spawn } = require('child_process');
 const fs = require('fs');

--- a/.github/extensions/firebase-mcp/extension.mjs
+++ b/.github/extensions/firebase-mcp/extension.mjs
@@ -1,0 +1,12 @@
+import { createMcpServer } from "copilot-sdk/mcp";
+import { joinSession } from "copilot-sdk/extension";
+
+await joinSession({
+    mcpServers: [
+        createMcpServer({
+            id: "firebase",
+            command: "firebase",
+            args: ["experimental:mcp", "--only", "crashlytics"],
+        }),
+    ],
+});

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "firebase": {
+      "command": "firebase",
+      "args": [
+        "experimental:mcp",
+        "--only",
+        "crashlytics"
+      ]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,7 +211,7 @@ frontmatter states when it applies.
 `create-feature-module`, `create-core-module`, `create-compose-component`, `implement-navigation`,
 `spotless-fix`, `git-commit-author`, `setup-local-tools`, `analyze-ci-failure`, `run-app`,
 `navigate-app-adb`, `sync-design-changes`, `translate-strings`, `release-app`,
-`capture-app-flow-media`.
+`capture-app-flow-media`, `triage-crashes`, `fix-crash`.
 
 All are shared by Claude and Copilot except `sync-design-changes`, which needs Claude's `DesignSync`
 tool.


### PR DESCRIPTION
This adds an operational workflow for production Crashlytics work so new issues in the latest release are consistently triaged and then fixed with a repeatable process. It codifies how to read Crashlytics data from Firebase CLI MCP, avoid duplicate issue filing, and keep fix work tied to real root-cause and compatibility checks.

## What changed
- Added `triage-crashes` skill to:
  - identify the latest release version correctly from git tags and release versionCode convention
  - query Crashlytics fatals, non-fatals, and ANRs for that release
  - dedupe against both Crashlytics notes and existing GitHub issues
  - file `bug` issues with concrete technical detail and console links
  - write back Crashlytics notes to prevent duplicate filing on reruns
- Added `fix-crash` skill to:
  - link Crashlytics and GitHub issues in both directions
  - pull issue/event/distribution data for root-cause analysis
  - require repro-first fixes where possible
  - enforce stored-data backward compatibility checks during persistence changes
  - define close-the-loop expectations after a fix
- Added `.claude/skills/triage-crashes/scripts/crashlytics.js`:
  - a small stdio bridge for running ordered Firebase MCP Crashlytics tool calls from JSON
  - works on Windows and non-Windows shells
- Updated root `AGENTS.md` skill list to include `triage-crashes` and `fix-crash`.

## Notable decisions
- Latest release detection intentionally does not rely on Crashlytics `topVersions` ordering, because that report is sorted by event count, not semantic recency.
- Non-fatals are always explicitly categorized (fix, wrong/misreported, unnecessary) so triage does not silently drop noisy signals.
- Triage does not close Crashlytics issues; only post-release observation should confirm closure.

## Validation
- Ran `./gradlew validateAgentContext` successfully.
- Exercised the Crashlytics MCP flow against project `apkanalyzer-f79a3`, including report queries and notes lookup.