### PR TITLE
Add App Functions support for on-device AI agents

### DIFF
--- a/.claude/skills/appfunctions/SKILL.md
+++ b/.claude/skills/appfunctions/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: appfunctions
+description: Use when discovering, implementing, documenting, or testing Android App Functions (androidx.appfunctions) that expose app capabilities to on-device AI agents like Gemini. Triggered by phrases like "add an app function", "implement AppFunctions", "expose this as an app function", "discover app function candidates", "write KDoc for an app function", "optimize for MCP", "test app functions with adb", "list app functions", "invoke an app function".
+---
+
+# App Functions
+
+Adapted from the official [Android App Functions skill](https://github.com/android/skills/tree/main/device-ai/appfunctions)
+(Apache License 2.0). `core:app-functions` is this repo's implementation — read its
+[`AGENTS.md`](../../../core/app-functions/AGENTS.md) first for the concrete module, service, and
+KDoc-exception rules before applying the general guidance below.
+
+Analyzes Android apps to identify key user workflows for AppFunctions such as creating a note,
+playing media, or sending an automated or AI agent triggered message, voice commands, or system
+shortcuts, without needing to open the app UI.
+
+Generates Kotlin code to expose these workflows to the Android system, allowing agents to discover
+and execute them on-device.
+
+Also refines KDoc documentation to ensure AI agents correctly understand and use the provided
+functionality.
+
+## Prerequisites
+
+The app must **`targetSdk 36`** or newer and use **`compileSdk 37`** or newer as AppFunctions, part
+of the Android platform API, are available from Android 16 onwards. Always use the Jetpack library
+(`androidx.appfunctions`) because it handles backward compatibility — the manifest component itself
+stays inert (never bound) on older platforms as long as it's `@RequiresApi(36)` /
+`tools:targetApi="36"`, so a module with a lower `minSdk` does not need a runtime SDK check.
+
+## Workflows
+
+This skill enables the caller to discover features that will be provided to system agents,
+implement these with AppFunctions, improve function description for agents, and use ADB commands
+for local evaluation and testing.
+
+The full AppFunction development flow consists of these four steps:
+
+- *[Step 1: Discovery](references/feature-discovery-analysis.md)*: Analyze Android codebases to identify and recommend potential AppFunctions. Use this step when a user asks to "discover AppFunctions," "find features for AI," or "analyze my app for agentic tools."
+- *[Step 2: Implementation and configuration](references/implementation-configuration.md)*: Generate Kotlin implementations of AppFunctions, manage system-wide configuration, and configure build dependencies. Use this step when a user asks to "implement AppFunctions," "set up the AppFunctions framework," or "configure Hilt for AppFunctions."
+- *[Step 3: KDoc refinement](references/kdoc-refinement-optimization.md)*: Optimize AppFunction KDoc for AI agents and Model Context Protocol. If a user asks to "write KDoc", "optimize for MCP", or "refactor tool descriptions for LLMs", use this step.
+- *[Step 4: Testing and debugging](references/adb-interaction-testing.md)*: Provide commands to interact with AppFunctions using ADB for testing and debugging. If a user wants to "list app functions", "invoke an app function", or "verify app function registration" on a device, use this step.
+
+If users request a subset of steps, you must encourage them to use all steps.
+
+If they apply, you must load the following references:
+
+- *[Context and terminology](references/context.md)*: Defines the ubiquitous language, architecture definitions, and design patterns across the AppFunctions skill suite. Load when you need to understand core architecture terminology or check the distinctions between modern and legacy AppFunctions APIs.
+- *[Migration to service entry point](references/migrate-to-service-entry-point.md)* : Documents the systematic procedure for migrating Android applications using AppFunctions versions 1.0.0-alpha09 and lower to `AppFunctionServiceEntryPoint` architecture introduced in version 1.0.0-alpha10. Load when a user asks to migrate or upgrade existing AppFunctions code, or when you encounter legacy `AppFunctionConfiguration.Provider` implementations.
+
+## Critical constraints
+
+- **Modular consistency**: You must refine KDocs immediately after you generate AppFunction implementations.
+- **Security**: Don't expose sensitive data or run destructive actions without user confirmation.
+- **This repo's KDoc rule**: outside `core:app-functions`'s `@AppFunction`/`@AppFunctionSerializable`
+  declarations, this repo never writes comments or KDoc. Do not let AppFunction-style documentation
+  leak into other modules.
+- **Multi-module aggregation**: only the `app` module sets
+  `ksp { arg("appfunctions:aggregateAppFunctions", "true") }`; a module that only declares
+  `@AppFunction`s needs the `appfunctions` runtime + compiler dependencies but not that argument —
+  see `core:app-functions/build.gradle.kts` and `app/build.gradle.kts`.
+
+## Troubleshooting
+
+- If you encounter build-time errors such as Kotlin Symbol Processing (KSP) issues, see [Implementation and configuration](references/implementation-configuration.md).
+- If you encounter runtime errors such as missing services or execution failures, see [Testing and debugging](references/adb-interaction-testing.md).
+- If you need architecture definitions and vocabulary, see [Context and terminology](references/context.md).
+- If you encounter issues when upgrading legacy configurations, see [Migration to service entry point](references/migrate-to-service-entry-point.md).

--- a/.claude/skills/appfunctions/references/adb-interaction-testing.md
+++ b/.claude/skills/appfunctions/references/adb-interaction-testing.md
@@ -1,0 +1,95 @@
+Provides commands to interact with AppFunctions on a connected device or
+emulator using ADB for AppFunction testing and debugging.
+
+## Instructions
+
+### Scenario 1: List app functions
+
+Use this scenario when you want to see which app functions are registered on
+the device.
+
+1. **List all functions** : To view all registered app functions in JSON format, run `adb shell cmd app_function list-app-functions`.
+2. **Filter by package** : To view functions for a specific package, pipe the output to `grep` or a JSON tool: `adb shell cmd app_function
+   list-app-functions | grep <package_name>`.
+
+### Scenario 2: Invoke app functions
+
+If you want to test the execution of an app function, use this scenario.
+
+1. **Analyze description** : Before invoking, you must read the `description` field for the function in the `list-app-functions` output. This often contains critical usage constraints, required workflows, or disambiguation rules.
+2. **Follow constraints**: Follow all instructions in the description, such as asking the user to disambiguate or calling another tool first.
+3. **Format parameters** : Format the `--parameters` argument as a valid JSON string that represents the function's input arguments.
+4. **Execute function** : Use `adb shell cmd app_function execute-app-function
+   --package <PACKAGE_NAME> --function <SERVICE_CLASS_NAME#FUNCTION_NAME>
+   --parameters '<PARAMETERS_JSON>'`.
+5. **Handle response** : The command returns the result as a JSON string. To get brief YAML output, use `--brief-yaml`.
+
+### Scenario 3: Manage function state
+
+If you need to enable or disable an app function for testing, use this scenario.
+
+1. **Set enabled state** : Use `adb shell cmd app_function set-enabled
+   --package <PACKAGE_NAME>
+   --function <SERVICE_CLASS_NAME#FUNCTION_NAME>
+   --state <enable|disable|default>`.
+
+## Critical constraints
+
+### Follow metadata descriptions
+
+**Mandatory** : The `description` field in the app function metadata is a set of
+instructions for the LLM. If a description says to "disambiguate with the user"
+or "call another function first," you must perform those steps before execution.
+
+### JSON escaping
+
+**Critical** : When passing JSON using `adb shell`, always wrap the JSON string
+in single quotes to prevent the shell from interpreting special characters or
+spaces. Example: `--parameters '{"key": "value"}'`.
+
+### Device availability
+
+The `app_function` service must be available on the device. If `cmd: Can't find
+service: app_function` is returned, the device doesn't support this feature.
+
+## Examples
+
+### Example 1: Verify app function service availability on connected device
+
+    adb shell cmd app_function help
+
+If executing the preceding command returns a help page, use the commands and
+parameters provided to guide the ADB interaction testing tool interactions.
+
+### Example 2: List all registered app functions
+
+     adb shell cmd app_function list-app-functions
+
+### Example 3: Execute a "send message" function
+
+     adb shell cmd app_function execute-app-function \
+     --package com.example.messaging \
+     --function
+    'com.example.messaging.appfunctions.MessagingAppFunctionService#sendMessage' \
+     --parameters '{"recipient": "Alice", "message": "Hello!"}'
+
+### Example 4: Disable a specific function
+
+     adb shell cmd app_function set-enabled --package com.example.app \
+     --function 'com.example.app.appfunctions.SomeAppFunctionService#someFunction'
+    --state disable
+
+## Troubleshooting
+
+### Error: "Unknown command"
+
+**Cause**: You are likely using an older version of the instructions.
+
+**Solution**: Look up supported commands using "Example 1".
+
+### Error: "Function not found"
+
+**Cause**: The function ID or package name is incorrect.
+
+**Solution** : Run `list-app-functions` and search for the relevant identifiers
+in the JSON output.

--- a/.claude/skills/appfunctions/references/context.md
+++ b/.claude/skills/appfunctions/references/context.md
@@ -1,0 +1,26 @@
+Defines the ubiquitous language for the Android AppFunctions skill suite.
+
+## Architecture and versioning
+
+`AppFunctionServiceEntryPoint` API:
+This compile-time AppFunctions architecture was introduced in version
+1.0.0-alpha10. You annotate a wrapper service extending
+`AppFunctionService` with `@AppFunctionServiceEntryPoint`. KSP then generates
+XML metadata and routes services at compile time.
+
+Legacy manual provider API:
+This deprecated AppFunctions architecture applies to version
+1.0.0-alpha09 and earlier. Applications implement
+`AppFunctionConfiguration.Provider` on the `Application` class. Methods
+require `AppFunctionContext` as the first parameter. Projects depend on
+a standalone `appfunctions-service` library.
+
+## Patterns
+
+Service entry point pattern:
+Version 1.0.0-alpha10 introduced this architectural pattern. You
+declare `@AppFunction` methods directly inside an abstract class extending
+`AppFunctionService`. This class uses `@AppFunctionServiceEntryPoint` and
+`@AndroidEntryPoint` annotations. These annotations let you inject data
+sources or repositories directly, without an intermediate business logic
+delegation layer.

--- a/.claude/skills/appfunctions/references/feature-discovery-analysis.md
+++ b/.claude/skills/appfunctions/references/feature-discovery-analysis.md
@@ -1,0 +1,71 @@
+Analyzes Android codebases to identify and recommend high-value AppFunctions.
+
+## Instructions
+
+### Discover features
+
+1. **Analyze manifest and entry points** : Scan `AndroidManifest.xml` and Activity, Fragment, and Service classes to identify core user journeys, for example, search, create, or share.
+2. **Identify atomic tasks**: Look for methods or logic that represent distinct, self-contained user outcomes.
+3. **Evaluate AI value**: Prioritize tasks that are frequently used or difficult to navigate using touch UI, but instead be expressed using voice or text, for example "Remind me to call Alice when I get home."
+4. **Recommend and justify**: List recommendations with a rationale. Focus on how an AI assistant adds value, such as efficiency, hands-free use, or multi-step automation.
+
+## Critical constraints
+
+### Tool-first thinking
+
+Avoid recommending functions that are purely informational or redundant with
+existing system actions. Focus on "mutations" (writing data) or "rich queries"
+(finding specific entities).
+
+### Security and privacy
+
+Don't recommend exposing functions that handle raw credentials, financial
+secrets, or irreversible destructive actions without explicit user confirmation
+steps.
+
+## Examples
+
+### Example 1: Media app discovery
+
+**Recommended AppFunction** : `playArtistRadio`
+
+**Rationale**: Lets you start a personalized music stream using a voice
+command, bypassing several layers of navigation in the "Search" and "Artist"
+menus.
+
+**Input required** : `artistName` as a `String`.
+
+### Example 2: Chat app contact discovery
+
+**Recommended AppFunction** : `searchContacts`
+
+**Rationale** : Serves as a "rich query" to resolve a human-readable contact
+name, email, or chat group to a unique identifier (`endpointValue`), which is a
+prerequisite before executing actions like sending messages or
+initiating calls. Also allows retrieving recently contacted entities when given
+a blank query.
+
+**Input required** : Query as a `String`, and Filter Type as a `String`
+constrained to `"INDIVIDUAL"` or `"GROUP"`.
+
+### Example 3: Chat app message sending
+
+**Recommended AppFunction** : `send`
+
+**Rationale**: This mutation function lets you send text messages and
+optional image attachments to a contact or group using natural language
+commands, for example, "Tell Alice I'm running 5 minutes late." This
+eliminates multi-step UI navigation across contact lists and conversation
+threads.
+
+**Input required** : Endpoint Value as a `String`, Message Body as a `String`,
+and Image URIs as an optional `List` of URIs.
+
+### Example 4: Chat app voice calling
+
+**Recommended AppFunction** : `makeCall`
+
+**Rationale**: Lets you initiate voice calls hands-free to a contact or
+group using an AI agent without navigating the app's UI.
+
+**Input required** : `endpointValue` as a `String`.

--- a/.claude/skills/appfunctions/references/implementation-configuration.md
+++ b/.claude/skills/appfunctions/references/implementation-configuration.md
@@ -1,0 +1,282 @@
+Specialized instructions for generating Kotlin implementations of AppFunctions,
+handling system-wide configuration, and managing build dependencies.
+
+## Instructions
+
+### Step 1: Configure Gradle dependencies and KSP
+
+Add the following to `build.gradle.kts`. App Functions requires the KSP (Kotlin
+Symbol Processing) plugin.
+
+1. **Version check** : Use library version `1.0.0-alpha10` or later from maven.google.com.
+
+
+```kotlin
+implementation(libs.androidx.appfunctions)
+ksp(libs.androidx.appfunctions.compiler)
+```
+
+<br />
+
+<br />
+
+<br />
+
+### Step 2: Set up app metadata XML
+
+Describe the app's capabilities to the LLM by defining
+`res/xml/app_metadata.xml`.
+
+
+```xml
+<AppFunctionAppMetadata xmlns:appfn="http://schemas.android.com/apk/androidx.appfunctions"
+    appfn:description="This app manages user tasks and reminders.
+    Operational Patterns:
+    - Use 'createTask' to add new tasks or reminders with titles and content.
+    Constraints:
+    - Title or content must be non-null when creating a task."
+    appfn:displayDescription="@string/user_visible_description" />
+```
+
+<br />
+
+Register the service and reference the app metadata in `AndroidManifest.xml`
+within the `<application>` tag:
+
+
+```xml
+<service
+    android:name="com.example.snippets.ai.TaskAppFunctionService"
+    android:permission="android.permission.BIND_APP_FUNCTION_SERVICE"
+    android:exported="true"
+    tools:targetApi="36">
+    <property
+        android:name="android.app.appfunctions.schema"
+        android:value="app_functions_schema.xsd" />
+    <property
+        android:name="android.app.appfunctions.v2"
+        android:value="task_app_function_service.xml" />
+    <intent-filter>
+        <action android:name="android.app.appfunctions.AppFunctionService" />
+    </intent-filter>
+</service>
+<property
+    android:name="android.app.appfunctions.app_metadata"
+    android:resource="@xml/app_metadata" />
+```
+
+<br />
+
+### Step 3: Implement functions
+
+When generating Kotlin code for AppFunctions, you MUST adhere to these rules:
+
+1. **Annotations** :
+   - Annotate the function with `@AppFunction(isDescribedByKDoc = true)`.
+   - Annotate associated data classes with `@AppFunctionSerializable(isDescribedByKDoc = true)`.
+2. **Parameter strategy** :
+   - **Specificity**: Keep parameters specific. State objects must be unambiguous.
+   - **Optionality**: If a parameter isn't essential, make it optional with a default value.
+3. **Execution and threading** :
+   - Use `suspend` functions.
+   - To avoid blocking the Android UI thread, always run AppFunction implementations on a background dispatcher, such as `withContext(Dispatchers.IO)`.
+4. **Supported types** :
+   - **Primitives** : `Int`, `Long`, `Float`, `Double`, `Boolean`
+   - **Arrays** : `IntArray`, `LongArray`, `FloatArray`, `DoubleArray`, `BooleanArray`
+   - **Native types** : `String`, `PendingIntent`, `Uri`, `LocalTime`, `LocalDate`, `LocalDateTime`, `Instant`. Prefer using `LocalDateTime` or `Instant` for date and time fields.
+   - **Custom objects** : Classes annotated with `@AppFunctionSerializable`.
+   - **Collections** : `List` of any supported non-primitive type
+5. **Default values** :
+   - Use defaults that align with the type's empty state, such as `0` for `Int`, `null` for nullable objects, and `emptyList()` for `List`.
+6. **Error handling** :
+   - Throw subclasses of `androidx.appfunctions.AppFunctionException` to report errors to callers.
+7. **Security** :
+   - Don't expose highly sensitive user data, such as passwords or financial details.
+   - Don't expose irreversible destructive actions without confirmation steps.
+
+### Step 4: Set up dependency injection and service entry points
+
+In version 1.0.0-alpha10 and later, App Functions use the compile-time
+`@AppFunctionServiceEntryPoint` architecture. Create an abstract class extending
+`AppFunctionService` annotated with `@AppFunctionServiceEntryPoint`. KSP
+generates the concrete service class and XML schema.
+
+#### Recommended approach with Hilt
+
+Annotate your service with `@AndroidEntryPoint` and inject your data
+repositories or use cases using standard `@Inject internal lateinit var`:
+
+
+```kotlin
+@RequiresApi(36)
+@AndroidEntryPoint
+@AppFunctionServiceEntryPoint(
+    serviceName = "ConfigAppFunctionServiceHeader",
+    appFunctionXmlFileName = "config_app_function_service_header",
+)
+abstract class BaseAppFunctionServiceHeader : AppFunctionService() {
+    @Inject internal lateinit var messageRepository: MessageRepository
+
+    @AppFunction(isDescribedByKDoc = true)
+    internal suspend fun send(
+        name: String,
+        endpointValue: String,
+        messageBody: String,
+    ): MessageResult {
+        return messageRepository.send(name, endpointValue, messageBody)
+    }
+}
+```
+
+<br />
+
+#### Framework-agnostic approach with alternative dependency injection or service locators
+
+While Hilt is recommended, many Android applications implement AppFunctions with
+alternative dependency injection frameworks (like Koin, Anvil, or manual Service
+Locators). Because `AppFunctionService` inherits from Android
+`android.app.Service` (and therefore `Context`), you are able access your
+application's DI container directly through `applicationContext` in property
+getters or during service lifecycle execution:
+
+
+```kotlin
+@RequiresApi(36)
+@AppFunctionServiceEntryPoint(
+    serviceName = "ServiceLocatorConfigAppFunctionService",
+    appFunctionXmlFileName = "service_locator_config_app_function_service",
+)
+abstract class BaseAppFunctionServiceLocator : AppFunctionService() {
+    // Example using a manual Service Locator / Application container
+    private val messageRepository by lazy {
+        (applicationContext as AppFunctionApplication).appContainer.messageRepository
+    }
+    // Or with Koin / alternative DI locators:
+    // private val messageRepository: MessageRepository by inject()
+
+    @AppFunction(isDescribedByKDoc = true)
+    internal suspend fun send(
+        name: String,
+        endpointValue: String,
+        messageBody: String,
+    ): MessageResult {
+        return messageRepository.send(name, endpointValue, messageBody)
+    }
+}
+```
+
+<br />
+
+### Step 5: Architectural cleanliness
+
+Don't attempt to make an `AppFunction` class or method OS-agnostic---App Functions are inherently part of the Android platform integration in `androidx.appfunctions`. For architectural cleanliness, use existing
+application functionality (such as existing repositories, use cases, or domain
+orchestrators) to execute the behavior within your `@AppFunction` methods rather
+than creating redundant abstraction layers around the OS service.
+
+<br />
+
+## Critical constraints
+
+### KSP compliance for serializables
+
+**Critical constraints** : For `@AppFunctionSerializable` data classes, KSP
+only extracts documentation if it's written as inline KDoc directly for each
+property definition. Don't use class-level `@param` or `@property` tags.
+
+### Package integrity
+
+Configuration APIs and the `@AppFunction` annotation are located in
+`androidx.appfunctions`.
+
+## Examples
+
+### Example: Serializable with inline KDoc
+
+
+```kotlin
+/** The parameter to create the task. */
+@AppFunctionSerializable(isDescribedByKDoc = true)
+data class CreateTaskParams(
+    /** The title of the task. */
+    val title: String?,
+    /** The content of the task. */
+    val content: String?,
+)
+
+/** The user-created task. */
+@AppFunctionSerializable(isDescribedByKDoc = true)
+data class Task(
+    /** The ID of the task. */
+    val id: String,
+    /** The title of the task. */
+    val title: String,
+    /** The content of the task. */
+    val content: String,
+)
+```
+
+<br />
+
+<br />
+
+### Example: Implementation detail
+
+
+```kotlin
+@RequiresApi(36)
+@AndroidEntryPoint
+@AppFunctionServiceEntryPoint(
+    serviceName = "TaskAppFunctionService",
+    appFunctionXmlFileName = "task_app_function_service",
+)
+abstract class BaseTaskAppFunctionService : AppFunctionService() {
+    @Inject internal lateinit var taskRepository: TaskRepository
+
+    /**
+     * Creates a task based on [createTaskParams].
+     *
+     * @param createTaskParams The parameter to describe how to create the task.
+     */
+    @AppFunction(isDescribedByKDoc = true)
+    suspend fun createTask(
+        createTaskParams: CreateTaskParams,
+    ): Task = withContext(Dispatchers.IO) {
+        // Developers can use predefined exceptions to let the agent know
+        // why it failed.
+        if (createTaskParams.title == null && createTaskParams.content == null) {
+            throw AppFunctionInvalidArgumentException("Title or content should be non-null")
+        }
+
+        val id = taskRepository.createTask(
+            createTaskParams.title,
+            createTaskParams.content
+        )
+
+        return@withContext taskRepository
+            .getTask(id)
+            ?.toTask()
+            ?: throw AppFunctionElementNotFoundException("Task not found for ID = $id")
+    }
+
+    // Maps internal TaskEntity
+    private fun TaskEntity.toTask() = Task(id = id, title = title, content = description)
+}
+```
+
+<br />
+
+<br />
+
+## Troubleshooting
+
+### Error: "AppFunction unavailable" or "Metadata missing"
+
+**Cause**: The AppSearch indexing failed to extract the schema correctly.
+
+**Solution**:
+
+1. Verify `@AppFunctionSerializable` classes use inline KDoc comments, not class-level `@param` tags.
+2. Check that the `assets/<appFunctionXmlFileName>.xml` file exists in the APK.
+3. Confirm the `ksp("androidx.appfunctions:appfunctions-compiler")` dependency is correctly applied.
+4. Ensure the `ksp` argument `appfunctions:aggregateAppFunctions` is set to `"true"`.

--- a/.claude/skills/appfunctions/references/kdoc-refinement-optimization.md
+++ b/.claude/skills/appfunctions/references/kdoc-refinement-optimization.md
@@ -1,0 +1,75 @@
+Optimizes AppFunction KDoc for AI agents and Model Context Protocol.
+
+## Instructions
+
+### Workflow: Agent-centric documentation
+
+1. **Identify the core outcome** : Start the description with a strong imperative verb, for example, "Search", "Create", or "Update". Focus on the *user benefit*, not the code implementation.
+2. **Workflow dependencies** : Explicitly state if another function must be called first using the standard phrase: **Required workflow: Call "Function
+   A" first to "Objective"**.
+3. **Parameter documentation** :
+   - For **functions** : Use specific `@param` tags. Isolate validation rules and default values here.
+   - For **serializables** : Use inline KDoc directly for each property declaration. KSP **won't** extract documentation from class-level tags.
+4. **Error surface mapping** : Rewrite `@throws` descriptions to provide useful recovery steps for the AI agent, for example "If "Error", suggest the user check their internet connection."
+
+### Workflow: Global app description for server instructions
+
+When writing the `appfn:description` for `app_metadata.xml`, follow these
+instructions:
+
+1. **Capture cross-function relationships**: Explain dependencies or sequences between tools, for example, "Always call 'authenticate' before fetching data.".
+2. **Document operational patterns**: Guide the LLM on token-conserving usage, for example, "Use 'batch_update' over multiple 'update' calls."
+3. **Specify constraints**: Define clear boundaries, for example, "File operations limited to workspace" or "Rate limit: 10 requests per minute."
+4. **Anti-patterns** :
+   - Don't repeat individual function descriptions.
+   - Don't include marketing claims or subjective praise.
+   - Don't attempt to prompt model personality or conversation style.
+
+## Critical constraints
+
+### Descriptive, not imperative
+
+Describe what the function *does* , not what the LLM *must* do. Avoid phrases
+like "You must call this..." in favor of "This function provides...".
+
+### No "fluff"
+
+Remove conversational padding like "This method is used to..." or "Helpful
+for...". Be concise and technical.
+
+### Inline KDoc for serializables
+
+**Mandatory** : For `@AppFunctionSerializable` classes, documentation must be
+inline for each property. KSP ignores class-level `@param` or `@property` tags
+for these classes.
+
+## Examples
+
+### Example: MCP refactoring
+
+**Original**:
+
+`/** This function helps you find people. */`
+
+**Refined**:
+
+     /**
+       * Search for message recipients by name or email.
+       * Required workflow: Call this before "sendMessage" to obtain valid recipient IDs.
+       * @param query Search string for name/email. If null, returns 3 most recent contacts.
+       * @return List of "Recipient" objects matching the query.
+       */
+
+### Example: Global app description
+
+**Refined**:
+
+    This app provides functions for task management and team collaboration.
+
+    Operational Patterns:
+    - Always use 'searchUsers' to resolve user handles to internal IDs before calling 'assignTask'.
+    - Prefer 'batchUpdateStatus' when modifying more than three tasks simultaneously to reduce latency.
+
+    Constraints:
+    - Task titles are limited to 100 characters.
+    - Attachment uploads are limited to 5 MB.

--- a/.claude/skills/appfunctions/references/migrate-to-service-entry-point.md
+++ b/.claude/skills/appfunctions/references/migrate-to-service-entry-point.md
@@ -1,0 +1,226 @@
+Follow this systematic procedure to migrate Android applications that use the
+AppFunctions API in version 1.0.0-alpha09 and lower to the compile-time
+`@AppFunctionServiceEntryPoint` architecture introduced in version
+`1.0.0-alpha10`.
+
+*** ** * ** ***
+
+## Architectural shift overview
+
+In lower versions of the AppFunctions API, for example version `1.0.0-alpha09`:
+
+- Applications require separate dependencies for core functionality, specifically `androidx.appfunctions:appfunctions`, and service components, specifically `androidx.appfunctions:appfunctions-service`.
+- The application implements `AppFunctionConfiguration.Provider` on its `Application` class.
+- You manually register enclosing class instantiation using `AppFunctionConfiguration.Builder().addEnclosingClassFactory(...)`.
+- You place metadata property tags directly under `<application>`.
+
+In version `1.0.0-alpha10` featuring `@AppFunctionServiceEntryPoint`:
+
+- The core and service dependencies are consolidated into a single runtime artifact, `androidx.appfunctions:appfunctions`, which eliminates the need for the standalone `appfunctions-service` library.
+- A dedicated wrapper class extending `AppFunctionService` is annotated with `@AppFunctionServiceEntryPoint` and Hilt's `@AndroidEntryPoint` or an alternative dependency injection framework.
+- The KSP compiler generates a concrete service subclass and an XML metadata schema file in `assets/`.
+- The OS discovers and routes executions using a consolidated `<service>` and `app_metadata` declaration in `AndroidManifest.xml`.
+
+### Strict migration requirements from 1.0.0-alpha09 to 1.0.0-alpha10
+
+When focusing solely on the mandatory API changes required by the new
+`@AppFunctionServiceEntryPoint` architecture, the migration consists of four
+strict requirements that you must complete:
+
+1. **Build dependency consolidation** : Remove the merged `appfunctions-service` dependency while retaining core `appfunctions` and the KSP compiler.
+2. **Service wrapper creation** : Replace the legacy `AppFunctionConfiguration.Provider` on the `Application` class with an abstract class extending `AppFunctionService`, annotated with `@AppFunctionServiceEntryPoint`.
+3. **Annotation and context decoupling** : Move `@AppFunction` annotations to the new wrapper methods and drop `AppFunctionContext` parameters because `AppFunctionService` inherits directly from `Context`.
+4. **Manifest registration** : Register the KSP-generated concrete service in `AndroidManifest.xml` with `BIND_APP_FUNCTION_SERVICE`, the `AppFunctionService` intent filter, and metadata property tags.
+
+*** ** * ** ***
+
+## Systematic migration steps
+
+### Consolidate AppFunctions build dependencies
+
+Remove the standalone `appfunctions-service` library from your module build
+files like `build.gradle.kts` and version catalog like `libs.versions.toml`. In
+version `1.0.0-alpha10`, all core service capabilities are consolidated directly
+within the main `appfunctions` artifact.
+
+    // build.gradle.kts
+    dependencies {
+        implementation(libs.androidx.appfunctions)
+    -   implementation(libs.androidx.appfunctions.service)
+        ksp(libs.androidx.appfunctions.compiler)
+    }
+
+    # libs.versions.toml
+    [versions]
+    appfunctions = "1.0.0-alpha10"
+
+    [libraries]
+    androidx-appfunctions = { module = "androidx.appfunctions:appfunctions", version.ref = "appfunctions" }
+    -   androidx-appfunctions-service = { module = "androidx.appfunctions:appfunctions-service", version.ref = "appfunctions" }
+    androidx-appfunctions-compiler = { module = "androidx.appfunctions:appfunctions-compiler", version.ref = "appfunctions" }
+
+> [!NOTE]
+> **Note:** If another dependency in your project uses snapshot builds like `1.0.0-SNAPSHOT` or custom snapshot repositories from `https://androidx.dev/snapshots/...`, preserve your custom snapshot repository configuration in `settings.gradle.kts`. Otherwise, standard Google Maven repositories resolve `1.0.0-alpha10` directly.
+
+*** ** * ** ***
+
+### Create a dedicated wrapper service extending `AppFunctionService`
+
+Instead of annotating standalone business logic classes or implementing manual
+configuration providers, create an abstract service wrapper across your project,
+for example `BaseAppFunctionService`, extending `AppFunctionService` and
+annotated with `@AppFunctionServiceEntryPoint`.
+
+#### Recommended approach using Hilt
+
+Annotate your service with `@AndroidEntryPoint` and inject your data
+repositories or use cases using standard `@Inject internal lateinit var`:
+
+
+```kotlin
+@RequiresApi(36)
+@AndroidEntryPoint
+@AppFunctionServiceEntryPoint(
+    serviceName = "MyAppFunctionService",
+    appFunctionXmlFileName = "my_app_function_service", // Do NOT include .xml extension
+)
+abstract class BaseAppFunctionService : AppFunctionService() {
+    @Inject internal lateinit var messageRepository: MessageRepository
+
+    @AppFunction(isDescribedByKDoc = true)
+    internal suspend fun send(
+        name: String,
+        endpointValue: String,
+        messageBody: String,
+    ): MessageResult {
+        return messageRepository.send(name, endpointValue, messageBody)
+    }
+}
+```
+
+<br />
+
+#### Framework-agnostic approach using alternative dependency injection or a service locator
+
+While Hilt is recommended, many Android applications implement AppFunctions with
+alternative dependency injection frameworks like Koin, Anvil, or manual Service
+Locators. Because `AppFunctionService` inherits from Android
+`android.app.Service` and therefore `Context`, you are able access your
+application's DI container directly through `applicationContext` in property
+getters or during service lifecycle execution:
+
+
+```kotlin
+@RequiresApi(36)
+@AppFunctionServiceEntryPoint(
+    serviceName = "ServiceLocatorMyAppFunctionService",
+    appFunctionXmlFileName = "service_locator_my_app_function_service",
+)
+abstract class ServiceLocatorBaseAppFunctionService : AppFunctionService() {
+    // Example using a manual Service Locator or Application container
+    private val messageRepository by lazy {
+        (applicationContext as AppFunctionApplication).appContainer.messageRepository
+    }
+    // Or with Koin / alternative DI locators:
+    // private val messageRepository: MessageRepository by inject()
+
+    @AppFunction(isDescribedByKDoc = true)
+    internal suspend fun send(
+        name: String,
+        endpointValue: String,
+        messageBody: String,
+    ): MessageResult {
+        return messageRepository.send(name, endpointValue, messageBody)
+    }
+}
+```
+
+<br />
+
+> [!IMPORTANT]
+> **Important:** The `appFunctionXmlFileName` parameter, for example `"my_app_function_service"`, mustn't include the `.xml` extension, as the KSP compiler automatically appends `.xml`. Passing `"my_app_function_service.xml"` results in the asset being named `"my_app_function_service.xml.xml"`.
+
+*** ** * ** ***
+
+### Simplify method signatures and decouple context
+
+Remove legacy `AppFunctionContext` parameters from your core methods. When a
+method requires an Android `Context`, for example when constructing a
+`PendingIntent`, access `this` directly from your `AppFunctionService` wrapper
+because the wrapper inherently extends `android.content.Context`.
+
+    -   suspend fun makeCall(appFunctionContext: AppFunctionContext, contactName: String?): PendingIntent
+    +   suspend fun makeCall(contactName: String?): PendingIntent
+
+*** ** * ** ***
+
+### Remove legacy configuration provider
+
+Update your `Application` class by removing
+`AppFunctionConfiguration.Provider` and its associated builder entry points:
+
+    -   abstract class BaseChatApplication : Application(), AppFunctionConfiguration.Provider { ... }
+    +   abstract class BaseChatApplication : Application()
+
+*** ** * ** ***
+
+### Avoid redundant abstraction layers
+
+Don't attempt to make an `AppFunction` class or method OS-agnostic---AppFunctions
+are inherently part of the Android platform integration through the
+`androidx.appfunctions` package. For architectural cleanliness, use existing
+application functionality, such as existing repositories, use cases, or domain
+orchestrators, to execute the behavior within your `@AppFunction` methods rather
+than creating redundant abstraction layers around the OS service.
+
+*** ** * ** ***
+
+### Consolidate service and metadata manifest declarations
+
+Register the KSP-generated service declaration and `app_metadata` property
+inside your module manifest, for example in `src/main/AndroidManifest.xml`
+within the `<application>` tag:
+
+
+```xml
+<service
+    android:name="com.example.snippets.ai.MyAppFunctionService"
+    android:permission="android.permission.BIND_APP_FUNCTION_SERVICE"
+    android:exported="true"
+    tools:targetApi="36">
+    <property
+        android:name="android.app.appfunctions.schema"
+        android:value="app_functions_schema.xsd" />
+    <property
+        android:name="android.app.appfunctions.v2"
+        android:value="my_app_function_service.xml" />
+    <intent-filter>
+        <action android:name="android.app.appfunctions.AppFunctionService" />
+    </intent-filter>
+</service>
+<property
+    android:name="android.app.appfunctions.app_metadata"
+    android:resource="@xml/app_metadata" />
+```
+
+<br />
+
+*** ** * ** ***
+
+## Verification and troubleshooting
+
+1. **Clean rebuild and deploy** : `bash
+   ./gradlew clean installDebug`
+2. **Verify AppSearch discovery / indexing** : Run the following ADB command to
+   confirm the OS successfully discovered and indexed your functions:
+   `bash
+   adb shell cmd app_function list-app-functions`
+   *If your package doesn't appear, confirm that `android.app.appfunctions.v2`
+   matches the exact asset name generated in `assets/`.*
+
+3. **Verify execution using ADB** :
+   `bash
+   adb shell "cmd app_function execute-app-function \
+   --package com.example.chatapp \
+   --function 'com.example.chatapp.appfunctions.BaseAppFunctionService#send' \
+   --parameters '{\"name\": \"Alice\", \"endpointValue\": \"1\", \"messageBody\": \"Hello Alice!\"}'"`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,10 @@ re-deriving the module's structure.
 * Don't add a dependency. [`gradle/libs.versions.toml`](gradle/libs.versions.toml) is the only
   source of coordinates and versions; if a new library seems necessary, ask first.
 * Never write comments or KDoc — not even when the WHY seems non-obvious. Use self-documenting
-  names and structure. The only exception is an explicit request for a comment in that instance.
+  names and structure. The only exceptions are an explicit request for a comment in that instance,
+  and KDoc on `@AppFunction`/`@AppFunctionSerializable` declarations in `core:app-functions`, which
+  the App Functions platform reads as the agent-facing tool description — see that module's
+  `AGENTS.md`.
 * Never hardcode a user-facing string in a Composable. Use `stringResource` backed by
   `res/values/strings.xml` in the module that owns the UI.
 * Never hardcode SDK levels or the JVM toolchain in a module's `build.gradle.kts` — they come from
@@ -211,7 +214,7 @@ frontmatter states when it applies.
 `create-feature-module`, `create-core-module`, `create-compose-component`, `implement-navigation`,
 `spotless-fix`, `git-commit-author`, `setup-local-tools`, `analyze-ci-failure`, `run-app`,
 `navigate-app-adb`, `sync-design-changes`, `translate-strings`, `release-app`,
-`capture-app-flow-media`, `triage-crashes`, `fix-crash`, `verify`.
+`capture-app-flow-media`, `triage-crashes`, `fix-crash`, `verify`, `appfunctions`.
 
 All are shared by Claude and Copilot except `sync-design-changes`, which needs Claude's `DesignSync`
 tool.

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -40,11 +40,8 @@ entry points in the app.
   authority.
 * Package visibility and usage-access permissions are intentional product requirements; preserve
   their lint suppressions when editing the manifest.
-* The App Functions service (`android.app.appfunctions.AppFunctionService`) and `res/xml/app_metadata.xml`
-  are registered here because only the application module aggregates App Function schemas across
-  modules (`ksp { arg("appfunctions:aggregateAppFunctions", "true") }`); the functions themselves are
-  declared in [`core:app-functions`](../core/app-functions/AGENTS.md). Requires API 36 — see that
-  module for the `MIN_SDK` 28 compatibility story.
+* The App Functions service and `res/xml/app_metadata.xml` are registered here; the functions
+  themselves are declared in [`core:app-functions`](../core/app-functions/AGENTS.md).
 
 Version name and code have local Gradle-property defaults. CI and release workflows override them;
 do not introduce a second version source.

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -40,6 +40,11 @@ entry points in the app.
   authority.
 * Package visibility and usage-access permissions are intentional product requirements; preserve
   their lint suppressions when editing the manifest.
+* The App Functions service (`android.app.appfunctions.AppFunctionService`) and `res/xml/app_metadata.xml`
+  are registered here because only the application module aggregates App Function schemas across
+  modules (`ksp { arg("appfunctions:aggregateAppFunctions", "true") }`); the functions themselves are
+  declared in [`core:app-functions`](../core/app-functions/AGENTS.md). Requires API 36 — see that
+  module for the `MIN_SDK` 28 compatibility story.
 
 Version name and code have local Gradle-property defaults. CI and release workflows override them;
 do not introduce a second version source.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.apkanalyzer.hilt)
     alias(libs.plugins.apkanalyzer.compose)
     alias(libs.plugins.apkanalyzer.spotless)
