### PR TITLE
Enable KVM for baseline profile emulator on GitHub Actions

### DIFF
--- a/.github/workflows/baseline-profiles.yml
+++ b/.github/workflows/baseline-profiles.yml
@@ -63,6 +63,12 @@ jobs:
           firebase-app-id: ${{ secrets.FIREBASE_APP_ID }}
           firebase-project-id: ${{ secrets.FIREBASE_PROJECT_ID }}
 
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Generate baseline profile
         run: ./gradlew :app:generateBaselineProfile
 


### PR DESCRIPTION
## Summary
- The `Baseline profiles` workflow's `generate` job runs `./gradlew :app:generateBaselineProfile`, which boots an x86_64 Android emulator via Gradle Managed Devices.
- `ubuntu-latest` runners don't grant KVM access by default, so the emulator can't get hardware acceleration and `pixel6ApiTargetSetup` fails after 5 retries (`x86_64 emulation currently requires hardware acceleration!`), as seen in [run 32767923358](https://github.com/MartinStyk/apk-analyzer/actions/runs/32767923358/job/97561562318).
- Adds the standard udev-based KVM permission step before the generate step, matching the fix used by other Android CI templates (e.g. Now in Android).

## Test plan
- [x] Trigger the `Baseline profiles` workflow manually (`workflow_dispatch`) and confirm `pixel6ApiTargetSetup` boots the emulator successfully