### PR TITLE
Stop offering Retry on APK-file analysis failures that can never succeed

### DIFF
--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepository.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepository.kt
@@ -6,3 +6,5 @@ import sk.styk.martin.apkanalyzer.core.common.model.AppReference
 interface AppDetailRepository {
     suspend fun details(reference: AppReference): Result<AppDetail>
 }
+
+class UnparsableApkFileException(path: String) : Exception("Cannot parse APK file: $path")

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
@@ -158,7 +158,7 @@ internal class AppDetailRepositoryImpl @Inject constructor(
         return runCatchingCancellable {
             val packageInfo = timedStage("package query", "package_query_ms", context) {
                 packageManager.getPackageArchiveInfoWithCorrectPath(accessibleFile.absolutePath, analysisFlags)
-            } ?: error("Cannot parse APK file: ${accessibleFile.absolutePath}")
+            } ?: throw UnparsableApkFileException(accessibleFile.absolutePath)
 
             getPackageDetails(
                 context = context,

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailScreen.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailScreen.kt
@@ -244,7 +244,7 @@ private fun AppDetailContent(
                     title = stringResource(R.string.app_detail_title),
                     onBack = onBack,
                 )
-                ErrorContent(onAction = onAction)
+                ErrorContent(canRetry = state.canRetry, onAction = onAction)
             }
 
             is AppDetailState.Loaded -> {
@@ -1064,22 +1064,28 @@ private fun LoadingContent(modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun ErrorContent(onAction: (AppDetailAction) -> Unit, modifier: Modifier = Modifier) {
+private fun ErrorContent(
+    canRetry: Boolean,
+    onAction: (AppDetailAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Column(
         modifier = modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
         Text(
-            text = stringResource(R.string.app_detail_error),
+            text = stringResource(if (canRetry) R.string.app_detail_error else R.string.app_detail_error_unsupported_apk),
             style = AppTheme.typography.bodyLarge,
             color = AppTheme.colors.onBackground,
         )
-        Spacer(modifier = Modifier.height(16.dp))
-        TextButton(
-            text = stringResource(R.string.app_detail_retry),
-            onClick = { onAction(AppDetailAction.Retry) },
-        )
+        if (canRetry) {
+            Spacer(modifier = Modifier.height(16.dp))
+            TextButton(
+                text = stringResource(R.string.app_detail_retry),
+                onClick = { onAction(AppDetailAction.Retry) },
+            )
+        }
     }
 }
 
@@ -1116,8 +1122,21 @@ private fun AppDetailLoadingPreview() {
 private fun AppDetailErrorPreview() {
     ApkAnalyzerTheme {
         AppDetailContent(
-            state = AppDetailState.Error,
+            state = AppDetailState.Error(canRetry = true),
             appReference = AppReference.InstalledPackage(PackageName("com.spotify.music")),
+            onAction = {},
+            onBack = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun AppDetailErrorUnsupportedApkPreview() {
+    ApkAnalyzerTheme {
+        AppDetailContent(
+            state = AppDetailState.Error(canRetry = false),
+            appReference = AppReference.ApkFile(path = "/data/local/tmp/sample.apk"),
             onAction = {},
             onBack = {},
         )

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailState.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailState.kt
@@ -131,5 +131,6 @@ internal sealed interface AppDetailState {
         data class RequirementPreview(val name: String?, val isUnmetRequirement: Boolean)
     }
 
-    data object Error : AppDetailState
+    @Immutable
+    data class Error(val canRetry: Boolean) : AppDetailState
 }

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailViewModel.kt
@@ -25,6 +25,7 @@ import sk.styk.martin.apkanalyzer.core.apkfiles.TemporaryApkManager
 import sk.styk.martin.apkanalyzer.core.apppermissions.PermissionLabelProvider
 import sk.styk.martin.apkanalyzer.core.apps.AppClassificationThresholds
 import sk.styk.martin.apkanalyzer.core.apps.AppDetailRepository
+import sk.styk.martin.apkanalyzer.core.apps.UnparsableApkFileException
 import sk.styk.martin.apkanalyzer.core.apps.devicefeatures.DeviceFeatures
 import sk.styk.martin.apkanalyzer.core.apps.devicefeatures.DeviceFeaturesRepository
 import sk.styk.martin.apkanalyzer.core.apps.devicefeatures.Feature
@@ -80,7 +81,7 @@ internal class AppDetailViewModel @AssistedInject constructor(
     val state: StateFlow<AppDetailState> = combine(source, exportInProgress) { source, exportInProgress ->
         when (source) {
             AppDetailSource.Loading -> AppDetailState.Loading
-            AppDetailSource.Error -> AppDetailState.Error
+            is AppDetailSource.Error -> AppDetailState.Error(canRetry = source.canRetry)
             is AppDetailSource.Ready -> source.state.copy(exportInProgress = exportInProgress)
         }
     }
@@ -298,7 +299,7 @@ internal class AppDetailViewModel @AssistedInject constructor(
                     analytics.track(AppDetailAnalyticsEvent.Opened(appReference))
                     AppDetailSource.Ready(detail.toLoadedState(deviceFeatures).withComputedBadges(Instant.now()))
                 },
-                onFailure = { AppDetailSource.Error },
+                onFailure = { AppDetailSource.Error(canRetry = it !is UnparsableApkFileException) },
             )
             if (detailResult.isSuccess && appReference is AppReference.InstalledPackage) {
                 recentlyViewedAppsRepository.addRecent(appReference.packageName)
@@ -413,7 +414,7 @@ internal class AppDetailViewModel @AssistedInject constructor(
 
 private sealed interface AppDetailSource {
     data object Loading : AppDetailSource
-    data object Error : AppDetailSource
+    data class Error(val canRetry: Boolean) : AppDetailSource
     data class Ready(val state: AppDetailState.Loaded) : AppDetailSource
 }
 

--- a/feature/app-detail/impl/src/main/res/values-ar/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values-ar/strings.xml
@@ -59,6 +59,7 @@
     <string name="app_detail_no">لا</string>
     <string name="app_detail_unknown">غير معروف</string>
     <string name="app_detail_error">فشل في تحميل تفاصيل التطبيق</string>
+    <string name="app_detail_error_unsupported_apk">هذا الملف ليس ملف APK صالحًا ولا يمكن تحليله</string>
     <string name="app_detail_retry">حاول مرة أخرى</string>
     <string name="app_detail_action_manifest">Manifest</string>
     <string name="app_detail_action_export_apk">تصدير APK</string>

--- a/feature/app-detail/impl/src/main/res/values-cs/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values-cs/strings.xml
@@ -49,6 +49,7 @@
     <string name="app_detail_no">Ne</string>
     <string name="app_detail_unknown">Neznámý</string>
     <string name="app_detail_error">Nepodařilo se načíst podrobnosti aplikace</string>
+    <string name="app_detail_error_unsupported_apk">Tento soubor není platný soubor APK a nelze ho analyzovat</string>
     <string name="app_detail_retry">Zkusit znovu</string>
     <string name="app_detail_action_manifest">Manifest</string>
     <string name="app_detail_action_export_apk">Exportovat APK</string>

--- a/feature/app-detail/impl/src/main/res/values-de/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values-de/strings.xml
@@ -39,6 +39,7 @@
     <string name="app_detail_no">Nein</string>
     <string name="app_detail_unknown">Unbekannt</string>
     <string name="app_detail_error">Fehler beim Laden der App-Details</string>
+    <string name="app_detail_error_unsupported_apk">Diese Datei ist keine gültige APK und kann nicht analysiert werden</string>
     <string name="app_detail_retry">Erneut versuchen</string>
     <string name="app_detail_action_manifest">Manifest</string>
     <string name="app_detail_action_export_apk">Export APK</string>

--- a/feature/app-detail/impl/src/main/res/values-es/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values-es/strings.xml
@@ -44,6 +44,7 @@
     <string name="app_detail_no">No</string>
     <string name="app_detail_unknown">Desconocido</string>
     <string name="app_detail_error">Error al cargar los detalles de la aplicación</string>
+    <string name="app_detail_error_unsupported_apk">Este archivo no es un APK válido y no se puede analizar</string>
     <string name="app_detail_retry">Intenta de nuevo</string>
     <string name="app_detail_action_manifest">Manifest</string>
     <string name="app_detail_action_export_apk">Exportar APK</string>

--- a/feature/app-detail/impl/src/main/res/values-fr/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values-fr/strings.xml
@@ -44,6 +44,7 @@
     <string name="app_detail_no">Non</string>
     <string name="app_detail_unknown">Inconnu</string>
     <string name="app_detail_error">Échec du chargement des détails de l\'application</string>
+    <string name="app_detail_error_unsupported_apk">Ce fichier n\'est pas un APK valide et ne peut pas être analysé</string>
     <string name="app_detail_retry">Réessayer</string>
     <string name="app_detail_action_manifest">Manifest</string>
     <string name="app_detail_action_export_apk">Exporter APK</string>

--- a/feature/app-detail/impl/src/main/res/values-hi/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values-hi/strings.xml
@@ -39,6 +39,7 @@
     <string name="app_detail_no">नहीं</string>
     <string name="app_detail_unknown">अज्ञात</string>
     <string name="app_detail_error">ऐप विवरण लोड करने में विफल</string>
+    <string name="app_detail_error_unsupported_apk">यह फ़ाइल मान्य APK नहीं है और इसका विश्लेषण नहीं किया जा सकता</string>
     <string name="app_detail_retry">फिर से प्रयास करें</string>
     <string name="app_detail_action_manifest">Manifest</string>
     <string name="app_detail_action_export_apk">APK निर्यात करें</string>

--- a/feature/app-detail/impl/src/main/res/values-in/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values-in/strings.xml
@@ -34,6 +34,7 @@
     <string name="app_detail_no">Tidak</string>
     <string name="app_detail_unknown">Tidak diketahui</string>
     <string name="app_detail_error">Gagal memuat rincian aplikasi</string>
+    <string name="app_detail_error_unsupported_apk">File ini bukan APK yang valid dan tidak dapat dianalisis</string>
     <string name="app_detail_retry">Coba lagi</string>
     <string name="app_detail_action_manifest">Manifest</string>
     <string name="app_detail_action_export_apk">Ekspor APK</string>

--- a/feature/app-detail/impl/src/main/res/values-it/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values-it/strings.xml
@@ -44,6 +44,7 @@
     <string name="app_detail_no">No</string>
     <string name="app_detail_unknown">Sconosciuto</string>
     <string name="app_detail_error">Impossibile caricare i dettagli dell\'app</string>
+    <string name="app_detail_error_unsupported_apk">Questo file non è un APK valido e non può essere analizzato</string>
     <string name="app_detail_retry">Riprova</string>
     <string name="app_detail_action_manifest">Manifest</string>
     <string name="app_detail_action_export_apk">Esporta APK</string>

--- a/feature/app-detail/impl/src/main/res/values-ja/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values-ja/strings.xml
@@ -34,6 +34,7 @@
     <string name="app_detail_no">いいえ</string>
     <string name="app_detail_unknown">不明</string>
     <string name="app_detail_error">アプリの詳細を読み込めませんでした</string>
+    <string name="app_detail_error_unsupported_apk">このファイルは有効なAPKではないため分析できません</string>
     <string name="app_detail_retry">再試行</string>
     <string name="app_detail_action_manifest">マニフェスト</string>
     <string name="app_detail_action_export_apk">APKをエクスポート</string>

--- a/feature/app-detail/impl/src/main/res/values-ko/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values-ko/strings.xml
@@ -34,6 +34,7 @@
     <string name="app_detail_no">아니오</string>
     <string name="app_detail_unknown">알 수 없음</string>
     <string name="app_detail_error">앱 세부정보를 로드하지 못했습니다</string>
+    <string name="app_detail_error_unsupported_apk">이 파일은 유효한 APK가 아니어서 분석할 수 없습니다</string>
     <string name="app_detail_retry">다시 시도</string>
     <string name="app_detail_action_manifest">매니페스트</string>
     <string name="app_detail_action_export_apk">APK 내보내기</string>

--- a/feature/app-detail/impl/src/main/res/values-pl/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values-pl/strings.xml
@@ -49,6 +49,7 @@
     <string name="app_detail_no">Nie</string>
     <string name="app_detail_unknown">Nieznany</string>
     <string name="app_detail_error">Nie udało się załadować szczegółów aplikacji</string>
+    <string name="app_detail_error_unsupported_apk">Ten plik nie jest prawidłowym plikiem APK i nie można go przeanalizować</string>
     <string name="app_detail_retry">Spróbuj ponownie</string>
     <string name="app_detail_action_manifest">Manifest</string>
     <string name="app_detail_action_export_apk">Eksportuj APK</string>

--- a/feature/app-detail/impl/src/main/res/values-pt-rBR/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values-pt-rBR/strings.xml
@@ -44,6 +44,7 @@
     <string name="app_detail_no">Não</string>
     <string name="app_detail_unknown">Desconhecido</string>
     <string name="app_detail_error">Falha ao carregar os detalhes do aplicativo</string>
+    <string name="app_detail_error_unsupported_apk">Este arquivo não é um APK válido e não pode ser analisado</string>
     <string name="app_detail_retry">Tente novamente</string>
     <string name="app_detail_action_manifest">Manifesto</string>
     <string name="app_detail_action_export_apk">Exportar APK</string>

--- a/feature/app-detail/impl/src/main/res/values-ru/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values-ru/strings.xml
@@ -49,6 +49,7 @@
     <string name="app_detail_no">Нет</string>
     <string name="app_detail_unknown">Неизвестно</string>
     <string name="app_detail_error">Не удалось загрузить данные приложения</string>
+    <string name="app_detail_error_unsupported_apk">Этот файл не является допустимым APK и не может быть проанализирован</string>
     <string name="app_detail_retry">Попробуйте снова</string>
     <string name="app_detail_action_manifest">Манифест</string>
     <string name="app_detail_action_export_apk">Экспорт APK</string>

--- a/feature/app-detail/impl/src/main/res/values-sk/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values-sk/strings.xml
@@ -49,6 +49,7 @@
     <string name="app_detail_no">Nie</string>
     <string name="app_detail_unknown">Neznáme</string>
     <string name="app_detail_error">Nepodarilo sa načítať podrobnosti aplikácie</string>
+    <string name="app_detail_error_unsupported_apk">Tento súbor nie je platný súbor APK a nedá sa analyzovať</string>
     <string name="app_detail_retry">Skúste znova</string>
     <string name="app_detail_action_manifest">Manifest</string>
     <string name="app_detail_action_export_apk">Exportovať APK</string>

--- a/feature/app-detail/impl/src/main/res/values-tr/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values-tr/strings.xml
@@ -39,6 +39,7 @@
     <string name="app_detail_no">Hayır</string>
     <string name="app_detail_unknown">Bilinmiyor</string>
     <string name="app_detail_error">Uygulama detayları yüklenemedi</string>
+    <string name="app_detail_error_unsupported_apk">Bu dosya geçerli bir APK değil ve analiz edilemiyor</string>
     <string name="app_detail_retry">Tekrar dene</string>
     <string name="app_detail_action_manifest">Manifest</string>
     <string name="app_detail_action_export_apk">APK\'yı Dışa Aktar</string>

--- a/feature/app-detail/impl/src/main/res/values-uk/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values-uk/strings.xml
@@ -49,6 +49,7 @@
     <string name="app_detail_no">Ні</string>
     <string name="app_detail_unknown">Невідомо</string>
     <string name="app_detail_error">Не вдалося завантажити деталі програми</string>
+    <string name="app_detail_error_unsupported_apk">Цей файл не є дійсним файлом APK і його не можна проаналізувати</string>
     <string name="app_detail_retry">Спробуйте ще раз</string>
     <string name="app_detail_action_manifest">Manifest</string>
     <string name="app_detail_action_export_apk">Експортувати APK</string>

--- a/feature/app-detail/impl/src/main/res/values-vi/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values-vi/strings.xml
@@ -34,6 +34,7 @@
     <string name="app_detail_no">Không</string>
     <string name="app_detail_unknown">Không xác định</string>
     <string name="app_detail_error">Không thể tải thông tin ứng dụng</string>
+    <string name="app_detail_error_unsupported_apk">Tệp này không phải là APK hợp lệ nên không thể phân tích</string>
     <string name="app_detail_retry">Thử lại</string>
     <string name="app_detail_action_manifest">Manifest</string>
     <string name="app_detail_action_export_apk">Xuất APK</string>

--- a/feature/app-detail/impl/src/main/res/values-zh-rCN/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values-zh-rCN/strings.xml
@@ -34,6 +34,7 @@
     <string name="app_detail_no">否</string>
     <string name="app_detail_unknown">未知</string>
     <string name="app_detail_error">加载应用详情失败</string>
+    <string name="app_detail_error_unsupported_apk">此文件不是有效的 APK，无法进行分析</string>
     <string name="app_detail_retry">再试一次</string>
     <string name="app_detail_action_manifest">清单</string>
     <string name="app_detail_action_export_apk">导出 APK</string>

--- a/feature/app-detail/impl/src/main/res/values/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
     <string name="app_detail_no">No</string>
     <string name="app_detail_unknown">Unknown</string>
     <string name="app_detail_error">Failed to load app details</string>
+    <string name="app_detail_error_unsupported_apk">This file isn\'t a valid APK and can\'t be analyzed</string>
     <string name="app_detail_retry">Try again</string>
     <string name="app_detail_action_manifest">Manifest</string>
     <string name="app_detail_action_export_apk">Export APK</string>


### PR DESCRIPTION
## Summary
- `apkFilePackageDetails` parses a fixed, already-copied local APK file, so when `getPackageArchiveInfo` returns null the failure is deterministic — retrying re-runs the identical parse against the identical bytes and fails again every time.
- The app-detail error screen still offered a generic "Try again" button for this case, which is why the linked Crashlytics issue shows one session logging 12 duplicate non-fatals from a user mashing Retry against the same file.
- `apkFilePackageDetails` now throws a dedicated `UnparsableApkFileException` (mirrors the `ApkTooLargeException` pattern already used in `TemporaryApkManager`) instead of a generic `IllegalStateException`. `AppDetailViewModel` uses it to mark that failure as non-retryable; the error screen hides the Retry button for it and explains the file isn't a valid APK instead.
- Confirmed this isn't a copy race: `TemporaryApkManagerImpl.copy()` fully streams and closes the file before the result is returned, so the parse always sees a complete, finalized file.

Fixes #203

## Test plan
- [x] `:core:apps:compileDebugKotlin` and `:feature:app-detail:impl:compileDebugKotlin`
- [x] `spotlessApply`
- [x] Added `AppDetailErrorUnsupportedApkPreview` alongside the existing error preview
- [x] Added the new string to all 18 locales, verified key parity and XML well-formedness
- [ ] Manual on-device verification (no device/emulator available in this environment) — please confirm the error screen renders as expected for an unparseable picked file

🤖 Generated with [Claude Code](https://claude.com/claude-code)