+    alias(libs.plugins.apkanalyzer.appfunctions)
     alias(libs.plugins.parcelize)
 }
 
@@ -44,6 +45,7 @@ dependencies {
     implementation(projects.core.apps)
     implementation(projects.core.appPermissions)
     implementation(projects.core.appIndex)
+    implementation(projects.core.appFunctions)
     implementation(projects.core.common)
     implementation(projects.core.userPreferences)
     implementation(projects.core.navigation)
@@ -67,3 +69,5 @@ dependencies {
 
     debugImplementation(libs.leakcanary)
 }
+
+ksp { arg("appfunctions:aggregateAppFunctions", "true") }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -68,6 +68,25 @@
             android:name="firebase_performance_collection_enabled"
             android:value="true" />
 
+        <service
+            android:name="sk.styk.martin.apkanalyzer.core.appfunctions.ApkAnalyzerAppFunctionServiceImpl"
+            android:permission="android.permission.BIND_APP_FUNCTION_SERVICE"
+            android:exported="true"
+            tools:targetApi="36">
+            <property
+                android:name="android.app.appfunctions.schema"
+                android:value="app_functions_schema.xsd" />
+            <property
+                android:name="android.app.appfunctions.v2"
+                android:value="apk_analyzer_app_function_service.xml" />
+            <intent-filter>
+                <action android:name="android.app.appfunctions.AppFunctionService" />
+            </intent-filter>
+        </service>
+        <property
+            android:name="android.app.appfunctions.app_metadata"
+            android:resource="@xml/app_metadata" />
+
     </application>
 
 </manifest>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="external_apk_open_error">لم نتمكن من فتح APK هذا</string>
+    <string name="app_function_app_display_description">يتيح لمساعد الذكاء الاصطناعي الاطلاع على تفاصيل التطبيقات على هذا الجهاز: الإصدارات، الأذونات، مصادر التثبيت، وشهادات التوقيع.</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="external_apk_open_error">Nelze otevřít tento APK</string>
+    <string name="app_function_app_display_description">Umožňuje asistentovi AI zobrazit podrobnosti o aplikacích v tomto zařízení: verze, oprávnění, zdroje instalace a certifikáty pro podepisování.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="external_apk_open_error">Dieses APK konnte nicht geöffnet werden</string>
+    <string name="app_function_app_display_description">Ermöglicht einem KI-Assistenten, App-Details auf diesem Gerät abzurufen: Versionen, Berechtigungen, Installationsquellen und Signaturzertifikate.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="external_apk_open_error">No se pudo abrir este APK</string>
+    <string name="app_function_app_display_description">Permite que un asistente de IA consulte los detalles de las aplicaciones en este dispositivo: versiones, permisos, fuentes de instalación y certificados de firma.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="external_apk_open_error">Impossible d\'ouvrir cet APK</string>
+    <string name="app_function_app_display_description">Permet à un assistant IA de consulter les détails des applications sur cet appareil : versions, permissions, sources d\'installation et certificats de signature.</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="external_apk_open_error">इस APK को खोलने में असमर्थ</string>
+    <string name="app_function_app_display_description">यह AI सहायक को इस डिवाइस पर ऐप्लिकेशन का विवरण देखने देता है: वर्शन, अनुमतियां, इंस्टॉल स्रोत और साइनिंग प्रमाणपत्र।</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="external_apk_open_error">Tidak dapat membuka APK ini</string>
+    <string name="app_function_app_display_description">Memungkinkan asisten AI melihat detail aplikasi di perangkat ini: versi, izin, sumber instalasi, dan sertifikat penandatangan.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="external_apk_open_error">Impossibile aprire questo APK</string>
+    <string name="app_function_app_display_description">Consente a un assistente IA di consultare i dettagli delle app su questo dispositivo: versioni, autorizzazioni, fonti di installazione e certificati di firma.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="external_apk_open_error">このAPKを開けませんでした</string>
+    <string name="app_function_app_display_description">AIアシスタントがこのデバイスのアプリの詳細を確認できるようにします: バージョン、権限、インストール元、署名証明書。</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="external_apk_open_error">이 APK를 열 수 없습니다</string>
+    <string name="app_function_app_display_description">AI 어시스턴트가 이 기기에 설치된 앱의 세부정보를 확인할 수 있게 합니다: 버전, 권한, 설치 출처, 서명 인증서.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="external_apk_open_error">Nie można otworzyć tego APK</string>
+    <string name="app_function_app_display_description">Umożliwia asystentowi AI wyświetlanie szczegółów aplikacji na tym urządzeniu: wersje, uprawnienia, źródła instalacji i certyfikaty podpisu.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="external_apk_open_error">Não foi possível abrir este APK</string>
+    <string name="app_function_app_display_description">Permite que um assistente de IA consulte os detalhes dos apps neste dispositivo: versões, permissões, fontes de instalação e certificados de assinatura.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="external_apk_open_error">Не удалось открыть этот APK</string>
+    <string name="app_function_app_display_description">Позволяет ИИ-ассистенту просматривать сведения о приложениях на этом устройстве: версии, разрешения, источники установки и сертификаты подписи.</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="external_apk_open_error">Nepodarilo sa otvoriť tento APK</string>
+    <string name="app_function_app_display_description">Umožňuje AI asistentovi zistiť podrobnosti o aplikáciách na tomto zariadení: verzie, povolenia, zdroje inštalácie a podpisové certifikáty.</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="external_apk_open_error">Bu APK açılamadı</string>
+    <string name="app_function_app_display_description">Bir yapay zeka asistanının bu cihazdaki uygulama ayrıntılarını görüntülemesine olanak tanır: sürümler, izinler, kurulum kaynakları ve imza sertifikaları.</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="external_apk_open_error">Не вдалося відкрити цей APK</string>
+    <string name="app_function_app_display_description">Дозволяє ШІ-асистенту переглядати відомості про застосунки на цьому пристрої: версії, дозволи, джерела встановлення та сертифікати підпису.</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="external_apk_open_error">Không thể mở APK này</string>
+    <string name="app_function_app_display_description">Cho phép trợ lý AI tra cứu thông tin chi tiết về ứng dụng trên thiết bị này: phiên bản, quyền, nguồn cài đặt và chứng chỉ ký.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="external_apk_open_error">无法打开此 APK</string>
+    <string name="app_function_app_display_description">允许 AI 助手查看此设备上的应用详情：版本、权限、安装来源和签名证书。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name" translatable="false">Apk Analyzer</string>
     <string name="external_apk_open_error">Couldn’t open this APK</string>
+    <string name="app_function_app_display_description">Lets an AI assistant look up app details on this device: versions, permissions, install sources, and signing certificates.</string>
 </resources>

--- a/app/src/main/res/xml/app_metadata.xml
+++ b/app/src/main/res/xml/app_metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AppFunctionAppMetadata xmlns:appfn="http://schemas.android.com/apk/androidx.appfunctions"
+    appfn:description="Provides read-only lookups over apps installed on this device: version, target and minimum SDK, install source, size, last-used time, requested permissions and their grant state, and signing certificates.
+Operational Patterns:
+- 'findApps' searches and filters apps by name, permission, install source, target SDK, minimum size, and days unused, all combinable in one call — for example 'large unused apps from Google Play' is minTotalSizeMb + unusedForDays + installSource together, not three separate calls.
+- Call 'findApps' first when the user names an app by its display name rather than its exact package name, then pass the resolved packageName to 'getAppDetail', 'getAppCertificates', or 'getAppPermissions'.
+- Use 'findApps' sortBy to match what the user asked for: SizeDescending for 'largest apps', LastUsedAscending for 'most unused apps'.
+Constraints:
+- Every function is a read-only query; none of them change anything on the device.
+- Results are capped at 25 apps per call; ask the user to narrow the search if they need more."
+    appfn:displayDescription="@string/app_function_app_display_description" />

--- a/build-logic/AGENTS.md
+++ b/build-logic/AGENTS.md
@@ -20,7 +20,7 @@ build scripts.
 | `apkanalyzer.spotless` | Applies the repository ktlint and Compose formatting rules. |
 | `apkanalyzer.detekt` | Applies baseline-free, type-resolved static analysis. |
 | `apkanalyzer.sarif-merge` | Merges module Detekt and Lint SARIF reports for CI upload. |
-| `apkanalyzer.appfunctions` | Applies KSP and the `androidx.appfunctions` runtime/compiler for App Functions declarations. Applied to both `core:app-functions` (declares functions) and `app` (aggregates schemas across modules via `ksp { arg("appfunctions:aggregateAppFunctions", "true") }` in `app/build.gradle.kts`, since only the application module aggregates). |
+| `apkanalyzer.appfunctions` | Applies KSP and the `androidx.appfunctions` runtime/compiler for App Functions declarations. |
 
 ## Non-Obvious Build Behavior
 

--- a/build-logic/AGENTS.md
+++ b/build-logic/AGENTS.md
@@ -20,6 +20,7 @@ build scripts.
 | `apkanalyzer.spotless` | Applies the repository ktlint and Compose formatting rules. |
 | `apkanalyzer.detekt` | Applies baseline-free, type-resolved static analysis. |
 | `apkanalyzer.sarif-merge` | Merges module Detekt and Lint SARIF reports for CI upload. |
+| `apkanalyzer.appfunctions` | Applies KSP and the `androidx.appfunctions` runtime/compiler for App Functions declarations. Applied to both `core:app-functions` (declares functions) and `app` (aggregates schemas across modules via `ksp { arg("appfunctions:aggregateAppFunctions", "true") }` in `app/build.gradle.kts`, since only the application module aggregates). |
 
 ## Non-Obvious Build Behavior
 

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -77,5 +77,9 @@ gradlePlugin {
             id = "apkanalyzer.baselineprofile"
             implementationClass = "sk.styk.martin.apkanalyzer.BaselineProfilePlugin"
         }
+        register("apkanalyzer.appfunctions") {
+            id = "apkanalyzer.appfunctions"
+            implementationClass = "sk.styk.martin.apkanalyzer.AppFunctionsPlugin"
+        }
     }
 }

--- a/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/AppFunctionsPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/AppFunctionsPlugin.kt
@@ -1,0 +1,19 @@
+package sk.styk.martin.apkanalyzer
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
+import sk.styk.martin.apkanalyzer.utils.implementation
+import sk.styk.martin.apkanalyzer.utils.ksp
+import sk.styk.martin.apkanalyzer.utils.libs
+
+class AppFunctionsPlugin : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        pluginManager.apply("com.google.devtools.ksp")
+
+        dependencies {
+            implementation(libs.findLibrary("androidx.appfunctions").get())
+            ksp(libs.findLibrary("androidx.appfunctions.compiler").get())
+        }
+    }
+}

--- a/core/app-functions/AGENTS.md
+++ b/core/app-functions/AGENTS.md
@@ -1,0 +1,100 @@
+# core:app-functions Module
+
+## Purpose and Boundary
+
+Exposes read-only app-analysis lookups as Android [App Functions](https://developer.android.com/ai/appfunctions)
+so an on-device AI agent (Gemini or another assistant) can search/filter installed apps and inspect
+one app's version, SDK targeting, install source, permission grants, and signing certificates
+without opening Apk Analyzer. The package is `sk.styk.martin.apkanalyzer.core.appfunctions`.
+
+This module owns no analysis logic of its own. Every function is a thin, agent-shaped wrapper over
+`core:apps`'s `AppDetailRepository` and `InstalledAppsRepository`. `InstalledApp` already carries
+permission, install-source, target-SDK, size, and last-used data per app, so `findApps` filters and
+sorts in one in-memory pass over `InstalledAppsRepository.apps()` rather than depending on
+`core:app-index`'s device-wide reverse index — that index exists for `feature:browse`'s bucketed
+counts, a different shape of question than "does this one list of apps match all these conditions."
+Do not duplicate extraction here — add it to `core:apps` and call it from here.
+
+## Structure
+
+* `ApkAnalyzerAppFunctionService` — the single `@AppFunctionServiceEntryPoint` abstract class.
+  Every `@AppFunction` is declared directly on this class per the framework's requirement, but each
+  one is a one-line delegation to an injected use case in `usecase/` — the framework requires the
+  annotation and KDoc to sit on this class's methods, not that the logic does.
+* `usecase/` — one `internal class ...UseCase @Inject constructor(...)` per `@AppFunction`, each a
+  `suspend operator fun invoke(...)`. `FindAppsUseCase` holds the combined filter/sort/validate
+  logic; `GetAppDetailUseCase`, `GetAppCertificatesUseCase`, and `GetAppPermissionsUseCase` each
+  wrap one `AppDetailRepository.details()` call and a mapping function. `AppFunctionErrors.kt` holds
+  the one error shared by the three `getXxx` use cases. This still follows the framework's own
+  guidance to call existing repositories directly rather than adding an abstraction layer around the
+  OS service — a use case *is* that direct call, just factored out of the framework-bound class for
+  readability and per-function separation now that the service has four functions.
+* `model/` — the `@AppFunctionSerializable` response types (`AppSummary`, `AppDetailResult`,
+  `CertificateSummary`, `PermissionGrantSummary`) returned to the agent. These are deliberately
+  smaller and differently shaped than `core:apps`'s domain models (`InstalledApp`, `AppDetail`,
+  `Certificate`, `UsedPermission`); map between them in each use case's private mapping function
+  rather than exposing domain models directly.
+* `AppSourceAgentLabel.kt` — the one `AppSource -> String` label mapping shared by `FindAppsUseCase`
+  and `GetAppDetailUseCase`. Plain English text for the agent, not `stringResource` — this module has
+  no UI and no `res/`.
+
+KSP generates a concrete `ApkAnalyzerAppFunctionServiceImpl` and the XML schema at compile time from
+the abstract `ApkAnalyzerAppFunctionService`; there is no hand-written service to register beyond
+the manifest entry, which references the generated `...Impl` name (see
+[`app/AGENTS.md`](../../app/AGENTS.md)). The two names matter for different things: the manifest
+`<service>` and Hilt both need the generated `...Impl` class, but `adb shell cmd app_function`'s
+`--function` identifiers use the *abstract* class instead —
+`sk.styk.martin.apkanalyzer.core.appfunctions.ApkAnalyzerAppFunctionService#findApps`, not the
+`...Impl` name. The generated schema reaches the final APK through Kotlin's ordinary
+resources→java-resources packaging path (`assets/apk_analyzer_app_function_service.xml` as a
+classpath resource), not through AGP's `res/`-driven asset merging — so `androidResources = false`
+here is correct and does not drop it; verify with `unzip -l app-debug.apk | grep app_function`
+rather than looking under `intermediates/assets/`, which stays empty.
+
+## The KDoc Exception
+
+The root `AGENTS.md` non-negotiable "never write comments or KDoc" has exactly one carve-out, scoped
+to this module: KDoc on `@AppFunction` and `@AppFunctionSerializable` declarations (functions,
+parameters, and serializable properties) is how `isDescribedByKDoc = true` tells the agent what a
+function does and how to use it — the KDoc *is* the tool description the platform indexes, not
+incidental documentation. Follow the agent-facing style already used throughout this module: an
+imperative-verb summary, a "Required workflow: call X first..." line where one function's output
+feeds another's input, `@param` validation notes, and `@throws` lines that tell the agent what to do
+when a call fails. Do not add KDoc anywhere else in this module (private helpers, the Hilt-injected
+fields, mapping functions) — the exception is for agent-indexed declarations only.
+
+Every `@AppFunctionSerializable` class needs inline KDoc on each property; KSP does not read
+class-level `@param`/`@property` tags for these classes.
+
+An optional `@AppFunction` parameter must be a nullable type with a `null` default — KSP fails the
+build (`Type kotlin.String cannot be optional`) on a non-nullable type with a non-null default like
+`sortBy: String = "Name"`. Use `sortBy: String? = null` and resolve the default inside the use case
+instead, the same way every other optional filter on `findApps` does.
+
+## Compatibility
+
+The module's own `minSdk` comes from the shared `MIN_SDK` (28) like every other module, but App
+Functions is an Android 16 (API 36) platform capability. `ApkAnalyzerAppFunctionService` and its
+manifest `<service>` entry (declared in `app`, see [`app/AGENTS.md`](../../app/AGENTS.md)) are
+`@RequiresApi(36)` / `tools:targetApi="36"`. This is safe on older devices without a runtime check:
+the service is a passive component nothing on API < 36 knows how to bind to (there is no
+`android.app.appfunctions.AppFunctionService` action or `BIND_APP_FUNCTION_SERVICE` permission on
+those platforms), so it never gets instantiated. Do not add defensive SDK-version checks inside the
+class itself.
+
+## Testing
+
+App Functions cannot be exercised through the normal UI — verify with `adb shell cmd app_function`
+(list, execute, set-enabled) against an API 36+ device or emulator. See the `appfunctions` skill for
+the exact commands, KDoc-optimization guidance, and candidate-discovery workflow used to build this
+module. Verified end to end on a Pixel 6 / API 37 emulator: all four functions are indexed and
+listed, `execute-app-function` returns real data for each, and both error paths (blank `findApps`,
+an unknown `packageName`) surface our custom `AppFunctionException` messages correctly.
+
+`@AppFunctionStringValueConstraint` is platform-enforced, not documentation-only: passing a value
+outside `installSource`'s or `sortBy`'s `enumValues` never reaches `FindAppsUseCase` — the platform
+rejects it first with its own generic type-mismatch message, before our friendlier
+`AppFunctionInvalidArgumentException` text ever gets a chance to run. Keep the manual
+`AppSource.valueOf()` / `sortBy` validation anyway as defense-in-depth (it's what actually fires for
+Gemini-originated calls or any future caller that doesn't go through this exact constraint path),
+but don't expect its message to be what a caller sees for an out-of-enum string.

--- a/core/app-functions/CLAUDE.md
+++ b/core/app-functions/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/core/app-functions/build.gradle.kts
+++ b/core/app-functions/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    alias(libs.plugins.apkanalyzer.library)
+    alias(libs.plugins.apkanalyzer.hilt)
+    alias(libs.plugins.apkanalyzer.appfunctions)
+}
+
+android {
+    namespace = "sk.styk.martin.apkanalyzer.core.appfunctions"
+
+    buildFeatures {
+        androidResources = false
+    }
+}
+
+dependencies {
+    implementation(projects.core.common)
+    implementation(projects.core.apps)
+}

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/ApkAnalyzerAppFunctionService.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/ApkAnalyzerAppFunctionService.kt
@@ -5,6 +5,7 @@ import androidx.appfunctions.AppFunction
 import androidx.appfunctions.AppFunctionAppUnknownException
 import androidx.appfunctions.AppFunctionElementNotFoundException
 import androidx.appfunctions.AppFunctionInvalidArgumentException
+import androidx.appfunctions.AppFunctionPermissionRequiredException
 import androidx.appfunctions.AppFunctionService
 import androidx.appfunctions.AppFunctionServiceEntryPoint
 import androidx.appfunctions.AppFunctionStringValueConstraint
@@ -73,8 +74,13 @@ abstract class ApkAnalyzerAppFunctionService : AppFunctionService() {
      * @return Up to 25 apps matching every condition supplied, in the requested order. Empty if
      *   none match.
      * @throws AppFunctionInvalidArgumentException If every parameter is left at its default (there
-     *   is nothing to search or filter by), or if installSource or sortBy isn't one of the
-     *   accepted values. If thrown, ask the user what to search for or narrow by.
+     *   is nothing to search or filter by), if installSource or sortBy isn't one of the accepted
+     *   values, or if targetSdk, minTotalSizeMb, or unusedForDays isn't a positive number. If
+     *   thrown, ask the user what to search for or narrow by.
+     * @throws AppFunctionPermissionRequiredException If unusedForDays or a "LastUsed" sortBy is
+     *   requested without Usage Access granted, or minTotalSizeMb or a "Size" sortBy is requested
+     *   without Storage Access granted. If thrown, tell the user to grant the relevant permission
+     *   to Apk Analyzer in system settings.
      */
     @AppFunction(isDescribedByKDoc = true)
     suspend fun findApps(

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/ApkAnalyzerAppFunctionService.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/ApkAnalyzerAppFunctionService.kt
@@ -1,0 +1,141 @@
+package sk.styk.martin.apkanalyzer.core.appfunctions
+
+import androidx.annotation.RequiresApi
+import androidx.appfunctions.AppFunction
+import androidx.appfunctions.AppFunctionElementNotFoundException
+import androidx.appfunctions.AppFunctionInvalidArgumentException
+import androidx.appfunctions.AppFunctionService
+import androidx.appfunctions.AppFunctionServiceEntryPoint
+import androidx.appfunctions.AppFunctionStringValueConstraint
+import dagger.hilt.android.AndroidEntryPoint
+import sk.styk.martin.apkanalyzer.core.appfunctions.model.AppDetailResult
+import sk.styk.martin.apkanalyzer.core.appfunctions.model.AppSummary
+import sk.styk.martin.apkanalyzer.core.appfunctions.model.CertificateSummary
+import sk.styk.martin.apkanalyzer.core.appfunctions.model.PermissionGrantSummary
+import sk.styk.martin.apkanalyzer.core.appfunctions.usecase.FindAppsUseCase
+import sk.styk.martin.apkanalyzer.core.appfunctions.usecase.GetAppCertificatesUseCase
+import sk.styk.martin.apkanalyzer.core.appfunctions.usecase.GetAppDetailUseCase
+import sk.styk.martin.apkanalyzer.core.appfunctions.usecase.GetAppPermissionsUseCase
+import javax.inject.Inject
+
+/**
+ * Lets an on-device AI agent search apps installed on this device and inspect one app's version,
+ * SDK targeting, install source, permissions, and signing certificates, without opening the app.
+ *
+ * Every function here is a read-only lookup; none of them change anything on the device.
+ */
+@RequiresApi(36)
+@AndroidEntryPoint
+@AppFunctionServiceEntryPoint(
+    serviceName = "ApkAnalyzerAppFunctionServiceImpl",
+    appFunctionXmlFileName = "apk_analyzer_app_function_service",
+)
+abstract class ApkAnalyzerAppFunctionService : AppFunctionService() {
+
+    @Inject internal lateinit var findAppsUseCase: FindAppsUseCase
+
+    @Inject internal lateinit var getAppDetailUseCase: GetAppDetailUseCase
+
+    @Inject internal lateinit var getAppCertificatesUseCase: GetAppCertificatesUseCase
+
+    @Inject internal lateinit var getAppPermissionsUseCase: GetAppPermissionsUseCase
+
+    /**
+     * Search and filter installed apps, combining as many conditions as needed in one call — for
+     * example "large unused apps from Google Play" combines "minTotalSizeMb", "unusedForDays", and
+     * "installSource" together instead of three separate lookups.
+     *
+     * Call this first when the user names an app by its display name rather than its exact
+     * package name, then pass the resolved packageName to "getAppDetail", "getAppCertificates", or
+     * "getAppPermissions".
+     *
+     * @param query Text matched case-insensitively against the app's display name or package
+     *   name.
+     * @param permission An Android permission the app must declare, for example
+     *   "android.permission.CAMERA". A bare name such as "CAMERA" is treated as
+     *   "android.permission.CAMERA".
+     * @param installSource The app must be installed from this source: one of "GooglePlay",
+     *   "SamsungGalaxyStore", "AmazonAppstore", "HuaweiAppGallery", "XiaomiGetApps", "FDroid",
+     *   "AuroraStore", "Sideloaded", "LocalInstall", "SystemPreinstalled", or "Unknown".
+     * @param targetSdk The exact Android API level the app must target, for example 34 for
+     *   Android 14.
+     * @param minTotalSizeMb The app's installed size, including its data when known, must be at
+     *   least this many megabytes. Use this for "large apps" style queries.
+     * @param unusedForDays The app must not have been opened in at least this many days, or never
+     *   recorded as opened at all. Use this for "unused apps" style queries.
+     * @param sortBy How to order the results: "Name" (alphabetical, used when omitted),
+     *   "SizeDescending" (largest first), "SizeAscending" (smallest first), "LastUsedAscending"
+     *   (least recently used, or never used, first), or "LastUsedDescending" (most recently used
+     *   first).
+     * @return Up to 25 apps matching every condition supplied, in the requested order. Empty if
+     *   none match.
+     * @throws AppFunctionInvalidArgumentException If every parameter is left at its default (there
+     *   is nothing to search or filter by), or if installSource or sortBy isn't one of the
+     *   accepted values. If thrown, ask the user what to search for or narrow by.
+     */
+    @AppFunction(isDescribedByKDoc = true)
+    suspend fun findApps(
+        query: String? = null,
+        permission: String? = null,
+        @AppFunctionStringValueConstraint(
+            enumValues = [
+                "GooglePlay", "SamsungGalaxyStore", "AmazonAppstore", "HuaweiAppGallery",
+                "XiaomiGetApps", "FDroid", "AuroraStore", "Sideloaded", "LocalInstall",
+                "SystemPreinstalled", "Unknown",
+            ],
+        )
+        installSource: String? = null,
+        targetSdk: Int? = null,
+        minTotalSizeMb: Int? = null,
+        unusedForDays: Int? = null,
+        @AppFunctionStringValueConstraint(
+            enumValues = ["Name", "SizeDescending", "SizeAscending", "LastUsedAscending", "LastUsedDescending"],
+        )
+        sortBy: String? = null,
+    ): List<AppSummary> = findAppsUseCase(query, permission, installSource, targetSdk, minTotalSizeMb, unusedForDays, sortBy)
+
+    /**
+     * Get version, SDK targeting, install source, permission count, and signing summary for one
+     * installed app.
+     *
+     * Required workflow: call "findApps" first if you only have the app's display name, to
+     * resolve it to an exact package name.
+     *
+     * @param packageName The app's exact package name, for example "com.example.app".
+     * @return The app's detail summary.
+     * @throws AppFunctionElementNotFoundException If no app with packageName is currently
+     *   installed. If thrown, call "findApps" to search by name instead.
+     */
+    @AppFunction(isDescribedByKDoc = true)
+    suspend fun getAppDetail(packageName: String): AppDetailResult = getAppDetailUseCase(packageName)
+
+    /**
+     * Get the certificates currently used to sign one installed app.
+     *
+     * Required workflow: call "findApps" first if you only have the app's display name, to
+     * resolve it to an exact package name.
+     *
+     * @param packageName The app's exact package name, for example "com.example.app".
+     * @return The app's current signing certificates. Most apps have exactly one; more than one
+     *   means the app is signed with multiple simultaneous signers.
+     * @throws AppFunctionElementNotFoundException If no app with packageName is currently
+     *   installed. If thrown, call "findApps" to search by name instead.
+     */
+    @AppFunction(isDescribedByKDoc = true)
+    suspend fun getAppCertificates(packageName: String): List<CertificateSummary> = getAppCertificatesUseCase(packageName)
+
+    /**
+     * Get an installed app's runtime permissions and whether each one is currently granted.
+     *
+     * Required workflow: call "findApps" first if you only have the app's display name, to
+     * resolve it to an exact package name.
+     *
+     * @param packageName The app's exact package name, for example "com.example.app".
+     * @return The app's runtime permissions and their grant state. Doesn't include permissions
+     *   that are always granted at install time and never need user approval.
+     * @throws AppFunctionElementNotFoundException If no app with packageName is currently
+     *   installed. If thrown, call "findApps" to search by name instead.
+     */
+    @AppFunction(isDescribedByKDoc = true)
+    suspend fun getAppPermissions(packageName: String): List<PermissionGrantSummary> = getAppPermissionsUseCase(packageName)
+}

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/ApkAnalyzerAppFunctionService.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/ApkAnalyzerAppFunctionService.kt
@@ -77,10 +77,10 @@ abstract class ApkAnalyzerAppFunctionService : AppFunctionService() {
      *   is nothing to search or filter by), if installSource or sortBy isn't one of the accepted
      *   values, or if targetSdk, minTotalSizeMb, or unusedForDays isn't a positive number. If
      *   thrown, ask the user what to search for or narrow by.
-     * @throws AppFunctionPermissionRequiredException If unusedForDays or a "LastUsed" sortBy is
-     *   requested without Usage Access granted, or minTotalSizeMb or a "Size" sortBy is requested
-     *   without Storage Access granted. If thrown, tell the user to grant the relevant permission
-     *   to Apk Analyzer in system settings.
+     * @throws AppFunctionPermissionRequiredException If unusedForDays, minTotalSizeMb, a "LastUsed"
+     *   sortBy, or a "Size" sortBy is requested without Usage Access granted — this single system
+     *   permission covers both size and last-used data. If thrown, tell the user to grant Usage
+     *   Access to Apk Analyzer in system settings.
      */
     @AppFunction(isDescribedByKDoc = true)
     suspend fun findApps(

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/ApkAnalyzerAppFunctionService.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/ApkAnalyzerAppFunctionService.kt
@@ -2,6 +2,7 @@ package sk.styk.martin.apkanalyzer.core.appfunctions
 
 import androidx.annotation.RequiresApi
 import androidx.appfunctions.AppFunction
+import androidx.appfunctions.AppFunctionAppUnknownException
 import androidx.appfunctions.AppFunctionElementNotFoundException
 import androidx.appfunctions.AppFunctionInvalidArgumentException
 import androidx.appfunctions.AppFunctionService
@@ -16,6 +17,8 @@ import sk.styk.martin.apkanalyzer.core.appfunctions.usecase.FindAppsUseCase
 import sk.styk.martin.apkanalyzer.core.appfunctions.usecase.GetAppCertificatesUseCase
 import sk.styk.martin.apkanalyzer.core.appfunctions.usecase.GetAppDetailUseCase
 import sk.styk.martin.apkanalyzer.core.appfunctions.usecase.GetAppPermissionsUseCase
+import sk.styk.martin.apkanalyzer.core.appfunctions.usecase.SearchFilters
+import sk.styk.martin.apkanalyzer.core.appfunctions.usecase.SortBy
 import javax.inject.Inject
 
 /**
@@ -92,7 +95,10 @@ abstract class ApkAnalyzerAppFunctionService : AppFunctionService() {
             enumValues = ["Name", "SizeDescending", "SizeAscending", "LastUsedAscending", "LastUsedDescending"],
         )
         sortBy: String? = null,
-    ): List<AppSummary> = findAppsUseCase(query, permission, installSource, targetSdk, minTotalSizeMb, unusedForDays, sortBy)
+    ): List<AppSummary> = findAppsUseCase(
+        SearchFilters.parse(query, permission, installSource, targetSdk, minTotalSizeMb, unusedForDays),
+        SortBy.parse(sortBy),
+    )
 
     /**
      * Get version, SDK targeting, install source, permission count, and signing summary for one
@@ -105,6 +111,8 @@ abstract class ApkAnalyzerAppFunctionService : AppFunctionService() {
      * @return The app's detail summary.
      * @throws AppFunctionElementNotFoundException If no app with packageName is currently
      *   installed. If thrown, call "findApps" to search by name instead.
+     * @throws AppFunctionAppUnknownException If the app's details couldn't be read for another
+     *   reason. If thrown, tell the user the lookup failed unexpectedly.
      */
     @AppFunction(isDescribedByKDoc = true)
     suspend fun getAppDetail(packageName: String): AppDetailResult = getAppDetailUseCase(packageName)
@@ -120,6 +128,8 @@ abstract class ApkAnalyzerAppFunctionService : AppFunctionService() {
      *   means the app is signed with multiple simultaneous signers.
      * @throws AppFunctionElementNotFoundException If no app with packageName is currently
      *   installed. If thrown, call "findApps" to search by name instead.
+     * @throws AppFunctionAppUnknownException If the app's certificates couldn't be read for
+     *   another reason. If thrown, tell the user the lookup failed unexpectedly.
      */
     @AppFunction(isDescribedByKDoc = true)
     suspend fun getAppCertificates(packageName: String): List<CertificateSummary> = getAppCertificatesUseCase(packageName)
@@ -135,6 +145,8 @@ abstract class ApkAnalyzerAppFunctionService : AppFunctionService() {
      *   that are always granted at install time and never need user approval.
      * @throws AppFunctionElementNotFoundException If no app with packageName is currently
      *   installed. If thrown, call "findApps" to search by name instead.
+     * @throws AppFunctionAppUnknownException If the app's permissions couldn't be read for
+     *   another reason. If thrown, tell the user the lookup failed unexpectedly.
      */
     @AppFunction(isDescribedByKDoc = true)
     suspend fun getAppPermissions(packageName: String): List<PermissionGrantSummary> = getAppPermissionsUseCase(packageName)

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/AppSourceAgentLabel.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/AppSourceAgentLabel.kt
@@ -1,0 +1,17 @@
+package sk.styk.martin.apkanalyzer.core.appfunctions
+
+import sk.styk.martin.apkanalyzer.core.common.model.AppSource
+
+internal fun AppSource.toAppFunctionLabel(): String = when (this) {
+    AppSource.GooglePlay -> "Google Play"
+    AppSource.SamsungGalaxyStore -> "Samsung Galaxy Store"
+    AppSource.AmazonAppstore -> "Amazon Appstore"
+    AppSource.HuaweiAppGallery -> "Huawei AppGallery"
+    AppSource.XiaomiGetApps -> "Xiaomi GetApps"
+    AppSource.FDroid -> "F-Droid"
+    AppSource.AuroraStore -> "Aurora Store"
+    AppSource.Sideloaded -> "Sideloaded"
+    AppSource.LocalInstall -> "Installed locally (ADB or file manager)"
+    AppSource.SystemPreinstalled -> "Preinstalled system app"
+    AppSource.Unknown -> "Unknown source"
+}

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/model/AppDetailResult.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/model/AppDetailResult.kt
@@ -1,0 +1,28 @@
+package sk.styk.martin.apkanalyzer.core.appfunctions.model
+
+import androidx.appfunctions.AppFunctionSerializable
+
+/** Version, SDK targeting, install source, permission, and signing summary for one installed app. */
+@AppFunctionSerializable(isDescribedByKDoc = true)
+data class AppDetailResult(
+    /** The app's unique package name, for example "com.example.app". */
+    val packageName: String,
+    /** The app's display name as the user sees it, for example "Chrome". */
+    val applicationName: String,
+    /** The app's user-visible version name, or null if the app doesn't declare one. */
+    val versionName: String?,
+    /** The app's internal version number. Not shown to users; use versionName for that. */
+    val versionCode: Long,
+    /** The Android version label the app targets, for example "Android 14", or null if unknown. */
+    val targetSdkLabel: String?,
+    /** The oldest Android version label the app supports, for example "Android 8.0", or null if unknown. */
+    val minSdkLabel: String?,
+    /** Where the app was installed from, for example "Google Play" or "Sideloaded". */
+    val installSourceLabel: String,
+    /** True if this is a system app that came preinstalled on the device, rather than one the user installed. */
+    val isSystemApp: Boolean,
+    /** How many permissions the app declares in its manifest. */
+    val requestedPermissionCount: Int,
+    /** True if the app is signed with more than one certificate at the same time. */
+    val hasMultipleSigners: Boolean,
+)

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/model/AppSummary.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/model/AppSummary.kt
@@ -1,0 +1,21 @@
+package sk.styk.martin.apkanalyzer.core.appfunctions.model
+
+import androidx.appfunctions.AppFunctionSerializable
+import java.time.Instant
+
+/** A short identification of one installed app, returned by search and lookup functions. */
+@AppFunctionSerializable(isDescribedByKDoc = true)
+data class AppSummary(
+    /** The app's unique package name, for example "com.example.app". Pass this to other functions that take a packageName. */
+    val packageName: String,
+    /** The app's display name as the user sees it, for example "Chrome". */
+    val applicationName: String,
+    /** The app's user-visible version name, or null if the app doesn't declare one. */
+    val versionName: String?,
+    /** Where the app was installed from, for example "Google Play" or "Sideloaded". */
+    val installSourceLabel: String,
+    /** The app's installed size in megabytes, including its data when that's known. */
+    val sizeMb: Double,
+    /** When the app was last opened, or null if that's never been recorded. */
+    val lastUsedTime: Instant?,
+)

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/model/CertificateSummary.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/model/CertificateSummary.kt
@@ -1,0 +1,28 @@
+package sk.styk.martin.apkanalyzer.core.appfunctions.model
+
+import androidx.appfunctions.AppFunctionSerializable
+import java.time.Instant
+
+/** One certificate an installed app is currently signed with. */
+@AppFunctionSerializable(isDescribedByKDoc = true)
+data class CertificateSummary(
+    /** The cryptographic algorithm used to sign the certificate, for example "SHA256withRSA". */
+    val signatureAlgorithm: String,
+    /**
+     * True if the app signed itself rather than being signed by a recognized certificate
+     * authority. Most Android apps are self-signed; this is normal and not a sign of tampering by
+     * itself.
+     */
+    val isSelfSigned: Boolean,
+    /**
+     * The certificate's SHA-256 fingerprint, formatted as colon-separated hex pairs. Use this to
+     * compare whether two apps share the same signer.
+     */
+    val sha256Fingerprint: String,
+    /** When the certificate became valid. */
+    val validFrom: Instant,
+    /** When the certificate expires. */
+    val validUntil: Instant,
+    /** The organization named on the certificate, or null if none is set. */
+    val issuerOrganization: String?,
+)

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/model/PermissionGrantSummary.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/model/PermissionGrantSummary.kt
@@ -1,0 +1,12 @@
+package sk.styk.martin.apkanalyzer.core.appfunctions.model
+
+import androidx.appfunctions.AppFunctionSerializable
+
+/** Whether an installed app currently holds one of its declared runtime permissions. */
+@AppFunctionSerializable(isDescribedByKDoc = true)
+data class PermissionGrantSummary(
+    /** The permission's full name, for example "android.permission.CAMERA". */
+    val permission: String,
+    /** True if the user currently has this permission granted to the app. */
+    val isGranted: Boolean,
+)

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/AppFunctionErrors.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/AppFunctionErrors.kt
@@ -1,6 +1,14 @@
 package sk.styk.martin.apkanalyzer.core.appfunctions.usecase
 
+import android.content.pm.PackageManager
+import androidx.appfunctions.AppFunctionAppUnknownException
 import androidx.appfunctions.AppFunctionElementNotFoundException
+import androidx.appfunctions.AppFunctionException
 
 internal fun notInstalled(packageName: String): AppFunctionElementNotFoundException =
     AppFunctionElementNotFoundException("No installed app with package name $packageName")
+
+internal fun appDetailLookupFailure(packageName: String, cause: Throwable): AppFunctionException = when (cause) {
+    is PackageManager.NameNotFoundException -> notInstalled(packageName)
+    else -> AppFunctionAppUnknownException("Failed to analyze $packageName: ${cause.message}")
+}

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/AppFunctionErrors.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/AppFunctionErrors.kt
@@ -1,0 +1,6 @@
+package sk.styk.martin.apkanalyzer.core.appfunctions.usecase
+
+import androidx.appfunctions.AppFunctionElementNotFoundException
+
+internal fun notInstalled(packageName: String): AppFunctionElementNotFoundException =
+    AppFunctionElementNotFoundException("No installed app with package name $packageName")

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/AppFunctionErrors.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/AppFunctionErrors.kt
@@ -10,5 +10,5 @@ internal fun notInstalled(packageName: String): AppFunctionElementNotFoundExcept
 
 internal fun appDetailLookupFailure(packageName: String, cause: Throwable): AppFunctionException = when (cause) {
     is PackageManager.NameNotFoundException -> notInstalled(packageName)
-    else -> AppFunctionAppUnknownException("Failed to analyze $packageName: ${cause.message}")
+    else -> AppFunctionAppUnknownException("Failed to analyze $packageName")
 }

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/FindAppsUseCase.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/FindAppsUseCase.kt
@@ -8,7 +8,6 @@ import sk.styk.martin.apkanalyzer.core.appfunctions.toAppFunctionLabel
 import sk.styk.martin.apkanalyzer.core.apps.InstalledAppsRepository
 import sk.styk.martin.apkanalyzer.core.apps.model.InstalledApp
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
-import sk.styk.martin.apkanalyzer.core.common.model.AppSource
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import javax.inject.Inject
@@ -19,113 +18,52 @@ internal class FindAppsUseCase @Inject constructor(
     private val installedAppsRepository: InstalledAppsRepository,
     private val dispatcherProvider: DispatcherProvider,
 ) {
-    suspend operator fun invoke(
-        query: String?,
-        permission: String?,
-        installSource: String?,
-        targetSdk: Int?,
-        minTotalSizeMb: Int?,
-        unusedForDays: Int?,
-        sortBy: String?,
-    ): List<AppSummary> = withContext(dispatcherProvider.io()) {
-        val normalizedQuery = query?.takeIf(String::isNotBlank)
-        val normalizedPermission = permission?.takeIf(String::isNotBlank)?.toFullPermissionName()
-        val normalizedSource = installSource?.takeIf(String::isNotBlank)?.toAppSource()
-        validate(normalizedQuery, normalizedPermission, normalizedSource, targetSdk, minTotalSizeMb, unusedForDays)
-        val comparator = (sortBy?.takeIf(String::isNotBlank) ?: "Name").toComparator()
+    suspend operator fun invoke(filters: SearchFilters, sortBy: SortBy?): List<AppSummary> = withContext(dispatcherProvider.io()) {
+        if (filters.isEmpty && sortBy == null) {
+            throw AppFunctionInvalidArgumentException(
+                "Provide at least one of query, permission, installSource, targetSdk, minTotalSizeMb, unusedForDays, or sortBy",
+            )
+        }
+        val comparator = (sortBy ?: SortBy.Name).toComparator()
         val now = Instant.now()
 
         installedAppsRepository.apps().first()
-            .filter {
-                it.matches(
-                    query = normalizedQuery,
-                    permission = normalizedPermission,
-                    installSource = normalizedSource,
-                    targetSdk = targetSdk,
-                    minTotalSizeMb = minTotalSizeMb,
-                    unusedForDays = unusedForDays,
-                    now = now,
-                )
-            }
+            .filter { it.matches(filters, now) }
             .sortedWith(comparator)
             .take(MAX_RESULTS)
             .map { it.toAppSummary() }
     }
 }
 
-private fun validate(
-    query: String?,
-    permission: String?,
-    installSource: AppSource?,
-    targetSdk: Int?,
-    minTotalSizeMb: Int?,
-    unusedForDays: Int?,
-) {
-    requireAtLeastOneFilter(query, permission, installSource, targetSdk, minTotalSizeMb, unusedForDays)
-    requirePositive(targetSdk, "targetSdk", "a positive Android API level")
-    requirePositive(minTotalSizeMb, "minTotalSizeMb", "a positive number of megabytes")
-    requirePositive(unusedForDays, "unusedForDays", "a positive number of days")
-}
-
-private fun requireAtLeastOneFilter(vararg filters: Any?) {
-    if (filters.all { it == null }) {
-        throw AppFunctionInvalidArgumentException(
-            "Provide at least one of query, permission, installSource, targetSdk, minTotalSizeMb, or unusedForDays",
-        )
-    }
-}
-
-private fun requirePositive(
-    value: Int?,
-    name: String,
-    expected: String,
-) {
-    if (value != null && value <= 0) {
-        throw AppFunctionInvalidArgumentException("$name must be $expected")
-    }
-}
-
-private fun InstalledApp.matches(
-    query: String?,
-    permission: String?,
-    installSource: AppSource?,
-    targetSdk: Int?,
-    minTotalSizeMb: Int?,
-    unusedForDays: Int?,
-    now: Instant,
-): Boolean {
+private fun InstalledApp.matches(filters: SearchFilters, now: Instant): Boolean {
+    val query = filters.query
     if (query != null && !applicationName.contains(query, ignoreCase = true) &&
         !packageName.value.contains(query, ignoreCase = true)
     ) {
         return false
     }
-    if (permission != null && permission !in requestedPermissions) return false
-    if (installSource != null && source != installSource) return false
-    if (targetSdk != null && this.targetSdk != targetSdk) return false
-    if (minTotalSizeMb != null && (totalSize ?: apkSize).megabytes < minTotalSizeMb) return false
-    if (unusedForDays != null) {
-        val cutoff = now.minus(unusedForDays.toLong(), ChronoUnit.DAYS)
+    if (filters.permission != null && filters.permission !in requestedPermissions) return false
+    if (filters.installSource != null && source != filters.installSource) return false
+    if (filters.targetSdk != null && targetSdk != filters.targetSdk) return false
+    if (filters.minTotalSizeMb != null && (totalSize ?: apkSize).megabytes < filters.minTotalSizeMb) return false
+    if (filters.unusedForDays != null) {
+        val cutoff = now.minus(filters.unusedForDays.toLong(), ChronoUnit.DAYS)
         val usedRecently = lastUsedTime?.isAfter(cutoff) == true
         if (usedRecently) return false
     }
     return true
 }
 
-private fun String.toFullPermissionName(): String = if (contains('.')) this else "android.permission.${uppercase()}"
+private fun SortBy.toComparator(): Comparator<InstalledApp> = when (this) {
+    SortBy.Name -> compareBy { it.applicationName }
 
-private fun String.toAppSource(): AppSource = runCatching { AppSource.valueOf(this) }
-    .getOrElse { throw AppFunctionInvalidArgumentException("Unknown install source: $this") }
+    SortBy.SizeDescending -> compareByDescending { (it.totalSize ?: it.apkSize).bytes }
 
-private fun String.toComparator(): Comparator<InstalledApp> = when (this) {
-    "Name" -> compareBy { it.applicationName }
+    SortBy.SizeAscending -> compareBy { (it.totalSize ?: it.apkSize).bytes }
 
-    "SizeDescending" -> compareByDescending { (it.totalSize ?: it.apkSize).bytes }
+    SortBy.LastUsedAscending -> compareBy(nullsFirst()) { it.lastUsedTime }
 
-    "SizeAscending" -> compareBy { (it.totalSize ?: it.apkSize).bytes }
-
-    "LastUsedAscending" -> compareBy(nullsFirst()) { it.lastUsedTime }
-
-    "LastUsedDescending" -> Comparator { a, b ->
+    SortBy.LastUsedDescending -> Comparator { a, b ->
         val aLastUsed = a.lastUsedTime
         val bLastUsed = b.lastUsedTime
         when {
@@ -135,8 +73,6 @@ private fun String.toComparator(): Comparator<InstalledApp> = when (this) {
             else -> bLastUsed.compareTo(aLastUsed)
         }
     }
-
-    else -> throw AppFunctionInvalidArgumentException("Unknown sortBy: $this")
 }
 
 private fun InstalledApp.toAppSummary() = AppSummary(

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/FindAppsUseCase.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/FindAppsUseCase.kt
@@ -1,0 +1,149 @@
+package sk.styk.martin.apkanalyzer.core.appfunctions.usecase
+
+import androidx.appfunctions.AppFunctionInvalidArgumentException
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import sk.styk.martin.apkanalyzer.core.appfunctions.model.AppSummary
+import sk.styk.martin.apkanalyzer.core.appfunctions.toAppFunctionLabel
+import sk.styk.martin.apkanalyzer.core.apps.InstalledAppsRepository
+import sk.styk.martin.apkanalyzer.core.apps.model.InstalledApp
+import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
+import sk.styk.martin.apkanalyzer.core.common.model.AppSource
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import javax.inject.Inject
+
+private const val MAX_RESULTS = 25
+
+internal class FindAppsUseCase @Inject constructor(
+    private val installedAppsRepository: InstalledAppsRepository,
+    private val dispatcherProvider: DispatcherProvider,
+) {
+    suspend operator fun invoke(
+        query: String?,
+        permission: String?,
+        installSource: String?,
+        targetSdk: Int?,
+        minTotalSizeMb: Int?,
+        unusedForDays: Int?,
+        sortBy: String?,
+    ): List<AppSummary> = withContext(dispatcherProvider.io()) {
+        val normalizedQuery = query?.takeIf(String::isNotBlank)
+        val normalizedPermission = permission?.takeIf(String::isNotBlank)?.toFullPermissionName()
+        val normalizedSource = installSource?.takeIf(String::isNotBlank)?.toAppSource()
+        validate(normalizedQuery, normalizedPermission, normalizedSource, targetSdk, minTotalSizeMb, unusedForDays)
+        val comparator = (sortBy?.takeIf(String::isNotBlank) ?: "Name").toComparator()
+        val now = Instant.now()
+
+        installedAppsRepository.apps().first()
+            .filter {
+                it.matches(
+                    query = normalizedQuery,
+                    permission = normalizedPermission,
+                    installSource = normalizedSource,
+                    targetSdk = targetSdk,
+                    minTotalSizeMb = minTotalSizeMb,
+                    unusedForDays = unusedForDays,
+                    now = now,
+                )
+            }
+            .sortedWith(comparator)
+            .take(MAX_RESULTS)
+            .map { it.toAppSummary() }
+    }
+}
+
+private fun validate(
+    query: String?,
+    permission: String?,
+    installSource: AppSource?,
+    targetSdk: Int?,
+    minTotalSizeMb: Int?,
+    unusedForDays: Int?,
+) {
+    requireAtLeastOneFilter(query, permission, installSource, targetSdk, minTotalSizeMb, unusedForDays)
+    requirePositive(targetSdk, "targetSdk", "a positive Android API level")
+    requirePositive(minTotalSizeMb, "minTotalSizeMb", "a positive number of megabytes")
+    requirePositive(unusedForDays, "unusedForDays", "a positive number of days")
+}
+
+private fun requireAtLeastOneFilter(vararg filters: Any?) {
+    if (filters.all { it == null }) {
+        throw AppFunctionInvalidArgumentException(
+            "Provide at least one of query, permission, installSource, targetSdk, minTotalSizeMb, or unusedForDays",
+        )
+    }
+}
+
+private fun requirePositive(
+    value: Int?,
+    name: String,
+    expected: String,
+) {
+    if (value != null && value <= 0) {
+        throw AppFunctionInvalidArgumentException("$name must be $expected")
+    }
+}
+
+private fun InstalledApp.matches(
+    query: String?,
+    permission: String?,
+    installSource: AppSource?,
+    targetSdk: Int?,
+    minTotalSizeMb: Int?,
+    unusedForDays: Int?,
+    now: Instant,
+): Boolean {
+    if (query != null && !applicationName.contains(query, ignoreCase = true) &&
+        !packageName.value.contains(query, ignoreCase = true)
+    ) {
+        return false
+    }
+    if (permission != null && permission !in requestedPermissions) return false
+    if (installSource != null && source != installSource) return false
+    if (targetSdk != null && this.targetSdk != targetSdk) return false
+    if (minTotalSizeMb != null && (totalSize ?: apkSize).megabytes < minTotalSizeMb) return false
+    if (unusedForDays != null) {
+        val cutoff = now.minus(unusedForDays.toLong(), ChronoUnit.DAYS)
+        val usedRecently = lastUsedTime?.isAfter(cutoff) == true
+        if (usedRecently) return false
+    }
+    return true
+}
+
+private fun String.toFullPermissionName(): String = if (contains('.')) this else "android.permission.${uppercase()}"
+
+private fun String.toAppSource(): AppSource = runCatching { AppSource.valueOf(this) }
+    .getOrElse { throw AppFunctionInvalidArgumentException("Unknown install source: $this") }
+
+private fun String.toComparator(): Comparator<InstalledApp> = when (this) {
+    "Name" -> compareBy { it.applicationName }
+
+    "SizeDescending" -> compareByDescending { (it.totalSize ?: it.apkSize).bytes }
+
+    "SizeAscending" -> compareBy { (it.totalSize ?: it.apkSize).bytes }
+
+    "LastUsedAscending" -> compareBy(nullsFirst()) { it.lastUsedTime }
+
+    "LastUsedDescending" -> Comparator { a, b ->
+        val aLastUsed = a.lastUsedTime
+        val bLastUsed = b.lastUsedTime
+        when {
+            aLastUsed == null && bLastUsed == null -> 0
+            aLastUsed == null -> 1
+            bLastUsed == null -> -1
+            else -> bLastUsed.compareTo(aLastUsed)
+        }
+    }
+
+    else -> throw AppFunctionInvalidArgumentException("Unknown sortBy: $this")
+}
+
+private fun InstalledApp.toAppSummary() = AppSummary(
+    packageName = packageName.value,
+    applicationName = applicationName,
+    versionName = versionName,
+    installSourceLabel = source.toAppFunctionLabel(),
+    sizeMb = (totalSize ?: apkSize).megabytes,
+    lastUsedTime = lastUsedTime,
+)

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/FindAppsUseCase.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/FindAppsUseCase.kt
@@ -1,11 +1,14 @@
 package sk.styk.martin.apkanalyzer.core.appfunctions.usecase
 
 import androidx.appfunctions.AppFunctionInvalidArgumentException
+import androidx.appfunctions.AppFunctionPermissionRequiredException
 import kotlinx.coroutines.withContext
 import sk.styk.martin.apkanalyzer.core.appfunctions.model.AppSummary
 import sk.styk.martin.apkanalyzer.core.appfunctions.toAppFunctionLabel
 import sk.styk.martin.apkanalyzer.core.apps.InstalledAppsRepository
 import sk.styk.martin.apkanalyzer.core.apps.model.InstalledApp
+import sk.styk.martin.apkanalyzer.core.apps.storagestats.StorageStatsRepository
+import sk.styk.martin.apkanalyzer.core.apps.usagestats.UsageStatsRepository
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -15,6 +18,8 @@ private const val MAX_RESULTS = 25
 
 internal class FindAppsUseCase @Inject constructor(
     private val installedAppsRepository: InstalledAppsRepository,
+    private val storageStatsRepository: StorageStatsRepository,
+    private val usageStatsRepository: UsageStatsRepository,
     private val dispatcherProvider: DispatcherProvider,
 ) {
     suspend operator fun invoke(filters: SearchFilters, sortBy: SortBy?): List<AppSummary> = withContext(dispatcherProvider.io()) {
@@ -23,6 +28,8 @@ internal class FindAppsUseCase @Inject constructor(
                 "Provide at least one of query, permission, installSource, targetSdk, minTotalSizeMb, unusedForDays, or sortBy",
             )
         }
+        requireUsagePermission(filters, sortBy)
+        requireStoragePermission(filters, sortBy)
         val comparator = (sortBy ?: SortBy.Name).toComparator()
         val now = Instant.now()
 
@@ -31,6 +38,24 @@ internal class FindAppsUseCase @Inject constructor(
             .sortedWith(comparator)
             .take(MAX_RESULTS)
             .map { it.toAppSummary() }
+    }
+
+    private fun requireUsagePermission(filters: SearchFilters, sortBy: SortBy?) {
+        val needsUsageData = filters.unusedForDays != null || sortBy == SortBy.LastUsedAscending || sortBy == SortBy.LastUsedDescending
+        if (needsUsageData && !usageStatsRepository.isPermissionGranted.value) {
+            throw AppFunctionPermissionRequiredException(
+                "Usage Access permission is required for unusedForDays or a LastUsed sortBy. Ask the user to grant Usage Access to Apk Analyzer.",
+            )
+        }
+    }
+
+    private fun requireStoragePermission(filters: SearchFilters, sortBy: SortBy?) {
+        val needsStorageData = filters.minTotalSizeMb != null || sortBy == SortBy.SizeAscending || sortBy == SortBy.SizeDescending
+        if (needsStorageData && !storageStatsRepository.isPermissionGranted.value) {
+            throw AppFunctionPermissionRequiredException(
+                "Usage Access permission is required for minTotalSizeMb or a Size sortBy. Ask the user to grant Usage Access to Apk Analyzer.",
+            )
+        }
     }
 }
 

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/FindAppsUseCase.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/FindAppsUseCase.kt
@@ -1,7 +1,6 @@
 package sk.styk.martin.apkanalyzer.core.appfunctions.usecase
 
 import androidx.appfunctions.AppFunctionInvalidArgumentException
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import sk.styk.martin.apkanalyzer.core.appfunctions.model.AppSummary
 import sk.styk.martin.apkanalyzer.core.appfunctions.toAppFunctionLabel
@@ -27,7 +26,7 @@ internal class FindAppsUseCase @Inject constructor(
         val comparator = (sortBy ?: SortBy.Name).toComparator()
         val now = Instant.now()
 
-        installedAppsRepository.apps().first()
+        installedAppsRepository.awaitFullyEnrichedApps()
             .filter { it.matches(filters, now) }
             .sortedWith(comparator)
             .take(MAX_RESULTS)

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/GetAppCertificatesUseCase.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/GetAppCertificatesUseCase.kt
@@ -15,7 +15,7 @@ internal class GetAppCertificatesUseCase @Inject constructor(
 ) {
     suspend operator fun invoke(packageName: String): List<CertificateSummary> = withContext(dispatcherProvider.io()) {
         appDetailRepository.details(AppReference.InstalledPackage(PackageName(packageName)))
-            .getOrElse { throw notInstalled(packageName) }
+            .getOrElse { throw appDetailLookupFailure(packageName, it) }
             .signing.currentCertificates.map { it.toCertificateSummary() }
     }
 }

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/GetAppCertificatesUseCase.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/GetAppCertificatesUseCase.kt
@@ -1,0 +1,30 @@
+package sk.styk.martin.apkanalyzer.core.appfunctions.usecase
+
+import kotlinx.coroutines.withContext
+import sk.styk.martin.apkanalyzer.core.appfunctions.model.CertificateSummary
+import sk.styk.martin.apkanalyzer.core.apps.AppDetailRepository
+import sk.styk.martin.apkanalyzer.core.apps.signing.Certificate
+import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
+import sk.styk.martin.apkanalyzer.core.common.model.AppReference
+import sk.styk.martin.apkanalyzer.core.common.model.PackageName
+import javax.inject.Inject
+
+internal class GetAppCertificatesUseCase @Inject constructor(
+    private val appDetailRepository: AppDetailRepository,
+    private val dispatcherProvider: DispatcherProvider,
+) {
+    suspend operator fun invoke(packageName: String): List<CertificateSummary> = withContext(dispatcherProvider.io()) {
+        appDetailRepository.details(AppReference.InstalledPackage(PackageName(packageName)))
+            .getOrElse { throw notInstalled(packageName) }
+            .signing.currentCertificates.map { it.toCertificateSummary() }
+    }
+}
+
+private fun Certificate.toCertificateSummary() = CertificateSummary(
+    signatureAlgorithm = signAlgorithm,
+    isSelfSigned = isSelfSigned,
+    sha256Fingerprint = formattedSha256Fingerprint,
+    validFrom = validFrom,
+    validUntil = validUntil,
+    issuerOrganization = issuer.organization,
+)

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/GetAppDetailUseCase.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/GetAppDetailUseCase.kt
@@ -1,0 +1,35 @@
+package sk.styk.martin.apkanalyzer.core.appfunctions.usecase
+
+import kotlinx.coroutines.withContext
+import sk.styk.martin.apkanalyzer.core.appfunctions.model.AppDetailResult
+import sk.styk.martin.apkanalyzer.core.appfunctions.toAppFunctionLabel
+import sk.styk.martin.apkanalyzer.core.apps.AppDetailRepository
+import sk.styk.martin.apkanalyzer.core.apps.model.AppDetail
+import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
+import sk.styk.martin.apkanalyzer.core.common.model.AppReference
+import sk.styk.martin.apkanalyzer.core.common.model.PackageName
+import javax.inject.Inject
+
+internal class GetAppDetailUseCase @Inject constructor(
+    private val appDetailRepository: AppDetailRepository,
+    private val dispatcherProvider: DispatcherProvider,
+) {
+    suspend operator fun invoke(packageName: String): AppDetailResult = withContext(dispatcherProvider.io()) {
+        appDetailRepository.details(AppReference.InstalledPackage(PackageName(packageName)))
+            .getOrElse { throw notInstalled(packageName) }
+            .toAppDetailResult()
+    }
+}
+
+private fun AppDetail.toAppDetailResult() = AppDetailResult(
+    packageName = info.packageName.value,
+    applicationName = info.applicationName,
+    versionName = info.versionName,
+    versionCode = info.versionCode,
+    targetSdkLabel = info.targetSdkLabel,
+    minSdkLabel = info.minSdkLabel,
+    installSourceLabel = info.source.toAppFunctionLabel(),
+    isSystemApp = info.isSystemApp,
+    requestedPermissionCount = permissions.defined.size,
+    hasMultipleSigners = signing.hasMultipleSigners,
+)

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/GetAppDetailUseCase.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/GetAppDetailUseCase.kt
@@ -16,7 +16,7 @@ internal class GetAppDetailUseCase @Inject constructor(
 ) {
     suspend operator fun invoke(packageName: String): AppDetailResult = withContext(dispatcherProvider.io()) {
         appDetailRepository.details(AppReference.InstalledPackage(PackageName(packageName)))
-            .getOrElse { throw notInstalled(packageName) }
+            .getOrElse { throw appDetailLookupFailure(packageName, it) }
             .toAppDetailResult()
     }
 }
@@ -30,6 +30,6 @@ private fun AppDetail.toAppDetailResult() = AppDetailResult(
     minSdkLabel = info.minSdkLabel,
     installSourceLabel = info.source.toAppFunctionLabel(),
     isSystemApp = info.isSystemApp,
-    requestedPermissionCount = permissions.defined.size,
+    requestedPermissionCount = permissions.used.size,
     hasMultipleSigners = signing.hasMultipleSigners,
 )

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/GetAppPermissionsUseCase.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/GetAppPermissionsUseCase.kt
@@ -1,0 +1,26 @@
+package sk.styk.martin.apkanalyzer.core.appfunctions.usecase
+
+import kotlinx.coroutines.withContext
+import sk.styk.martin.apkanalyzer.core.appfunctions.model.PermissionGrantSummary
+import sk.styk.martin.apkanalyzer.core.apps.AppDetailRepository
+import sk.styk.martin.apkanalyzer.core.apps.permissions.UsedPermission
+import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
+import sk.styk.martin.apkanalyzer.core.common.model.AppReference
+import sk.styk.martin.apkanalyzer.core.common.model.PackageName
+import javax.inject.Inject
+
+internal class GetAppPermissionsUseCase @Inject constructor(
+    private val appDetailRepository: AppDetailRepository,
+    private val dispatcherProvider: DispatcherProvider,
+) {
+    suspend operator fun invoke(packageName: String): List<PermissionGrantSummary> = withContext(dispatcherProvider.io()) {
+        appDetailRepository.details(AppReference.InstalledPackage(PackageName(packageName)))
+            .getOrElse { throw notInstalled(packageName) }
+            .permissions.used.map { it.toPermissionGrantSummary() }
+    }
+}
+
+private fun UsedPermission.toPermissionGrantSummary() = PermissionGrantSummary(
+    permission = permissionData.name,
+    isGranted = isGranted,
+)

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/GetAppPermissionsUseCase.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/GetAppPermissionsUseCase.kt
@@ -3,6 +3,7 @@ package sk.styk.martin.apkanalyzer.core.appfunctions.usecase
 import kotlinx.coroutines.withContext
 import sk.styk.martin.apkanalyzer.core.appfunctions.model.PermissionGrantSummary
 import sk.styk.martin.apkanalyzer.core.apps.AppDetailRepository
+import sk.styk.martin.apkanalyzer.core.apps.permissions.ProtectionLevel
 import sk.styk.martin.apkanalyzer.core.apps.permissions.UsedPermission
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
 import sk.styk.martin.apkanalyzer.core.common.model.AppReference
@@ -15,8 +16,10 @@ internal class GetAppPermissionsUseCase @Inject constructor(
 ) {
     suspend operator fun invoke(packageName: String): List<PermissionGrantSummary> = withContext(dispatcherProvider.io()) {
         appDetailRepository.details(AppReference.InstalledPackage(PackageName(packageName)))
-            .getOrElse { throw notInstalled(packageName) }
-            .permissions.used.map { it.toPermissionGrantSummary() }
+            .getOrElse { throw appDetailLookupFailure(packageName, it) }
+            .permissions.used
+            .filter { it.permissionData.details?.protectionLevel == ProtectionLevel.Dangerous }
+            .map { it.toPermissionGrantSummary() }
     }
 }
 

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/SearchFilters.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/SearchFilters.kt
@@ -1,0 +1,55 @@
+package sk.styk.martin.apkanalyzer.core.appfunctions.usecase
+
+import androidx.appfunctions.AppFunctionInvalidArgumentException
+import sk.styk.martin.apkanalyzer.core.common.model.AppSource
+
+internal data class SearchFilters(
+    val query: String?,
+    val permission: String?,
+    val installSource: AppSource?,
+    val targetSdk: Int?,
+    val minTotalSizeMb: Int?,
+    val unusedForDays: Int?,
+) {
+    val isEmpty: Boolean
+        get() = query == null && permission == null && installSource == null &&
+            targetSdk == null && minTotalSizeMb == null && unusedForDays == null
+
+    companion object {
+        fun parse(
+            query: String?,
+            permission: String?,
+            installSource: String?,
+            targetSdk: Int?,
+            minTotalSizeMb: Int?,
+            unusedForDays: Int?,
+        ): SearchFilters {
+            requirePositive(targetSdk, "targetSdk", "a positive Android API level")
+            requirePositive(minTotalSizeMb, "minTotalSizeMb", "a positive number of megabytes")
+            requirePositive(unusedForDays, "unusedForDays", "a positive number of days")
+            return SearchFilters(
+                query = query?.takeIf(String::isNotBlank),
+                permission = permission?.takeIf(String::isNotBlank)?.toFullPermissionName(),
+                installSource = installSource?.takeIf(String::isNotBlank)?.toAppSource(),
+                targetSdk = targetSdk,
+                minTotalSizeMb = minTotalSizeMb,
+                unusedForDays = unusedForDays,
+            )
+        }
+    }
+}
+
+private fun requirePositive(
+    value: Int?,
+    name: String,
+    expected: String,
+) {
+    if (value != null && value <= 0) {
+        throw AppFunctionInvalidArgumentException("$name must be $expected")
+    }
+}
+
+private fun String.toFullPermissionName(): String = if (contains('.')) this else "android.permission.${uppercase()}"
+
+private fun String.toAppSource(): AppSource = runCatching { AppSource.valueOf(this) }
+    .getOrElse { throw AppFunctionInvalidArgumentException("Unknown install source: $this") }

--- a/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/SortBy.kt
+++ b/core/app-functions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appfunctions/usecase/SortBy.kt
@@ -1,0 +1,20 @@
+package sk.styk.martin.apkanalyzer.core.appfunctions.usecase
+
+import androidx.appfunctions.AppFunctionInvalidArgumentException
+
+internal enum class SortBy {
+    Name,
+    SizeDescending,
+    SizeAscending,
+    LastUsedAscending,
+    LastUsedDescending,
+    ;
+
+    companion object {
+        fun parse(value: String?): SortBy? {
+            val normalized = value?.takeIf(String::isNotBlank) ?: return null
+            return entries.find { it.name == normalized }
+                ?: throw AppFunctionInvalidArgumentException("Unknown sortBy: $normalized")
+        }
+    }
+}

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepository.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepository.kt
@@ -5,4 +5,5 @@ import sk.styk.martin.apkanalyzer.core.apps.model.InstalledApp
 
 interface InstalledAppsRepository {
     fun apps(): Flow<List<InstalledApp>>
+    suspend fun awaitFullyEnrichedApps(): List<InstalledApp>
 }

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.mapLatest
@@ -43,8 +44,8 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
     private val installSourceResolver: InstallSourceResolver,
     packageChangesObserver: PackageChangesObserver,
     dispatcherProvider: DispatcherProvider,
-    storageStatsRepository: StorageStatsRepository,
-    usageStatsRepository: UsageStatsRepository,
+    private val storageStatsRepository: StorageStatsRepository,
+    private val usageStatsRepository: UsageStatsRepository,
     appScope: CoroutineScope,
     private val performanceTracker: PerformanceTracker,
 ) : InstalledAppsRepository {
@@ -73,6 +74,20 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
         .shareIn(appScope, SharingStarted.Eagerly, replay = 1)
 
     override fun apps(): Flow<List<InstalledApp>> = cachedApps
+
+    override suspend fun awaitFullyEnrichedApps(): List<InstalledApp> {
+        val currentApps = cachedApps.first()
+        usageStatsRepository.ensureLoaded()
+        storageStatsRepository.ensureLoaded(currentApps.map { it.packageName })
+        val totalSizes = storageStatsRepository.totalSizes.value
+        val lastUsedTimes = usageStatsRepository.lastUsedTimes.value
+        return currentApps.map { app ->
+            app.copy(
+                totalSize = totalSizes[app.packageName] ?: app.totalSize,
+                lastUsedTime = lastUsedTimes[app.packageName] ?: app.lastUsedTime,
+            )
+        }
+    }
 
     @SuppressLint("QueryPermissionsNeeded")
     private suspend fun loadAllApps(): List<InstalledApp> = performanceTracker.startCancellableTrace("installed_apps_load") {

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepository.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepository.kt
@@ -9,4 +9,5 @@ interface StorageStatsRepository {
     val totalSizes: StateFlow<Map<PackageName, AppSize>>
     fun requestTotalSizes(packageNames: List<PackageName>)
     suspend fun queryTotalSize(packageName: PackageName): AppSize?
+    suspend fun ensureLoaded(packageNames: List<PackageName>)
 }

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
@@ -52,10 +52,18 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
     final override val totalSizes: StateFlow<Map<PackageName, AppSize>>
         field = MutableStateFlow<Map<PackageName, AppSize>>(emptyMap())
 
+    private var hasLoadedOnce = false
+
     override fun onStart(owner: LifecycleOwner) {
         applicationScope.launch(dispatcherProvider.io()) {
             fetchTotalSizes(packageNames, "lifecycle_start")
         }
+    }
+
+    override suspend fun ensureLoaded(packageNames: List<PackageName>) {
+        if (hasLoadedOnce) return
+        this.packageNames = packageNames
+        fetchTotalSizes(packageNames, "ensure_loaded")
     }
 
     private fun checkPermission(): Boolean {
@@ -165,6 +173,7 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
                 },
             )
         }
+        hasLoadedOnce = true
     }
 
     private fun queryPackageSize(user: UserHandle, packageName: PackageName): SizeQueryResult = try {

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
@@ -55,24 +55,21 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
         field = MutableStateFlow<Map<PackageName, AppSize>>(emptyMap())
 
     private val fetchMutex = Mutex()
-    private var loadedPackageNames: Set<PackageName> = emptySet()
 
     override fun onStart(owner: LifecycleOwner) {
         applicationScope.launch(dispatcherProvider.io()) {
-            fetchTotalSizesTracked(packageNames, "lifecycle_start")
+            fetchTotalSizesLocked(packageNames, "lifecycle_start")
         }
     }
 
     override suspend fun ensureLoaded(packageNames: List<PackageName>) {
-        fetchTotalSizesTracked(packageNames, "ensure_loaded")
+        fetchTotalSizesLocked(packageNames, "ensure_loaded")
     }
 
-    private suspend fun fetchTotalSizesTracked(packageNames: List<PackageName>, trigger: String) {
+    private suspend fun fetchTotalSizesLocked(packageNames: List<PackageName>, trigger: String) {
         fetchMutex.withLock {
-            if (loadedPackageNames.containsAll(packageNames)) return
             this.packageNames = packageNames
             fetchTotalSizes(packageNames, trigger)
-            loadedPackageNames = packageNames.toSet()
         }
     }
 
@@ -88,7 +85,7 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
     override fun requestTotalSizes(packageNames: List<PackageName>) {
         this.packageNames = packageNames
         applicationScope.launch(dispatcherProvider.io()) {
-            fetchTotalSizesTracked(packageNames, "installed_apps")
+            fetchTotalSizesLocked(packageNames, "installed_apps")
         }
     }
 

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
 import sk.styk.martin.apkanalyzer.core.common.coroutines.runCatchingCancellable
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
@@ -52,18 +54,26 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
     final override val totalSizes: StateFlow<Map<PackageName, AppSize>>
         field = MutableStateFlow<Map<PackageName, AppSize>>(emptyMap())
 
-    private var hasLoadedOnce = false
+    private val fetchMutex = Mutex()
+    private var loadedPackageNames: Set<PackageName> = emptySet()
 
     override fun onStart(owner: LifecycleOwner) {
         applicationScope.launch(dispatcherProvider.io()) {
-            fetchTotalSizes(packageNames, "lifecycle_start")
+            fetchTotalSizesTracked(packageNames, "lifecycle_start")
         }
     }
 
     override suspend fun ensureLoaded(packageNames: List<PackageName>) {
-        if (hasLoadedOnce) return
-        this.packageNames = packageNames
-        fetchTotalSizes(packageNames, "ensure_loaded")
+        fetchTotalSizesTracked(packageNames, "ensure_loaded")
+    }
+
+    private suspend fun fetchTotalSizesTracked(packageNames: List<PackageName>, trigger: String) {
+        fetchMutex.withLock {
+            if (loadedPackageNames.containsAll(packageNames)) return
+            this.packageNames = packageNames
+            fetchTotalSizes(packageNames, trigger)
+            loadedPackageNames = packageNames.toSet()
+        }
     }
 
     private fun checkPermission(): Boolean {
@@ -78,7 +88,7 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
     override fun requestTotalSizes(packageNames: List<PackageName>) {
         this.packageNames = packageNames
         applicationScope.launch(dispatcherProvider.io()) {
-            fetchTotalSizes(packageNames, "installed_apps")
+            fetchTotalSizesTracked(packageNames, "installed_apps")
         }
     }
 
@@ -173,7 +183,6 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
                 },
             )
         }
-        hasLoadedOnce = true
     }
 
     private fun queryPackageSize(user: UserHandle, packageName: PackageName): SizeQueryResult = try {

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/usagestats/UsageStatsRepository.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/usagestats/UsageStatsRepository.kt
@@ -8,4 +8,5 @@ interface UsageStatsRepository {
     val isPermissionGranted: StateFlow<Boolean>
     val lastUsedTimes: StateFlow<Map<PackageName, Instant>>
     suspend fun queryLastUsedTime(packageName: PackageName): Instant?
+    suspend fun ensureLoaded()
 }

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/usagestats/UsageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/usagestats/UsageStatsRepositoryImpl.kt
@@ -48,8 +48,6 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
     final override val lastUsedTimes: StateFlow<Map<PackageName, Instant>>
         field = MutableStateFlow<Map<PackageName, Instant>>(emptyMap())
 
-    private var hasLoadedOnce = false
-
     override fun onStart(owner: LifecycleOwner) {
         applicationScope.launch(dispatcherProvider.default()) {
             fetchUsageTimes()
@@ -57,7 +55,6 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun ensureLoaded() {
-        if (hasLoadedOnce) return
         fetchUsageTimes()
     }
 
@@ -99,7 +96,6 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
                 },
             )
         }
-        hasLoadedOnce = true
     }
 
     @SuppressLint("MissingPermission")

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/usagestats/UsageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/usagestats/UsageStatsRepositoryImpl.kt
@@ -48,10 +48,17 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
     final override val lastUsedTimes: StateFlow<Map<PackageName, Instant>>
         field = MutableStateFlow<Map<PackageName, Instant>>(emptyMap())
 
+    private var hasLoadedOnce = false
+
     override fun onStart(owner: LifecycleOwner) {
         applicationScope.launch(dispatcherProvider.default()) {
             fetchUsageTimes()
         }
+    }
+
+    override suspend fun ensureLoaded() {
+        if (hasLoadedOnce) return
+        fetchUsageTimes()
     }
 
     override suspend fun queryLastUsedTime(packageName: PackageName): Instant? = lastUsedTimes.value[packageName] ?: if (checkPermission()) {
@@ -92,6 +99,7 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
                 },
             )
         }
+        hasLoadedOnce = true
     }
 
     @SuppressLint("MissingPermission")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ play-review = "2.0.2"
 
 # On-device AI
 mlkit-genai-prompt = "1.0.0-beta4"
+androidx-appfunctions = "1.0.0-alpha10"
 
 # Third-party
 timber = "5.0.1"
@@ -108,6 +109,10 @@ androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref =
 # On-device AI
 mlkit-genai-prompt = { module = "com.google.mlkit:genai-prompt", version.ref = "mlkit-genai-prompt" }
 
+# App Functions
+androidx-appfunctions = { module = "androidx.appfunctions:appfunctions", version.ref = "androidx-appfunctions" }
+androidx-appfunctions-compiler = { module = "androidx.appfunctions:appfunctions-compiler", version.ref = "androidx-appfunctions" }
+
 # Play Core
 play-review-ktx = { module = "com.google.android.play:review-ktx", version.ref = "play-review" }
 
@@ -154,6 +159,7 @@ apkanalyzer-sarif-merge = { id = "apkanalyzer.sarif-merge" }
 apkanalyzer-compose = { id = "apkanalyzer.compose" }
 apkanalyzer-room = { id = "apkanalyzer.room" }
 apkanalyzer-baselineprofile = { id = "apkanalyzer.baselineprofile" }
+apkanalyzer-appfunctions = { id = "apkanalyzer.appfunctions" }
 
 [bundles]
 compose = ["androidx-compose-ui", "androidx-compose-ui-tooling", "androidx-compose-foundation", "androidx-compose-foundation-layout"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ play-review = "2.0.2"
 
 # On-device AI
 mlkit-genai-prompt = "1.0.0-beta4"
-androidx-appfunctions = "1.0.0-alpha10"
+androidx-appfunctions = "1.0.0-alpha11"
 
 # Third-party
 timber = "5.0.1"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,6 +29,7 @@ include(
     ":core:apk-files",
     ":core:apps",
     ":core:app-permissions",
+    ":core:app-functions",
     ":core:ai-insights",
     ":core:app-index",
     ":core:common",


### PR DESCRIPTION
## Summary
- Adds `core:app-functions`, exposing 4 read-only App Functions (`findApps`, `getAppDetail`, `getAppCertificates`, `getAppPermissions`) so an on-device AI agent (Gemini or similar) can search/filter installed apps and inspect one app's version, SDK targeting, install source, permission grants, and signing certificates without opening Apk Analyzer.
- `findApps` combines all filters (name/package query, permission, install source, target SDK, minimum size, days unused) in one call with a configurable `sortBy`, so a compound request like "large unused apps from Google Play" is a single call.
- One use case per `@AppFunction`, injected into the thin `ApkAnalyzerAppFunctionService` entry point.
- New `apkanalyzer.appfunctions` convention plugin; manifest `<service>` + `app_metadata.xml` registration lives in `app` (only the app module aggregates schemas across modules).
- Pulled in the official `appfunctions` skill from `android/skills` for future implementation/KDoc/testing work, and documented a repo-specific KDoc-as-agent-description carve-out in `AGENTS.md`.
- Closes #206.

## Test plan
- [x] `./gradlew spotlessApply detektDebug :app:assembleDebug` clean
- [x] Inspected the shipped `app-debug.apk` directly — generated schema contains all 4 functions with clean (bracket-free) agent-facing descriptions
- [x] Verified end to end on a Pixel 6 / API 37 emulator:
  - `adb shell cmd app_function list-app-functions` lists all 4 functions
  - `execute-app-function` returns real data for `findApps` (text search, combined filters, `sortBy` ordering verified numerically), `getAppDetail`, `getAppCertificates`, `getAppPermissions`
  - Both error paths (`AppFunctionInvalidArgumentException` on a blank `findApps` call, `AppFunctionElementNotFoundException` on an unknown package) return the expected messages
  - No crashes in logcat throughout