### PR TITLE
Add app history capture pipeline (core:app-history)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(projects.core.appPermissions)
     implementation(projects.core.appIndex)
     implementation(projects.core.appFunctions)
+    implementation(projects.core.appHistory)
     implementation(projects.core.common)
     implementation(projects.core.userPreferences)
     implementation(projects.core.navigation)

--- a/core/app-history/AGENTS.md
+++ b/core/app-history/AGENTS.md
@@ -1,0 +1,215 @@
+# core:app-history Module
+
+## Purpose and Boundary
+
+Room-backed storage for full-state app history snapshots — one row per captured install instance,
+enough to reconstruct the existing app-detail screens against a past point in time. The package is
+`sk.styk.martin.apkanalyzer.core.apphistory`.
+
+**Status:** capture is implemented and running (schema, pipeline, both triggers). Not yet built: the
+diff engine (`HI-03`), any UI (`HI-06`/`HI-08`/`HI-14`), retention/pruning (`HI-04`), Drive backup
+(`HI-16`/`HI-17`), the `HI-10` runtime-state (enabled/install-source) tier, and periodic `WorkManager`
+reconciliation (today's reconciliation runs once per app process start only). See
+[`docs/app/technical/app-history-capture-schema.md`](../../docs/app/technical/app-history-capture-schema.md)
+for the full design — read it before touching this module; it is the source of truth for schema and
+capture semantics, not this file.
+
+## Package Map
+
+Two domain families, each in its own subpackage — schema/persistence versus the capture pipeline
+that populates it:
+
+* `storage/` — three `@Dao` interfaces, one per concern, each with its own query-result types and its
+  own file: `AppHistoryGateDao` (gate-check reads, used only by the capture pipeline),
+  `AppHistoryWriteDao` (the insert path), `AppHistoryReadDao` (snapshot content reads — see
+  [Reading a Snapshot](#reading-a-snapshot); not consumed by anything yet). Plus `AppHistoryDatabase`
+  (`apkanalyzer.room` convention plugin, exposing all three DAOs) and `storage/di/AppHistoryStorageModule`.
+  A single combined `AppHistoryDao` used to hold all three — split apart because gate-checking,
+  writing, and reading are genuinely different callers with different needs (today's only real
+  consumer, the capture repository, injects the gate and write DAOs but never the read one), not
+  because Room requires it — Room happily supports one `@Dao` per database too.
+  `storage/entity/` holds the two `@Entity` classes, `AppHistorySnapshotEntity` and
+  `AppHistoryBlobEntity` (+ its `SectionType` column enum).
+* `capture/` — the pipeline and its two triggers:
+  * `AppHistoryCaptureRepository` (+ `Impl`) — *how* to capture: `reconcile(packageName)` and
+    `reconcileAll()`.
+  * `AppHistoryCaptureScheduler` (+ `AppHistoryCaptureSchedulerImpl`) — *when* to capture. The `Impl`
+    also implements `DefaultLifecycleObserver`; its `onCreate(owner)` calls `start()`, which launches
+    the reconciliation sweep and starts collecting the fast-path broadcast flow. See
+    [Triggers](#triggers) for why `onCreate` and not `onStart`.
+  * `capture/snapshot/` — the wire DTOs and mappers. See [DTO Boundary](#dto-boundary-not-a-detail).
+  * `capture/di/AppHistoryCaptureModule` — binds `AppHistoryCaptureRepository`, binds
+    `AppHistoryCaptureScheduler`, and separately binds the same `AppHistoryCaptureSchedulerImpl`
+    `@IntoSet` as `DefaultLifecycleObserver` to force its construction at app launch (three `@Binds`
+    methods over two interfaces, one underlying singleton).
+
+Every type in both subpackages stays `internal` — nothing outside this module reads Room or
+wire-format types, or calls the scheduler/repository, directly today.
+
+## Schema
+
+* `AppHistorySnapshotEntity` (`app_history_snapshot`) — one append-only row per captured install
+  instance. Identity is `packageName` + `firstInstallTime` + `lastUpdateTime`, not version code, and
+  that identity is enforced as a `unique` index, not just implied by the capture gate — the
+  surrogate `id` stays the `@PrimaryKey` (a single-column handle `AppHistoryReadDao` and future
+  history-list UI can address a snapshot by, instead of a three-column composite), but the unique
+  index means a bug that ever bypassed `AppHistoryCaptureRepositoryImpl`'s per-package `Mutex` +
+  gate check surfaces as a loud `insertSnapshot` `ABORT` failure rather than a silent duplicate row.
+  Component/permission/signing/etc. sections are not inlined here; each is a hash column pointing
+  into `app_history_blob`. A hash column is `null` if and only if that section's extraction failed.
+* `AppHistoryBlobEntity` (`app_history_blob`) — content-addressed JSON, keyed by
+  `(packageName, hash)`. Scoped per package, not globally shared, so deleting one app's history is
+  two direct deletes with no reference-counting or GC sweep needed.
+* `AppHistoryGateDao` — the two gate-check queries (single package, and all packages in one round
+  trip). `AppHistoryWriteDao` — `insertSnapshotWithBlobs` (bulk `insertBlobs` with
+  `OnConflictStrategy.IGNORE` — a blob's key is content-derived and legitimately repeats — then
+  `insertSnapshot` with `OnConflictStrategy.ABORT`, both in one `@Transaction`). No mutate-in-place
+  query exists; every write is an insert.
+  `insertSnapshot`'s `ABORT` is deliberately explicit, not just Room's default left implicit: unlike
+  the blob table, neither a surrogate-`id` collision nor a natural-key collision can legitimately
+  happen. `AppHistorySnapshotEntity.id` is `@PrimaryKey(autoGenerate = true) = 0`, and every
+  construction site leaves it at that default, which Room translates to `NULL` (SQLite assigns a
+  fresh rowid); the natural key's uniqueness is what the capture gate exists to guarantee. Either
+  kind of collision would mean a stale entity got reused or the gate got bypassed, and that should
+  crash loudly, not silently corrupt append-only history the way `IGNORE` would.
+
+`AppHistoryDatabase`/`AppHistoryStorageModule` follow the same shape as `core:user-preferences`'s
+`UserPreferencesDatabase` (`exportSchema = false`, no destructive-migration fallback — a schema
+change needs a real `Migration`; this hasn't shipped yet, so schema iteration during development
+just means wiping local app data, not writing one).
+
+## Reading a Snapshot
+
+`AppHistoryReadDao.snapshotWithSections(id)` resolves one snapshot's full content — the scalar row plus
+all eleven sections' JSON — as a single flat `@Query`, no `@Relation` and no `@Transaction` needed:
+a single `SELECT` is already atomic, so there's nothing to wrap.
+
+The read shape deliberately mirrors the write shape: `AppHistorySnapshot` has one
+nullable `String` content property per section (`activitiesContent`, `signingContent`, ...),
+matching `AppHistorySnapshotEntity`'s own `activitiesHash`/`signingHash`/... hash columns one for
+one. The query gets there with eleven `LEFT JOIN`s against `app_history_blob` — the same table
+aliased once per section, each joined on `(packageName, <that section's hash column>)` — plus one
+`s.*` to pull in every scalar column via `@Embedded`. `LEFT JOIN` (not `INNER`) is what makes a
+`NULL` hash column resolve to a `NULL` content column rather than dropping the row: `pb.hash = NULL`
+is never true in SQL, so that join side simply finds no match. An earlier version of this read used
+a `@DatabaseView` with an eleven-branch `UNION ALL` collapsed through `@Relation` into a
+`List<AppHistoryResolvedSectionView>` — normalized and reusable, but it made every caller search the
+list by `sectionType` to get one section, out of step with how the entity itself is shaped. Named
+columns read better for the shape this data actually has: fetch one snapshot, look at its named
+fields. Verified on-device against 111 real captured snapshots with zero partial-capture failures —
+every named column resolved to the correct package's real content.
+
+Content stays JSON `String` here too — decoding into `capture/snapshot/` DTOs is a future reader's
+job (there is none yet); this module's contract ends at handing back the stored bytes correctly.
+
+## DTO Boundary — Not a Detail
+
+`core:apps` domain types (`Activity`, `Certificate`, `Permissions`, ...) are **never** `@Serializable`
+and never serialized directly into a blob. `core:app-history` defines its own mirror types in
+`capture/snapshot/` (one `@Serializable internal` DTO + a `toSnapshot()` mapper per captured section)
+and maps to them at capture time.
+
+This was a deliberate correction mid-implementation, not the original design. Serializing the live
+domain model straight into permanent storage means an ordinary `core:apps` change unrelated to
+history — renaming or retyping a captured field — silently breaks deserialization of every historical
+blob written before the change. For a security-positioned app, corrupting old data silently is worse
+than the alternative's real cost: a field added to a domain type isn't captured until someone updates
+the matching DTO + mapper, which is a visible compile-time/code-review gap, not silent drift. Nested
+enums in the DTOs are stored as their `.name` string rather than mirrored as DTO enums, to keep file
+count down — lossless either way since nothing decodes this data yet (no diff engine).
+
+The `kotlin-serialization` plugin and every `@Serializable` annotation are scoped to this module
+alone — `core:apps`/`core:common` carry no serialization dependency or annotations because of this
+module's needs.
+
+## Capture Pipeline
+
+`AppHistoryCaptureRepositoryImpl` implements the schema doc's Capture Gate and Capture Pipeline
+sections exactly:
+
+1. Resolve the package's current identity — `InstalledApp` from `InstalledAppsRepository` (already
+   cached, so this is cheap even on the fast path), never a fresh device-wide `PackageManager` scan
+   from this module.
+2. Compare `lastUpdateTime`/`firstInstallTime` against the latest stored row (`AppHistoryGateDao`'s
+   gate queries). Unchanged → return, no further work.
+3. Gate open → concurrently call `AppDetailRepository.details()`, `IntentFiltersRepository`,
+   `NativeLibrariesRepository`, `SigningSchemeRepository` on `DispatcherProvider.io()`.
+   `AppDetailRepository` failure aborts the whole capture. Any of the other three failing
+   (`Result.isFailure`) records that section's hash as `null` and keeps the rest — including hashing
+   the legitimate `signingSchemeVersions` inner-`null` "structurally ambiguous" result, so a `null`
+   hash column only ever means a genuine extraction failure, never a real answer.
+4. Map each section to its `capture/snapshot/` DTO, encode with one shared `Json` instance, hash with
+   `DigestManager.sha256Digest` (`core:common/digest`).
+5. `INSERT OR IGNORE` each blob, then insert one new snapshot row. Always a new row, never an update.
+
+**Observability.** `reconcileAll()` runs inside a `PerformanceTracker` trace (`app_history_reconcile`:
+`appCount`, `captured_count`, `failed_count` attributes, outcome `Degraded` if any per-package
+capture failed) and each `capture()` call inside its own (`app_history_capture`: `degraded_sections`
+count, outcome `Error`/`Degraded`/`Success`) — matching the `<operation>_load` trace convention
+`core:apps` already uses everywhere else. `capture()` itself returns a private `CaptureOutcome`
+(`Aborted` / `Completed(degradedSectionCount)`) rather than owning its own trace, since it needs
+`coroutineScope` for its `async`/`await` fan-out — making it a `PerformanceTrace` extension function
+would shadow that receiver with `CoroutineScope` and force `this@capture` disambiguation everywhere;
+the caller (`captureIfGateOpen`) owns the trace instead. `reconcileAll()`'s own started/finished
+`Logger.i` pair (`InstalledAppsRepositoryImpl.loadAllApps()`'s same convention) only logs "finished"
+on genuine completion — a thrown exception skips it, and the scheduler's existing `onFailure` warning
+covers that case instead.
+
+**Concurrent-capture race.** Reconciliation and the fast path run as two independent coroutines (see
+[Triggers](#triggers)) and can both target the same package — e.g. a change broadcast for a package
+arrives while reconciliation's sequential sweep hasn't reached it yet. Both would read the gate
+before either writes, both see "changed," and both would insert a snapshot row with identical
+`packageName`/`firstInstallTime`/`lastUpdateTime` were the gate-check-then-write not serialized.
+`AppHistoryCaptureRepositoryImpl` guards this with a per-package `Mutex`
+(`ConcurrentHashMap<PackageName, Mutex>`, `computeIfAbsent`), matching
+`AppAiDescriptionRepositoryImpl`'s (`core:ai-insights`) per-key coalescing for the same class of
+problem — one `Mutex` per package rather than one global lock, so a slow reconciliation sweep never
+blocks the fast path from handling an unrelated package. `captureIfGateOpen` (the single place that
+both `reconcile` and `reconcileAll` route through) does the gate re-check *inside* the lock:
+the loser of the race re-checks after acquiring it, sees the winner's just-written row, and returns
+without capturing — no wasted work beyond the lock wait, no duplicate row.
+`reconcileAll`'s own batched gate comparison (`latestGateTimestampsForAllPackages`, one round trip)
+is unaffected and stays the cheap first-pass filter it was designed to be — `captureIfGateOpen`'s
+authoritative single-package re-check only runs for packages that pass it, not the full sweep.
+
+## Triggers
+
+Both triggers live in `AppHistoryCaptureSchedulerImpl.start()`, called once from its
+`onCreate(owner)` override:
+
+* **Reconciliation** — `reconcileAll()` sweeps every installed app
+  (`InstalledAppsRepository.awaitFullyEnrichedApps()`) through the batched gate query. This is what
+  guarantees completeness; broadcasts missed while the process was dead are otherwise lost.
+* **Fast path** — collects `PackageChangesObserver.observe()` and calls `reconcile` on
+  `Added`/`Replaced`, skipping `Removed` (reconciliation only ever visits currently-installed
+  packages, so a removal needs no capture-side handling at all).
+
+`start()` runs from `onCreate`, not `onStart` — `onStart` fires on every foreground return, which is
+correct for `UsageStatsRepositoryImpl`'s genuinely volatile data but wrong here: reconciliation must
+run once per process, and the fast-path collector must subscribe exactly once, not resubscribe (and
+duplicate) on every resume. `onCreate` fires once, when `ProcessLifecycleOwner` reaches `CREATED` —
+Lifecycle dispatches the backlog of already-passed states to an observer added slightly late, so this
+fires reliably even though `ApkAnalyzer.onCreate()` registers the observer set itself. The
+`@IntoSet DefaultLifecycleObserver` binding exists solely so that registration forces Hilt to
+construct this singleton at app launch in the first place — nothing else in the app injects
+`AppHistoryCaptureScheduler`/`AppHistoryCaptureRepository` directly, so without that forced
+construction capture would never run. Periodic `WorkManager` reconciliation (covering long stretches
+where the app is never opened) is a deferred follow-up — `androidx.work` is not yet a dependency.
+
+`start()` guards itself with an `AtomicBoolean` so a second call is a no-op: `onCreate` is the only
+caller today, but `start()` is also reachable through the separately bound `AppHistoryCaptureScheduler`
+interface, and the delayed reconciliation launch plus the flow subscription are not otherwise
+idempotent — a second call would launch a second reconciliation sweep and double-subscribe to the
+fast path.
+
+`PackageChangesObserver` (`core:apps`) surfaces the changed package name and
+`PackageChangeAction` (`Added`/`Removed`/`Replaced`) parsed from the broadcast `Intent`; this module
+was the reason that observer was extended off a bare `Flow<Unit>`.
+
+## Module Wiring
+
+`app/build.gradle.kts` depends on this module directly (`implementation(projects.core.appHistory)`)
+purely to pull its Hilt bindings into the graph — no other module (feature or core) depends on
+`core:app-history` today, so without that direct dependency Hilt would never see this module's
+`@InstallIn(SingletonComponent::class)` modules and capture would silently never run. Keep that
+dependency even if it looks unused from `app`'s own Kotlin code.

--- a/core/app-history/AGENTS.md
+++ b/core/app-history/AGENTS.md
@@ -29,7 +29,7 @@ that populates it:
   consumer, the capture repository, injects the gate and write DAOs but never the read one), not
   because Room requires it — Room happily supports one `@Dao` per database too.
   `storage/entity/` holds the two `@Entity` classes, `AppHistorySnapshotEntity` and
-  `AppHistoryBlobEntity` (+ its `SectionType` column enum).
+  `AppHistoryBlobEntity`.
 * `capture/` — the pipeline and its two triggers:
   * `AppHistoryCaptureRepository` (+ `Impl`) — *how* to capture: `reconcile(packageName)` and
     `reconcileAll()`.
@@ -127,8 +127,10 @@ module's needs.
 `AppHistoryCaptureRepositoryImpl` implements the schema doc's Capture Gate and Capture Pipeline
 sections exactly:
 
-1. Resolve the package's current identity — `InstalledApp` from `InstalledAppsRepository` (already
-   cached, so this is cheap even on the fast path), never a fresh device-wide `PackageManager` scan
+1. Resolve the package's current identity — `InstalledApp` from `InstalledAppsRepository`.
+   `reconcileAll()` uses the already-cached `apps()` flow (loaded once for the whole sweep); the
+   fast path uses `app(packageName)`, an uncached single-package `PackageManager.getPackageInfo()`
+   call — not free, but still cheap, since it's scoped to one package and never a device-wide scan
    from this module.
 2. Compare `lastUpdateTime`/`firstInstallTime` against the latest stored row (`AppHistoryGateDao`'s
    gate queries). Unchanged → return, no further work.
@@ -139,7 +141,19 @@ sections exactly:
    the legitimate `signingSchemeVersions` inner-`null` "structurally ambiguous" result, so a `null`
    hash column only ever means a genuine extraction failure, never a real answer.
 4. Map each section to its `capture/snapshot/` DTO, encode with one shared `Json` instance, hash with
-   `DigestManager.sha256Digest` (`core:common/digest`).
+   `DigestManager.sha256Digest` (`core:common/digest`) — content only, nothing else mixed into the
+   hash input. `AppHistoryBlobEntity` deliberately has no `sectionType` column: an earlier version
+   added one (and folded the section type into the hash to keep it truthful, since most apps have
+   several genuinely empty sections — `"[]"` for `Receivers`, `Providers`, `Features`, ... all
+   identical bytes — which would otherwise collide onto one blob row and leave that row's own
+   `sectionType` correct for only one of them). That traded away the actual point of content
+   addressing: on real captured data, 68% of snapshot rows had two or more section-hash columns
+   already pointing at the same shared blob, and forcing the section type into the hash would have
+   turned every one of those genuine, harmless duplicates into a separate stored copy. A blob is
+   just bytes; which section(s) it represents is already fully answered by whichever snapshot column
+   points at it — `permissionsHash`, `activitiesHash`, ... — so a blob's own opinion about its
+   section type was redundant at best and wrong (post-collision) at worst. Removing the column
+   restores real cross-section dedup with no loss: nothing ever read `sectionType`.
 5. `INSERT OR IGNORE` each blob, then insert one new snapshot row. Always a new row, never an update.
 
 **Observability.** `reconcileAll()` runs inside a `PerformanceTracker` trace (`app_history_reconcile`:
@@ -147,10 +161,14 @@ sections exactly:
 capture failed) and each `capture()` call inside its own (`app_history_capture`: `degraded_sections`
 count, outcome `Error`/`Degraded`/`Success`) — matching the `<operation>_load` trace convention
 `core:apps` already uses everywhere else. `capture()` itself returns a private `CaptureOutcome`
-(`Aborted` / `Completed(degradedSectionCount)`) rather than owning its own trace, since it needs
-`coroutineScope` for its `async`/`await` fan-out — making it a `PerformanceTrace` extension function
-would shadow that receiver with `CoroutineScope` and force `this@capture` disambiguation everywhere;
-the caller (`captureIfGateOpen`) owns the trace instead. `reconcileAll()`'s own started/finished
+(`Aborted(cause)` / `Completed(degradedSectionCount)`) rather than owning its own trace, since it
+needs `coroutineScope` for its `async`/`await` fan-out — making it a `PerformanceTrace` extension
+function would shadow that receiver with `CoroutineScope` and force `this@capture` disambiguation
+everywhere; the caller (`captureIfGateOpen`) owns the trace instead. `captureIfGateOpen` records the
+trace outcome for `Aborted` the same as any other capture, then rethrows `cause` after the trace
+closes — an aborted capture is a real failure, not a captured-but-empty result, so both `reconcile`
+and `reconcileAll` must see it as one (`reconcileAll`'s `failed_count`/scheduler `onFailure` handling
+and `reconcile`'s own `Result.failure` both depend on this). `reconcileAll()`'s own started/finished
 `Logger.i` pair (`InstalledAppsRepositoryImpl.loadAllApps()`'s same convention) only logs "finished"
 on genuine completion — a thrown exception skips it, and the scheduler's existing `onFailure` warning
 covers that case instead.
@@ -177,9 +195,12 @@ authoritative single-package re-check only runs for packages that pass it, not t
 Both triggers live in `AppHistoryCaptureSchedulerImpl.start()`, called once from its
 `onCreate(owner)` override:
 
-* **Reconciliation** — `reconcileAll()` sweeps every installed app
-  (`InstalledAppsRepository.awaitFullyEnrichedApps()`) through the batched gate query. This is what
-  guarantees completeness; broadcasts missed while the process was dead are otherwise lost.
+* **Reconciliation** — `reconcileAll()` sweeps every installed app (`InstalledAppsRepository.apps()
+  .first()`) through the batched gate query. Deliberately not `awaitFullyEnrichedApps()`: the gate
+  only ever compares `lastUpdateTime`/`firstInstallTime`, so waiting for usage-stats/storage-stats
+  enrichment before the sweep can even start would be pure latency with no correctness benefit. This
+  sweep is what guarantees completeness; broadcasts missed while the process was dead are otherwise
+  lost.
 * **Fast path** — collects `PackageChangesObserver.observe()` and calls `reconcile` on
   `Added`/`Replaced`, skipping `Removed` (reconciliation only ever visits currently-installed
   packages, so a removal needs no capture-side handling at all).

--- a/core/app-history/AGENTS.md
+++ b/core/app-history/AGENTS.md
@@ -11,96 +11,22 @@ diff engine (`HI-03`), any UI (`HI-06`/`HI-08`/`HI-14`), retention/pruning (`HI-
 (`HI-16`/`HI-17`), the `HI-10` runtime-state (enabled/install-source) tier, and periodic `WorkManager`
 reconciliation (today's reconciliation runs once per app process start only). See
 [`docs/app/technical/app-history-capture-schema.md`](../../docs/app/technical/app-history-capture-schema.md)
-for the full design — read it before touching this module; it is the source of truth for schema and
-capture semantics, not this file.
+for the full design, including the entity/DAO schema — read it before touching this module; it is the
+source of truth for schema and capture semantics, not this file.
 
 ## Package Map
 
-Two domain families, each in its own subpackage — schema/persistence versus the capture pipeline
-that populates it:
+Two domain subpackages: `storage/` (Room schema and DAOs — persistence only, no capture logic) and
+`capture/` (the pipeline, its two triggers, the wire DTOs in `capture/snapshot/`, and Hilt bindings
+in `capture/di/`). See [Reading a Snapshot](#reading-a-snapshot) for `storage/`'s read path — not
+consumed by anything yet — and [Capture Pipeline](#capture-pipeline) / [Triggers](#triggers) for
+`capture/`'s. Everything in both subpackages stays `internal`; nothing outside this module reads
+Room or wire-format types, or calls the scheduler/repository, directly today.
 
-* `storage/` — three `@Dao` interfaces, one per concern, each with its own query-result types and its
-  own file: `AppHistoryGateDao` (gate-check reads, used only by the capture pipeline),
-  `AppHistoryWriteDao` (the insert path), `AppHistoryReadDao` (snapshot content reads — see
-  [Reading a Snapshot](#reading-a-snapshot); not consumed by anything yet). Plus `AppHistoryDatabase`
-  (`apkanalyzer.room` convention plugin, exposing all three DAOs) and `storage/di/AppHistoryStorageModule`.
-  A single combined `AppHistoryDao` used to hold all three — split apart because gate-checking,
-  writing, and reading are genuinely different callers with different needs (today's only real
-  consumer, the capture repository, injects the gate and write DAOs but never the read one), not
-  because Room requires it — Room happily supports one `@Dao` per database too.
-  `storage/entity/` holds the two `@Entity` classes, `AppHistorySnapshotEntity` and
-  `AppHistoryBlobEntity`.
-* `capture/` — the pipeline and its two triggers:
-  * `AppHistoryCaptureRepository` (+ `Impl`) — *how* to capture: `reconcile(packageName)` and
-    `reconcileAll()`.
-  * `AppHistoryCaptureScheduler` (+ `AppHistoryCaptureSchedulerImpl`) — *when* to capture. The `Impl`
-    also implements `DefaultLifecycleObserver`; its `onCreate(owner)` calls `start()`, which launches
-    the reconciliation sweep and starts collecting the fast-path broadcast flow. See
-    [Triggers](#triggers) for why `onCreate` and not `onStart`.
-  * `capture/snapshot/` — the wire DTOs and mappers. See [DTO Boundary](#dto-boundary-not-a-detail).
-  * `capture/di/AppHistoryCaptureModule` — binds `AppHistoryCaptureRepository`, binds
-    `AppHistoryCaptureScheduler`, and separately binds the same `AppHistoryCaptureSchedulerImpl`
-    `@IntoSet` as `DefaultLifecycleObserver` to force its construction at app launch (three `@Binds`
-    methods over two interfaces, one underlying singleton).
-
-Every type in both subpackages stays `internal` — nothing outside this module reads Room or
-wire-format types, or calls the scheduler/repository, directly today.
-
-## Schema
-
-* `AppHistorySnapshotEntity` (`app_history_snapshot`) — one append-only row per captured install
-  instance. Identity is `packageName` + `firstInstallTime` + `lastUpdateTime`, not version code, and
-  that identity is enforced as a `unique` index, not just implied by the capture gate — the
-  surrogate `id` stays the `@PrimaryKey` (a single-column handle `AppHistoryReadDao` and future
-  history-list UI can address a snapshot by, instead of a three-column composite), but the unique
-  index means a bug that ever bypassed `AppHistoryCaptureRepositoryImpl`'s per-package `Mutex` +
-  gate check surfaces as a loud `insertSnapshot` `ABORT` failure rather than a silent duplicate row.
-  Component/permission/signing/etc. sections are not inlined here; each is a hash column pointing
-  into `app_history_blob`. A hash column is `null` if and only if that section's extraction failed.
-* `AppHistoryBlobEntity` (`app_history_blob`) — content-addressed JSON, keyed by
-  `(packageName, hash)`. Scoped per package, not globally shared, so deleting one app's history is
-  two direct deletes with no reference-counting or GC sweep needed.
-* `AppHistoryGateDao` — the two gate-check queries (single package, and all packages in one round
-  trip). `AppHistoryWriteDao` — `insertSnapshotWithBlobs` (bulk `insertBlobs` with
-  `OnConflictStrategy.IGNORE` — a blob's key is content-derived and legitimately repeats — then
-  `insertSnapshot` with `OnConflictStrategy.ABORT`, both in one `@Transaction`). No mutate-in-place
-  query exists; every write is an insert.
-  `insertSnapshot`'s `ABORT` is deliberately explicit, not just Room's default left implicit: unlike
-  the blob table, neither a surrogate-`id` collision nor a natural-key collision can legitimately
-  happen. `AppHistorySnapshotEntity.id` is `@PrimaryKey(autoGenerate = true) = 0`, and every
-  construction site leaves it at that default, which Room translates to `NULL` (SQLite assigns a
-  fresh rowid); the natural key's uniqueness is what the capture gate exists to guarantee. Either
-  kind of collision would mean a stale entity got reused or the gate got bypassed, and that should
-  crash loudly, not silently corrupt append-only history the way `IGNORE` would.
-
-`AppHistoryDatabase`/`AppHistoryStorageModule` follow the same shape as `core:user-preferences`'s
-`UserPreferencesDatabase` (`exportSchema = false`, no destructive-migration fallback — a schema
-change needs a real `Migration`; this hasn't shipped yet, so schema iteration during development
-just means wiping local app data, not writing one).
-
-## Reading a Snapshot
-
-`AppHistoryReadDao.snapshotWithSections(id)` resolves one snapshot's full content — the scalar row plus
-all eleven sections' JSON — as a single flat `@Query`, no `@Relation` and no `@Transaction` needed:
-a single `SELECT` is already atomic, so there's nothing to wrap.
-
-The read shape deliberately mirrors the write shape: `AppHistorySnapshot` has one
-nullable `String` content property per section (`activitiesContent`, `signingContent`, ...),
-matching `AppHistorySnapshotEntity`'s own `activitiesHash`/`signingHash`/... hash columns one for
-one. The query gets there with eleven `LEFT JOIN`s against `app_history_blob` — the same table
-aliased once per section, each joined on `(packageName, <that section's hash column>)` — plus one
-`s.*` to pull in every scalar column via `@Embedded`. `LEFT JOIN` (not `INNER`) is what makes a
-`NULL` hash column resolve to a `NULL` content column rather than dropping the row: `pb.hash = NULL`
-is never true in SQL, so that join side simply finds no match. An earlier version of this read used
-a `@DatabaseView` with an eleven-branch `UNION ALL` collapsed through `@Relation` into a
-`List<AppHistoryResolvedSectionView>` — normalized and reusable, but it made every caller search the
-list by `sectionType` to get one section, out of step with how the entity itself is shaped. Named
-columns read better for the shape this data actually has: fetch one snapshot, look at its named
-fields. Verified on-device against 111 real captured snapshots with zero partial-capture failures —
-every named column resolved to the correct package's real content.
-
-Content stays JSON `String` here too — decoding into `capture/snapshot/` DTOs is a future reader's
-job (there is none yet); this module's contract ends at handing back the stored bytes correctly.
+`storage/` splits gate-checking, writing, and reading into three separate `@Dao` interfaces rather
+than one combined DAO — not because Room requires it, but because those are genuinely different
+callers with different needs (today's only real consumer, the capture repository, injects the gate
+and write DAOs but never the read one).
 
 ## DTO Boundary — Not a Detail
 
@@ -114,114 +40,78 @@ domain model straight into permanent storage means an ordinary `core:apps` chang
 history — renaming or retyping a captured field — silently breaks deserialization of every historical
 blob written before the change. For a security-positioned app, corrupting old data silently is worse
 than the alternative's real cost: a field added to a domain type isn't captured until someone updates
-the matching DTO + mapper, which is a visible compile-time/code-review gap, not silent drift. Nested
-enums in the DTOs are stored as their `.name` string rather than mirrored as DTO enums, to keep file
-count down — lossless either way since nothing decodes this data yet (no diff engine).
+the matching DTO + mapper, which is a visible compile-time/code-review gap, not silent drift. A
+polymorphic DTO (`FeatureSnapshot`'s `Hardware`/`OpenGlEs` variants) carries an explicit
+`@SerialName` on every variant for the same reason — the default discriminator is the Kotlin class
+name, which would tie the wire format to a name nobody would think twice about renaming. Nested
+enums, by contrast, are stored as their plain `.name` string rather than mirrored as DTO enums, to
+keep file count down — lossless either way since nothing decodes this data yet (no diff engine).
 
 The `kotlin-serialization` plugin and every `@Serializable` annotation are scoped to this module
 alone — `core:apps`/`core:common` carry no serialization dependency or annotations because of this
 module's needs.
 
+## Reading a Snapshot
+
+`AppHistoryReadDao.snapshotWithSections(id)` resolves one snapshot's full content — the scalar row
+plus all eleven sections' JSON — as a single flat `@Query`, no `@Relation` and no `@Transaction`
+needed: a single `SELECT` is already atomic. It joins `app_history_blob` once per section (aliased,
+each on `(packageName, <that section's hash column>)`) with `LEFT JOIN`, not `INNER` — that's what
+makes a `NULL` hash column resolve to a `NULL` content column instead of dropping the row — plus one
+`s.*` to pull in every scalar column via `@Embedded`. An earlier version normalized this through a
+`@DatabaseView`/`@Relation` into a `List<AppHistoryResolvedSectionView>` callers had to search by
+`sectionType`; named columns fit this data's actual shape better — fetch one snapshot, read its
+named fields.
+
+Content stays JSON `String` here too — decoding into `capture/snapshot/` DTOs is a future reader's
+job (there is none yet); this module's contract ends at handing back the stored bytes correctly.
+
 ## Capture Pipeline
 
-`AppHistoryCaptureRepositoryImpl` implements the schema doc's Capture Gate and Capture Pipeline
-sections exactly:
+`AppHistoryCaptureRepositoryImpl` implements the schema doc's
+[Capture Gate](../../docs/app/technical/app-history-capture-schema.md#capture-gate) and
+[Capture Pipeline](../../docs/app/technical/app-history-capture-schema.md#capture-pipeline) sections
+exactly — read there for the gate/write steps. Two invariants live only in this implementation, not
+in the design doc:
 
-1. Resolve the package's current identity — `InstalledApp` from `InstalledAppsRepository`.
-   `reconcileAll()` uses the already-cached `apps()` flow (loaded once for the whole sweep); the
-   fast path uses `app(packageName)`, an uncached single-package `PackageManager.getPackageInfo()`
-   call — not free, but still cheap, since it's scoped to one package and never a device-wide scan
-   from this module.
-2. Compare `lastUpdateTime`/`firstInstallTime` against the latest stored row (`AppHistoryGateDao`'s
-   gate queries). Unchanged → return, no further work.
-3. Gate open → concurrently call `AppDetailRepository.details()`, `IntentFiltersRepository`,
-   `NativeLibrariesRepository`, `SigningSchemeRepository` on `DispatcherProvider.io()`.
-   `AppDetailRepository` failure aborts the whole capture. Any of the other three failing
-   (`Result.isFailure`) records that section's hash as `null` and keeps the rest — including hashing
-   the legitimate `signingSchemeVersions` inner-`null` "structurally ambiguous" result, so a `null`
-   hash column only ever means a genuine extraction failure, never a real answer.
-4. Map each section to its `capture/snapshot/` DTO, encode with one shared `Json` instance, hash with
-   `DigestManager.sha256Digest` (`core:common/digest`) — content only, nothing else mixed into the
-   hash input. `AppHistoryBlobEntity` deliberately has no `sectionType` column: an earlier version
-   added one (and folded the section type into the hash to keep it truthful, since most apps have
-   several genuinely empty sections — `"[]"` for `Receivers`, `Providers`, `Features`, ... all
-   identical bytes — which would otherwise collide onto one blob row and leave that row's own
-   `sectionType` correct for only one of them). That traded away the actual point of content
-   addressing: on real captured data, 68% of snapshot rows had two or more section-hash columns
-   already pointing at the same shared blob, and forcing the section type into the hash would have
-   turned every one of those genuine, harmless duplicates into a separate stored copy. A blob is
-   just bytes; which section(s) it represents is already fully answered by whichever snapshot column
-   points at it — `permissionsHash`, `activitiesHash`, ... — so a blob's own opinion about its
-   section type was redundant at best and wrong (post-collision) at worst. Removing the column
-   restores real cross-section dedup with no loss: nothing ever read `sectionType`.
-5. `INSERT OR IGNORE` each blob, then insert one new snapshot row. Always a new row, never an update.
-
-**Observability.** `reconcileAll()` runs inside a `PerformanceTracker` trace (`app_history_reconcile`:
-`appCount`, `captured_count`, `failed_count` attributes, outcome `Degraded` if any per-package
-capture failed) and each `capture()` call inside its own (`app_history_capture`: `degraded_sections`
-count, outcome `Error`/`Degraded`/`Success`) — matching the `<operation>_load` trace convention
-`core:apps` already uses everywhere else. `capture()` itself returns a private `CaptureOutcome`
-(`Aborted(cause)` / `Completed(degradedSectionCount)`) rather than owning its own trace, since it
-needs `coroutineScope` for its `async`/`await` fan-out — making it a `PerformanceTrace` extension
-function would shadow that receiver with `CoroutineScope` and force `this@capture` disambiguation
-everywhere; the caller (`captureIfGateOpen`) owns the trace instead. `captureIfGateOpen` records the
-trace outcome for `Aborted` the same as any other capture, then rethrows `cause` after the trace
-closes — an aborted capture is a real failure, not a captured-but-empty result, so both `reconcile`
-and `reconcileAll` must see it as one (`reconcileAll`'s `failed_count`/scheduler `onFailure` handling
-and `reconcile`'s own `Result.failure` both depend on this). `reconcileAll()`'s own started/finished
-`Logger.i` pair (`InstalledAppsRepositoryImpl.loadAllApps()`'s same convention) only logs "finished"
-on genuine completion — a thrown exception skips it, and the scheduler's existing `onFailure` warning
-covers that case instead.
+**Observability.** `reconcileAll()` and each `capture()` call each run inside their own
+`PerformanceTracker` trace (`app_history_reconcile`, `app_history_capture`), matching the
+`<operation>_load` convention `core:apps` already uses everywhere. `capture()` itself returns a
+private `CaptureOutcome` (`Aborted(cause)` / `Completed(degradedSectionCount)`) rather than owning
+its own trace, since it needs `coroutineScope` for its `async`/`await` fan-out — making it a
+`PerformanceTrace` extension function would shadow that receiver with `CoroutineScope`; the caller
+(`captureIfGateOpen`) owns the trace instead, records `Aborted` as any other capture failure, then
+rethrows `cause` after the trace closes — an aborted capture must count as a real failure for both
+`reconcile` and `reconcileAll`, not a captured-but-empty result.
 
 **Concurrent-capture race.** Reconciliation and the fast path run as two independent coroutines (see
-[Triggers](#triggers)) and can both target the same package — e.g. a change broadcast for a package
-arrives while reconciliation's sequential sweep hasn't reached it yet. Both would read the gate
-before either writes, both see "changed," and both would insert a snapshot row with identical
-`packageName`/`firstInstallTime`/`lastUpdateTime` were the gate-check-then-write not serialized.
-`AppHistoryCaptureRepositoryImpl` guards this with a per-package `Mutex`
-(`ConcurrentHashMap<PackageName, Mutex>`, `computeIfAbsent`), matching
+[Triggers](#triggers)) and can both target the same package — e.g. a change broadcast arrives while
+reconciliation's sweep hasn't reached that package yet. Without serialization, both would read the
+gate before either writes, both see "changed," and both insert a snapshot row with an identical
+natural key. `AppHistoryCaptureRepositoryImpl` guards this with a per-package `Mutex`
+(`ConcurrentHashMap<PackageName, Mutex>`, `computeIfAbsent`) — matching
 `AppAiDescriptionRepositoryImpl`'s (`core:ai-insights`) per-key coalescing for the same class of
-problem — one `Mutex` per package rather than one global lock, so a slow reconciliation sweep never
-blocks the fast path from handling an unrelated package. `captureIfGateOpen` (the single place that
-both `reconcile` and `reconcileAll` route through) does the gate re-check *inside* the lock:
-the loser of the race re-checks after acquiring it, sees the winner's just-written row, and returns
-without capturing — no wasted work beyond the lock wait, no duplicate row.
-`reconcileAll`'s own batched gate comparison (`latestGateTimestampsForAllPackages`, one round trip)
-is unaffected and stays the cheap first-pass filter it was designed to be — `captureIfGateOpen`'s
-authoritative single-package re-check only runs for packages that pass it, not the full sweep.
+problem — and does the gate re-check *inside* the lock: the loser of the race re-checks after
+acquiring it, sees the winner's just-written row, and returns without capturing. `reconcileAll`'s own
+batched gate comparison stays the cheap first-pass filter it was designed to be; only the
+per-package re-check inside the lock is authoritative.
 
 ## Triggers
 
 Both triggers live in `AppHistoryCaptureSchedulerImpl.start()`, called once from its
-`onCreate(owner)` override:
-
-* **Reconciliation** — `reconcileAll()` sweeps every installed app (`InstalledAppsRepository.apps()
-  .first()`) through the batched gate query. Deliberately not `awaitFullyEnrichedApps()`: the gate
-  only ever compares `lastUpdateTime`/`firstInstallTime`, so waiting for usage-stats/storage-stats
-  enrichment before the sweep can even start would be pure latency with no correctness benefit. This
-  sweep is what guarantees completeness; broadcasts missed while the process was dead are otherwise
-  lost.
-* **Fast path** — collects `PackageChangesObserver.observe()` and calls `reconcile` on
-  `Added`/`Replaced`, skipping `Removed` (reconciliation only ever visits currently-installed
-  packages, so a removal needs no capture-side handling at all).
-
-`start()` runs from `onCreate`, not `onStart` — `onStart` fires on every foreground return, which is
-correct for `UsageStatsRepositoryImpl`'s genuinely volatile data but wrong here: reconciliation must
-run once per process, and the fast-path collector must subscribe exactly once, not resubscribe (and
-duplicate) on every resume. `onCreate` fires once, when `ProcessLifecycleOwner` reaches `CREATED` —
-Lifecycle dispatches the backlog of already-passed states to an observer added slightly late, so this
-fires reliably even though `ApkAnalyzer.onCreate()` registers the observer set itself. The
-`@IntoSet DefaultLifecycleObserver` binding exists solely so that registration forces Hilt to
-construct this singleton at app launch in the first place — nothing else in the app injects
-`AppHistoryCaptureScheduler`/`AppHistoryCaptureRepository` directly, so without that forced
-construction capture would never run. Periodic `WorkManager` reconciliation (covering long stretches
-where the app is never opened) is a deferred follow-up — `androidx.work` is not yet a dependency.
+`onCreate(owner)` override — not `onStart`, which re-fires on every foreground return and would
+double-run reconciliation and double-subscribe the fast-path collector. `onCreate` fires once, when
+`ProcessLifecycleOwner` reaches `CREATED`; Lifecycle dispatches the backlog of already-passed states
+to an observer added slightly late, so this fires reliably even though `ApkAnalyzer.onCreate()`
+registers the observer set itself. The `@IntoSet DefaultLifecycleObserver` binding exists solely so
+that registration forces Hilt to construct this singleton at app launch in the first place — nothing
+else in the app injects `AppHistoryCaptureScheduler`/`AppHistoryCaptureRepository` directly, so
+without that forced construction capture would never run.
 
 `start()` guards itself with an `AtomicBoolean` so a second call is a no-op: `onCreate` is the only
 caller today, but `start()` is also reachable through the separately bound `AppHistoryCaptureScheduler`
-interface, and the delayed reconciliation launch plus the flow subscription are not otherwise
-idempotent — a second call would launch a second reconciliation sweep and double-subscribe to the
-fast path.
+interface, and neither the delayed reconciliation launch nor the flow subscription is otherwise
+idempotent.
 
 `PackageChangesObserver` (`core:apps`) surfaces the changed package name and
 `PackageChangeAction` (`Added`/`Removed`/`Replaced`) parsed from the broadcast `Intent`; this module

--- a/core/app-history/CLAUDE.md
+++ b/core/app-history/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/core/app-history/build.gradle.kts
+++ b/core/app-history/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    alias(libs.plugins.apkanalyzer.library)
+    alias(libs.plugins.apkanalyzer.hilt)
+    alias(libs.plugins.apkanalyzer.room)
+    alias(libs.plugins.kotlin.serialization)
+}
+
+android {
+    namespace = "sk.styk.martin.apkanalyzer.core.apphistory"
+
+    androidResources.enable = false
+}
+
+dependencies {
+    implementation(projects.core.common)
+    implementation(projects.core.apps)
+    implementation(libs.kotlinx.serialization.json)
+}

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/AppHistoryCaptureRepository.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/AppHistoryCaptureRepository.kt
@@ -1,0 +1,8 @@
+package sk.styk.martin.apkanalyzer.core.apphistory.capture
+
+import sk.styk.martin.apkanalyzer.core.common.model.PackageName
+
+internal interface AppHistoryCaptureRepository {
+    suspend fun reconcile(packageName: PackageName): Result<Unit>
+    suspend fun reconcileAll(): Result<Unit>
+}

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/AppHistoryCaptureRepositoryImpl.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/AppHistoryCaptureRepositoryImpl.kt
@@ -1,0 +1,281 @@
+package sk.styk.martin.apkanalyzer.core.apphistory.capture
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import sk.styk.martin.apkanalyzer.core.apphistory.capture.snapshot.ComponentIntentFilterEntrySnapshot
+import sk.styk.martin.apkanalyzer.core.apphistory.capture.snapshot.toSnapshot
+import sk.styk.martin.apkanalyzer.core.apphistory.storage.AppHistoryGateDao
+import sk.styk.martin.apkanalyzer.core.apphistory.storage.AppHistoryWriteDao
+import sk.styk.martin.apkanalyzer.core.apphistory.storage.entity.AppHistoryBlobEntity
+import sk.styk.martin.apkanalyzer.core.apphistory.storage.entity.AppHistorySnapshotEntity
+import sk.styk.martin.apkanalyzer.core.apphistory.storage.entity.SectionType
+import sk.styk.martin.apkanalyzer.core.apps.AppDetailRepository
+import sk.styk.martin.apkanalyzer.core.apps.InstalledAppsRepository
+import sk.styk.martin.apkanalyzer.core.apps.components.ComponentIntentFilter
+import sk.styk.martin.apkanalyzer.core.apps.components.ComponentIntentFilterKey
+import sk.styk.martin.apkanalyzer.core.apps.intentfilters.IntentFiltersRepository
+import sk.styk.martin.apkanalyzer.core.apps.model.AppDetail
+import sk.styk.martin.apkanalyzer.core.apps.model.InstalledApp
+import sk.styk.martin.apkanalyzer.core.apps.packaging.NativeLibraries
+import sk.styk.martin.apkanalyzer.core.apps.packaging.NativeLibrariesRepository
+import sk.styk.martin.apkanalyzer.core.apps.signing.SigningSchemeRepository
+import sk.styk.martin.apkanalyzer.core.apps.signing.SigningSchemeVersion
+import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
+import sk.styk.martin.apkanalyzer.core.common.coroutines.runCatchingCancellable
+import sk.styk.martin.apkanalyzer.core.common.device.DeviceIdProvider
+import sk.styk.martin.apkanalyzer.core.common.digest.DigestManager
+import sk.styk.martin.apkanalyzer.core.common.logger.Logger
+import sk.styk.martin.apkanalyzer.core.common.model.AppReference
+import sk.styk.martin.apkanalyzer.core.common.model.PackageName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
+import sk.styk.martin.apkanalyzer.core.common.performance.TraceOutcome
+import sk.styk.martin.apkanalyzer.core.common.performance.appCount
+import sk.styk.martin.apkanalyzer.core.common.performance.outcome
+import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+internal const val APP_HISTORY = "AppHistory"
+
+@Singleton
+internal class AppHistoryCaptureRepositoryImpl @Inject constructor(
+    private val installedAppsRepository: InstalledAppsRepository,
+    private val appDetailRepository: AppDetailRepository,
+    private val intentFiltersRepository: IntentFiltersRepository,
+    private val nativeLibrariesRepository: NativeLibrariesRepository,
+    private val signingSchemeRepository: SigningSchemeRepository,
+    private val appHistoryGateDao: AppHistoryGateDao,
+    private val appHistoryWriteDao: AppHistoryWriteDao,
+    private val digestManager: DigestManager,
+    private val deviceIdProvider: DeviceIdProvider,
+    private val dispatcherProvider: DispatcherProvider,
+    private val performanceTracker: PerformanceTracker,
+) : AppHistoryCaptureRepository {
+
+    private val perPackageMutexes = ConcurrentHashMap<PackageName, Mutex>()
+
+    override suspend fun reconcile(packageName: PackageName): Result<Unit> = runCatchingCancellable {
+        Logger.i(APP_HISTORY, "Package reconcile loading started for ${packageName.value}")
+        val app = installedAppsRepository.app(packageName)
+        if (app == null) {
+            Logger.i(APP_HISTORY, "Package reconcile loading finished for ${packageName.value}: package not found, skipped")
+            return@runCatchingCancellable
+        }
+        val captured = captureIfGateOpen(app)
+        val status = if (captured) "captured" else "skipped, no change detected"
+        Logger.i(APP_HISTORY, "Package reconcile loading finished for ${packageName.value}: $status")
+    }
+
+    override suspend fun reconcileAll(): Result<Unit> = runCatchingCancellable {
+        performanceTracker.startCancellableTrace("app_history_reconcile") {
+            Logger.i(APP_HISTORY, "Reconciliation sweep loading started")
+            val apps = installedAppsRepository.apps().first()
+            appCount = apps.size
+            val latestByPackage = appHistoryGateDao.latestGateTimestampsForAllPackages().associateBy { it.packageName }
+            var capturedCount = 0
+            var failedCount = 0
+            apps.forEach { app ->
+                val gate = latestByPackage[app.packageName.value]
+                if (app.hasChangedSince(gate?.lastUpdateTime, gate?.firstInstallTime)) {
+                    runCatchingCancellable { captureIfGateOpen(app) }
+                        .onSuccess { captured -> if (captured) capturedCount++ }
+                        .onFailure {
+                            failedCount++
+                            Logger.w(APP_HISTORY, it, "Reconciliation capture failed for ${app.packageName.value}, continuing sweep")
+                        }
+                }
+            }
+            this["captured_count"] = capturedCount
+            this["failed_count"] = failedCount
+            outcome = if (failedCount == 0) TraceOutcome.Success else TraceOutcome.Degraded
+            Logger.i(APP_HISTORY, "Reconciliation sweep loading finished: ${apps.size} apps scanned, $capturedCount captured")
+        }
+    }
+
+    private suspend fun captureIfGateOpen(app: InstalledApp): Boolean = perPackageMutexes.computeIfAbsent(app.packageName) { Mutex() }.withLock {
+        val gate = appHistoryGateDao.latestGateTimestamps(app.packageName.value)
+        if (!app.hasChangedSince(gate?.lastUpdateTime, gate?.firstInstallTime)) {
+            return@withLock false
+        }
+        performanceTracker.startCancellableTrace("app_history_capture") {
+            when (val result = capture(app)) {
+                CaptureOutcome.Aborted -> outcome = TraceOutcome.Error
+
+                is CaptureOutcome.Completed -> {
+                    this["degraded_sections"] = result.degradedSectionCount
+                    outcome = if (result.degradedSectionCount == 0) TraceOutcome.Success else TraceOutcome.Degraded
+                }
+            }
+        }
+        true
+    }
+
+    private suspend fun capture(app: InstalledApp): CaptureOutcome = coroutineScope {
+        val reference = AppReference.InstalledPackage(app.packageName)
+        val detailDeferred = async(dispatcherProvider.io()) { appDetailRepository.details(reference) }
+        val intentFiltersDeferred = async(dispatcherProvider.io()) { intentFiltersRepository.componentIntentFilters(reference) }
+        val nativeLibrariesDeferred = async(dispatcherProvider.io()) { nativeLibrariesRepository.nativeLibraries(reference) }
+        val signingSchemeDeferred = async(dispatcherProvider.io()) { signingSchemeRepository.signingSchemeVersions(reference) }
+
+        val detailResult = detailDeferred.await()
+        val intentFiltersResult = intentFiltersDeferred.await()
+        val nativeLibrariesResult = nativeLibrariesDeferred.await()
+        val signingSchemeResult = signingSchemeDeferred.await()
+
+        val detail = detailResult.getOrElse {
+            Logger.w(APP_HISTORY, it, "App detail load failed for ${app.packageName.value}, skipping capture")
+            return@coroutineScope CaptureOutcome.Aborted
+        }
+
+        val sections = hashSections(app.packageName, detail, intentFiltersResult, nativeLibrariesResult, signingSchemeResult)
+        appHistoryWriteDao.insertSnapshotWithBlobs(sections.toSnapshotEntity(app, detail, deviceIdProvider.deviceId), sections.blobs)
+        CaptureOutcome.Completed(sections.degradedSectionCount)
+    }
+
+    private fun hashSections(
+        packageName: PackageName,
+        detail: AppDetail,
+        intentFiltersResult: Result<Map<ComponentIntentFilterKey, List<ComponentIntentFilter>>>,
+        nativeLibrariesResult: Result<NativeLibraries>,
+        signingSchemeResult: Result<List<SigningSchemeVersion>?>,
+    ): CapturedSections {
+        val packageNameValue = packageName.value
+        return CapturedSections(
+            permissions = hashSection(SectionType.Permissions, packageNameValue, detail.permissions.toSnapshot()),
+            activities = hashSection(SectionType.Activities, packageNameValue, detail.activities.map { it.toSnapshot() }.sortedBy { it.name }),
+            services = hashSection(SectionType.Services, packageNameValue, detail.services.map { it.toSnapshot() }.sortedBy { it.name }),
+            receivers = hashSection(SectionType.Receivers, packageNameValue, detail.receivers.map { it.toSnapshot() }.sortedBy { it.name }),
+            providers = hashSection(SectionType.Providers, packageNameValue, detail.contentProviders.map { it.toSnapshot() }.sortedBy { it.name }),
+            features = hashSection(SectionType.Features, packageNameValue, detail.features.map { it.toSnapshot() }.sortedBy { Json.encodeToString(it) }),
+            signing = hashSection(SectionType.Signing, packageNameValue, detail.signing.toSnapshot()),
+            installedSplits = hashSection(
+                SectionType.InstalledSplits,
+                packageNameValue,
+                detail.info.installedSplits.map { it.toSnapshot() }.sortedBy { it.fileName },
+            ),
+            intentFilters = intentFiltersResult.fold(
+                onSuccess = { filters ->
+                    val entries = filters.map { (key, value) ->
+                        ComponentIntentFilterEntrySnapshot(key.toSnapshot(), value.map { it.toSnapshot() }.sortedBy { Json.encodeToString(it) })
+                    }.sortedWith(compareBy({ it.key.name }, { it.key.kind }))
+                    hashSection(SectionType.IntentFilters, packageNameValue, entries)
+                },
+                onFailure = { logSectionFailure(packageName, "Intent filters", it) },
+            ),
+            nativeLibraries = nativeLibrariesResult.fold(
+                onSuccess = { libraries ->
+                    val sorted = libraries.files.map { it.toSnapshot() }.sortedWith(compareBy({ it.name }, { it.abi }, { it.containingApkFileName }))
+                    hashSection(SectionType.NativeLibraries, packageNameValue, sorted)
+                },
+                onFailure = { logSectionFailure(packageName, "Native libraries", it) },
+            ),
+            signingScheme = signingSchemeResult.fold(
+                onSuccess = { versions -> hashSection(SectionType.SigningScheme, packageNameValue, versions?.map { it.name }?.sorted()) },
+                onFailure = { logSectionFailure(packageName, "Signing scheme", it) },
+            ),
+        )
+    }
+
+    private fun logSectionFailure(
+        packageName: PackageName,
+        sectionName: String,
+        throwable: Throwable,
+    ): SectionHash? {
+        Logger.w(APP_HISTORY, throwable, "$sectionName extraction failed for ${packageName.value}")
+        return null
+    }
+
+    private inline fun <reified T> hashSection(
+        sectionType: SectionType,
+        packageName: String,
+        content: T,
+    ): SectionHash {
+        val serialized = Json.encodeToString(content)
+        val hash = digestManager.sha256Digest(serialized)
+        val blob = AppHistoryBlobEntity(packageName = packageName, hash = hash, sectionType = sectionType, content = serialized)
+        return SectionHash(hash, blob)
+    }
+
+    private data class SectionHash(val hash: String, val blob: AppHistoryBlobEntity)
+
+    private data class CapturedSections(
+        val permissions: SectionHash,
+        val activities: SectionHash,
+        val services: SectionHash,
+        val receivers: SectionHash,
+        val providers: SectionHash,
+        val features: SectionHash,
+        val signing: SectionHash,
+        val installedSplits: SectionHash,
+        val intentFilters: SectionHash?,
+        val nativeLibraries: SectionHash?,
+        val signingScheme: SectionHash?,
+    ) {
+        val degradedSectionCount: Int
+            get() = listOf(intentFilters, nativeLibraries, signingScheme).count { it == null }
+
+        val blobs: List<AppHistoryBlobEntity>
+            get() = listOfNotNull(
+                permissions.blob, activities.blob, services.blob, receivers.blob, providers.blob,
+                features.blob, signing.blob, installedSplits.blob,
+                intentFilters?.blob, nativeLibraries?.blob, signingScheme?.blob,
+            )
+    }
+
+    private fun CapturedSections.toSnapshotEntity(
+        app: InstalledApp,
+        detail: AppDetail,
+        deviceId: String,
+    ): AppHistorySnapshotEntity {
+        val info = detail.info
+        return AppHistorySnapshotEntity(
+            packageName = app.packageName.value,
+            deviceId = deviceId,
+            firstInstallTime = app.installTime.toEpochMilli(),
+            lastUpdateTime = app.lastUpdateTime.toEpochMilli(),
+            applicationName = info.applicationName,
+            processName = info.processName,
+            versionCode = info.versionCode,
+            versionName = info.versionName,
+            isSystemApp = info.isSystemApp,
+            isDebuggable = info.isDebuggable,
+            allowsBackup = info.allowsBackup,
+            usesCleartextTraffic = info.usesCleartextTraffic,
+            uid = info.uid,
+            sharedUserId = info.sharedUserId,
+            description = info.description,
+            installLocation = info.installLocation.name,
+            installingPackage = info.installSourceChain.installingPackage?.value,
+            initiatingPackage = info.installSourceChain.initiatingPackage?.value,
+            originatingPackage = info.installSourceChain.originatingPackage?.value,
+            apkSize = info.apkSize.bytes,
+            targetSdkVersion = info.targetSdkVersion,
+            minSdkVersion = info.minSdkVersion,
+            permissionsHash = permissions.hash,
+            activitiesHash = activities.hash,
+            servicesHash = services.hash,
+            receiversHash = receivers.hash,
+            providersHash = providers.hash,
+            featuresHash = features.hash,
+            signingHash = signing.hash,
+            intentFiltersHash = intentFilters?.hash,
+            nativeLibrariesHash = nativeLibraries?.hash,
+            signingSchemeHash = signingScheme?.hash,
+            installedSplitsHash = installedSplits.hash,
+        )
+    }
+
+    private sealed interface CaptureOutcome {
+        data object Aborted : CaptureOutcome
+        data class Completed(val degradedSectionCount: Int) : CaptureOutcome
+    }
+}
+
+private fun InstalledApp.hasChangedSince(storedLastUpdateTime: Long?, storedFirstInstallTime: Long?): Boolean =
+    storedLastUpdateTime != lastUpdateTime.toEpochMilli() || storedFirstInstallTime != installTime.toEpochMilli()

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/AppHistoryCaptureRepositoryImpl.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/AppHistoryCaptureRepositoryImpl.kt
@@ -13,7 +13,6 @@ import sk.styk.martin.apkanalyzer.core.apphistory.storage.AppHistoryGateDao
 import sk.styk.martin.apkanalyzer.core.apphistory.storage.AppHistoryWriteDao
 import sk.styk.martin.apkanalyzer.core.apphistory.storage.entity.AppHistoryBlobEntity
 import sk.styk.martin.apkanalyzer.core.apphistory.storage.entity.AppHistorySnapshotEntity
-import sk.styk.martin.apkanalyzer.core.apphistory.storage.entity.SectionType
 import sk.styk.martin.apkanalyzer.core.apps.AppDetailRepository
 import sk.styk.martin.apkanalyzer.core.apps.InstalledAppsRepository
 import sk.styk.martin.apkanalyzer.core.apps.components.ComponentIntentFilter
@@ -103,16 +102,19 @@ internal class AppHistoryCaptureRepositoryImpl @Inject constructor(
         if (!app.hasChangedSince(gate?.lastUpdateTime, gate?.firstInstallTime)) {
             return@withLock false
         }
-        performanceTracker.startCancellableTrace("app_history_capture") {
-            when (val result = capture(app)) {
-                CaptureOutcome.Aborted -> outcome = TraceOutcome.Error
+        val result = performanceTracker.startCancellableTrace("app_history_capture") {
+            val captureOutcome = capture(app)
+            when (captureOutcome) {
+                is CaptureOutcome.Aborted -> outcome = TraceOutcome.Error
 
                 is CaptureOutcome.Completed -> {
-                    this["degraded_sections"] = result.degradedSectionCount
-                    outcome = if (result.degradedSectionCount == 0) TraceOutcome.Success else TraceOutcome.Degraded
+                    this["degraded_sections"] = captureOutcome.degradedSectionCount
+                    outcome = if (captureOutcome.degradedSectionCount == 0) TraceOutcome.Success else TraceOutcome.Degraded
                 }
             }
+            captureOutcome
         }
+        if (result is CaptureOutcome.Aborted) throw result.cause
         true
     }
 
@@ -130,7 +132,7 @@ internal class AppHistoryCaptureRepositoryImpl @Inject constructor(
 
         val detail = detailResult.getOrElse {
             Logger.w(APP_HISTORY, it, "App detail load failed for ${app.packageName.value}, skipping capture")
-            return@coroutineScope CaptureOutcome.Aborted
+            return@coroutineScope CaptureOutcome.Aborted(it)
         }
 
         val sections = hashSections(app.packageName, detail, intentFiltersResult, nativeLibrariesResult, signingSchemeResult)
@@ -147,15 +149,14 @@ internal class AppHistoryCaptureRepositoryImpl @Inject constructor(
     ): CapturedSections {
         val packageNameValue = packageName.value
         return CapturedSections(
-            permissions = hashSection(SectionType.Permissions, packageNameValue, detail.permissions.toSnapshot()),
-            activities = hashSection(SectionType.Activities, packageNameValue, detail.activities.map { it.toSnapshot() }.sortedBy { it.name }),
-            services = hashSection(SectionType.Services, packageNameValue, detail.services.map { it.toSnapshot() }.sortedBy { it.name }),
-            receivers = hashSection(SectionType.Receivers, packageNameValue, detail.receivers.map { it.toSnapshot() }.sortedBy { it.name }),
-            providers = hashSection(SectionType.Providers, packageNameValue, detail.contentProviders.map { it.toSnapshot() }.sortedBy { it.name }),
-            features = hashSection(SectionType.Features, packageNameValue, detail.features.map { it.toSnapshot() }.sortedBy { Json.encodeToString(it) }),
-            signing = hashSection(SectionType.Signing, packageNameValue, detail.signing.toSnapshot()),
+            permissions = hashSection(packageNameValue, detail.permissions.toSnapshot()),
+            activities = hashSection(packageNameValue, detail.activities.map { it.toSnapshot() }.sortedBy { it.name }),
+            services = hashSection(packageNameValue, detail.services.map { it.toSnapshot() }.sortedBy { it.name }),
+            receivers = hashSection(packageNameValue, detail.receivers.map { it.toSnapshot() }.sortedBy { it.name }),
+            providers = hashSection(packageNameValue, detail.contentProviders.map { it.toSnapshot() }.sortedBy { it.name }),
+            features = hashSection(packageNameValue, detail.features.map { it.toSnapshot() }.sortedBy { Json.encodeToString(it) }),
+            signing = hashSection(packageNameValue, detail.signing.toSnapshot()),
             installedSplits = hashSection(
-                SectionType.InstalledSplits,
                 packageNameValue,
                 detail.info.installedSplits.map { it.toSnapshot() }.sortedBy { it.fileName },
             ),
@@ -164,19 +165,19 @@ internal class AppHistoryCaptureRepositoryImpl @Inject constructor(
                     val entries = filters.map { (key, value) ->
                         ComponentIntentFilterEntrySnapshot(key.toSnapshot(), value.map { it.toSnapshot() }.sortedBy { Json.encodeToString(it) })
                     }.sortedWith(compareBy({ it.key.name }, { it.key.kind }))
-                    hashSection(SectionType.IntentFilters, packageNameValue, entries)
+                    hashSection(packageNameValue, entries)
                 },
                 onFailure = { logSectionFailure(packageName, "Intent filters", it) },
             ),
             nativeLibraries = nativeLibrariesResult.fold(
                 onSuccess = { libraries ->
                     val sorted = libraries.files.map { it.toSnapshot() }.sortedWith(compareBy({ it.name }, { it.abi }, { it.containingApkFileName }))
-                    hashSection(SectionType.NativeLibraries, packageNameValue, sorted)
+                    hashSection(packageNameValue, sorted)
                 },
                 onFailure = { logSectionFailure(packageName, "Native libraries", it) },
             ),
             signingScheme = signingSchemeResult.fold(
-                onSuccess = { versions -> hashSection(SectionType.SigningScheme, packageNameValue, versions?.map { it.name }?.sorted()) },
+                onSuccess = { versions -> hashSection(packageNameValue, versions?.map { it.name }?.sorted()) },
                 onFailure = { logSectionFailure(packageName, "Signing scheme", it) },
             ),
         )
@@ -191,14 +192,10 @@ internal class AppHistoryCaptureRepositoryImpl @Inject constructor(
         return null
     }
 
-    private inline fun <reified T> hashSection(
-        sectionType: SectionType,
-        packageName: String,
-        content: T,
-    ): SectionHash {
+    private inline fun <reified T> hashSection(packageName: String, content: T): SectionHash {
         val serialized = Json.encodeToString(content)
         val hash = digestManager.sha256Digest(serialized)
-        val blob = AppHistoryBlobEntity(packageName = packageName, hash = hash, sectionType = sectionType, content = serialized)
+        val blob = AppHistoryBlobEntity(packageName = packageName, hash = hash, content = serialized)
         return SectionHash(hash, blob)
     }
 
@@ -272,7 +269,7 @@ internal class AppHistoryCaptureRepositoryImpl @Inject constructor(
     }
 
     private sealed interface CaptureOutcome {
-        data object Aborted : CaptureOutcome
+        data class Aborted(val cause: Throwable) : CaptureOutcome
         data class Completed(val degradedSectionCount: Int) : CaptureOutcome
     }
 }

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/AppHistoryCaptureScheduler.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/AppHistoryCaptureScheduler.kt
@@ -1,0 +1,5 @@
+package sk.styk.martin.apkanalyzer.core.apphistory.capture
+
+internal interface AppHistoryCaptureScheduler {
+    fun start()
+}

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/AppHistoryCaptureSchedulerImpl.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/AppHistoryCaptureSchedulerImpl.kt
@@ -1,0 +1,55 @@
+package sk.styk.martin.apkanalyzer.core.apphistory.capture
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
+import sk.styk.martin.apkanalyzer.core.apps.PackageChangeAction
+import sk.styk.martin.apkanalyzer.core.apps.PackageChangesObserver
+import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
+import sk.styk.martin.apkanalyzer.core.common.logger.Logger
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.time.Duration.Companion.seconds
+
+private val RECONCILIATION_START_DELAY = 30.seconds
+
+@Singleton
+internal class AppHistoryCaptureSchedulerImpl @Inject constructor(
+    private val captureRepository: AppHistoryCaptureRepository,
+    private val packageChangesObserver: PackageChangesObserver,
+    private val appScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
+) : AppHistoryCaptureScheduler,
+    DefaultLifecycleObserver {
+
+    private val started = AtomicBoolean(false)
+
+    override fun onCreate(owner: LifecycleOwner) {
+        start()
+    }
+
+    override fun start() {
+        if (!started.compareAndSet(false, true)) return
+
+        appScope.launch(dispatcherProvider.default()) {
+            delay(RECONCILIATION_START_DELAY)
+            captureRepository.reconcileAll()
+                .onFailure { Logger.w(APP_HISTORY, it, "Reconciliation sweep failed") }
+        }
+
+        packageChangesObserver.observe()
+            .onEach { event ->
+                if (event.action != PackageChangeAction.Removed) {
+                    captureRepository.reconcile(event.packageName)
+                        .onFailure { Logger.w(APP_HISTORY, it, "Fast-path capture failed for ${event.packageName.value}") }
+                }
+            }
+            .launchIn(appScope + dispatcherProvider.default())
+    }
+}

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/di/AppHistoryCaptureModule.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/di/AppHistoryCaptureModule.kt
@@ -1,0 +1,30 @@
+package sk.styk.martin.apkanalyzer.core.apphistory.capture.di
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import sk.styk.martin.apkanalyzer.core.apphistory.capture.AppHistoryCaptureRepository
+import sk.styk.martin.apkanalyzer.core.apphistory.capture.AppHistoryCaptureRepositoryImpl
+import sk.styk.martin.apkanalyzer.core.apphistory.capture.AppHistoryCaptureScheduler
+import sk.styk.martin.apkanalyzer.core.apphistory.capture.AppHistoryCaptureSchedulerImpl
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal interface AppHistoryCaptureModule {
+    @Binds
+    @Singleton
+    fun bindAppHistoryCaptureRepository(impl: AppHistoryCaptureRepositoryImpl): AppHistoryCaptureRepository
+
+    @Binds
+    @Singleton
+    fun bindAppHistoryCaptureScheduler(impl: AppHistoryCaptureSchedulerImpl): AppHistoryCaptureScheduler
+
+    @Binds
+    @Singleton
+    @IntoSet
+    fun bindAppHistoryCaptureSchedulerAsLifecycleObserver(impl: AppHistoryCaptureSchedulerImpl): DefaultLifecycleObserver
+}

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/snapshot/ActivitySnapshot.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/snapshot/ActivitySnapshot.kt
@@ -1,0 +1,27 @@
+package sk.styk.martin.apkanalyzer.core.apphistory.capture.snapshot
+
+import kotlinx.serialization.Serializable
+import sk.styk.martin.apkanalyzer.core.apps.components.Activity
+
+@Serializable
+internal data class ActivitySnapshot(
+    val name: String,
+    val packageName: String,
+    val label: String?,
+    val targetActivity: String?,
+    val permission: String?,
+    val parentName: String?,
+    val isExported: Boolean,
+    val isLauncher: Boolean?,
+)
+
+internal fun Activity.toSnapshot() = ActivitySnapshot(
+    name = name,
+    packageName = packageName.value,
+    label = label,
+    targetActivity = targetActivity,
+    permission = permission,
+    parentName = parentName,
+    isExported = isExported,
+    isLauncher = isLauncher,
+)

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/snapshot/BroadcastReceiverSnapshot.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/snapshot/BroadcastReceiverSnapshot.kt
@@ -1,0 +1,17 @@
+package sk.styk.martin.apkanalyzer.core.apphistory.capture.snapshot
+
+import kotlinx.serialization.Serializable
+import sk.styk.martin.apkanalyzer.core.apps.components.BroadcastReceiver
+
+@Serializable
+internal data class BroadcastReceiverSnapshot(
+    val name: String,
+    val permission: String?,
+    val isExported: Boolean,
+)
+
+internal fun BroadcastReceiver.toSnapshot() = BroadcastReceiverSnapshot(
+    name = name,
+    permission = permission,
+    isExported = isExported,
+)

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/snapshot/ComponentIntentFilterSnapshot.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/snapshot/ComponentIntentFilterSnapshot.kt
@@ -1,0 +1,53 @@
+package sk.styk.martin.apkanalyzer.core.apphistory.capture.snapshot
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import sk.styk.martin.apkanalyzer.core.apps.components.ComponentIntentFilter
+import sk.styk.martin.apkanalyzer.core.apps.components.ComponentIntentFilterKey
+import sk.styk.martin.apkanalyzer.core.apps.components.IntentFilterDataRule
+import sk.styk.martin.apkanalyzer.core.apps.components.IntentFilterUriRelativeGroup
+
+@Serializable
+internal data class ComponentIntentFilterEntrySnapshot(val key: ComponentIntentFilterKeySnapshot, val filters: List<ComponentIntentFilterSnapshot>)
+
+@Serializable
+internal data class ComponentIntentFilterKeySnapshot(val name: String, val kind: String)
+
+@Serializable
+internal data class ComponentIntentFilterSnapshot(
+    val actions: List<String>,
+    val categories: List<String>,
+    val dataRules: List<IntentFilterDataRuleSnapshot>,
+    val uriRelativeGroups: List<IntentFilterUriRelativeGroupSnapshot>,
+    val priority: Int,
+    val order: Int,
+    val isAutoVerify: Boolean,
+)
+
+@Serializable
+internal data class IntentFilterUriRelativeGroupSnapshot(val isAllowed: Boolean, val dataRules: List<IntentFilterDataRuleSnapshot>)
+
+@Serializable
+internal data class IntentFilterDataRuleSnapshot(val type: String, val value: String)
+
+internal fun ComponentIntentFilterKey.toSnapshot() = ComponentIntentFilterKeySnapshot(name = name, kind = kind.name)
+
+internal fun ComponentIntentFilter.toSnapshot() = ComponentIntentFilterSnapshot(
+    actions = actions.sorted(),
+    categories = categories.sorted(),
+    dataRules = dataRules.map { it.toSnapshot() }.sortedDataRules(),
+    uriRelativeGroups = uriRelativeGroups.map { it.toSnapshot() }.sortedBy { Json.encodeToString(it) },
+    priority = priority,
+    order = order,
+    isAutoVerify = isAutoVerify,
+)
+
+internal fun IntentFilterUriRelativeGroup.toSnapshot() = IntentFilterUriRelativeGroupSnapshot(
+    isAllowed = isAllowed,
+    dataRules = dataRules.map { it.toSnapshot() }.sortedDataRules(),
+)
+
+internal fun IntentFilterDataRule.toSnapshot() = IntentFilterDataRuleSnapshot(type = type.name, value = value)
+
+private fun List<IntentFilterDataRuleSnapshot>.sortedDataRules() = sortedWith(compareBy({ it.type }, { it.value }))

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/snapshot/ContentProviderSnapshot.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/snapshot/ContentProviderSnapshot.kt
@@ -1,0 +1,39 @@
+package sk.styk.martin.apkanalyzer.core.apphistory.capture.snapshot
+
+import kotlinx.serialization.Serializable
+import sk.styk.martin.apkanalyzer.core.apps.components.ContentProvider
+import sk.styk.martin.apkanalyzer.core.apps.components.ProviderPathPermission
+
+@Serializable
+internal data class ContentProviderSnapshot(
+    val name: String,
+    val authority: String?,
+    val readPermission: String?,
+    val writePermission: String?,
+    val isExported: Boolean,
+    val pathPermissions: List<ProviderPathPermissionSnapshot>,
+)
+
+@Serializable
+internal data class ProviderPathPermissionSnapshot(
+    val path: String,
+    val matchType: String,
+    val readPermission: String?,
+    val writePermission: String?,
+)
+
+internal fun ContentProvider.toSnapshot() = ContentProviderSnapshot(
+    name = name,
+    authority = authority,
+    readPermission = readPermission,
+    writePermission = writePermission,
+    isExported = isExported,
+    pathPermissions = pathPermissions.map { it.toSnapshot() }.sortedWith(compareBy({ it.path }, { it.matchType })),
+)
+
+internal fun ProviderPathPermission.toSnapshot() = ProviderPathPermissionSnapshot(
+    path = path,
+    matchType = matchType.name,
+    readPermission = readPermission,
+    writePermission = writePermission,
+)

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/snapshot/FeatureSnapshot.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/snapshot/FeatureSnapshot.kt
@@ -1,0 +1,23 @@
+package sk.styk.martin.apkanalyzer.core.apphistory.capture.snapshot
+
+import kotlinx.serialization.Serializable
+import sk.styk.martin.apkanalyzer.core.apps.devicefeatures.Feature
+
+@Serializable
+internal sealed interface FeatureSnapshot {
+
+    @Serializable
+    data class Hardware(
+        val name: String,
+        val version: Int,
+        val isRequired: Boolean,
+    ) : FeatureSnapshot
+
+    @Serializable
+    data class OpenGlEs(val reqGlEsVersion: Int, val isRequired: Boolean) : FeatureSnapshot
+}
+
+internal fun Feature.toSnapshot(): FeatureSnapshot = when (this) {
+    is Feature.Hardware -> FeatureSnapshot.Hardware(name = name, version = version, isRequired = isRequired)
+    is Feature.OpenGlEs -> FeatureSnapshot.OpenGlEs(reqGlEsVersion = reqGlEsVersion, isRequired = isRequired)
+}

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/snapshot/FeatureSnapshot.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/snapshot/FeatureSnapshot.kt
@@ -1,5 +1,6 @@
 package sk.styk.martin.apkanalyzer.core.apphistory.capture.snapshot
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import sk.styk.martin.apkanalyzer.core.apps.devicefeatures.Feature
 
@@ -7,6 +8,7 @@ import sk.styk.martin.apkanalyzer.core.apps.devicefeatures.Feature
 internal sealed interface FeatureSnapshot {
 
     @Serializable
+    @SerialName("hardware")
     data class Hardware(
         val name: String,
         val version: Int,
@@ -14,6 +16,7 @@ internal sealed interface FeatureSnapshot {
     ) : FeatureSnapshot
 
     @Serializable
+    @SerialName("open_gl_es")
     data class OpenGlEs(val reqGlEsVersion: Int, val isRequired: Boolean) : FeatureSnapshot
 }
 

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/snapshot/InstalledSplitApkSnapshot.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/snapshot/InstalledSplitApkSnapshot.kt
@@ -1,0 +1,19 @@
+package sk.styk.martin.apkanalyzer.core.apphistory.capture.snapshot
+
+import kotlinx.serialization.Serializable
+import sk.styk.martin.apkanalyzer.core.apps.packaging.InstalledSplitApk
+
+@Serializable
+internal data class InstalledSplitApkSnapshot(
+    val fileName: String,
+    val size: Long,
+    val kind: String,
+    val qualifier: String,
+)
+
+internal fun InstalledSplitApk.toSnapshot() = InstalledSplitApkSnapshot(
+    fileName = fileName,
+    size = size.bytes,
+    kind = kind.name,
+    qualifier = qualifier,
+)

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/snapshot/NativeLibraryFileSnapshot.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/snapshot/NativeLibraryFileSnapshot.kt
@@ -1,0 +1,19 @@
+package sk.styk.martin.apkanalyzer.core.apphistory.capture.snapshot
+
+import kotlinx.serialization.Serializable
+import sk.styk.martin.apkanalyzer.core.apps.packaging.NativeLibraryFile
+
+@Serializable
+internal data class NativeLibraryFileSnapshot(
+    val name: String,
+    val abi: String,
+    val size: Long,
+    val containingApkFileName: String,
+)
+
+internal fun NativeLibraryFile.toSnapshot() = NativeLibraryFileSnapshot(
+    name = name,
+    abi = abi,
+    size = size.bytes,
+    containingApkFileName = containingApkFileName,
+)

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/snapshot/PermissionsSnapshot.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/snapshot/PermissionsSnapshot.kt
@@ -1,0 +1,39 @@
+package sk.styk.martin.apkanalyzer.core.apphistory.capture.snapshot
+
+import kotlinx.serialization.Serializable
+import sk.styk.martin.apkanalyzer.core.apps.permissions.Permission
+import sk.styk.martin.apkanalyzer.core.apps.permissions.PermissionDetails
+import sk.styk.martin.apkanalyzer.core.apps.permissions.Permissions
+
+@Serializable
+internal data class PermissionsSnapshot(val defined: List<PermissionSnapshot>, val used: List<PermissionSnapshot>)
+
+@Serializable
+internal data class PermissionSnapshot(val name: String, val details: PermissionDetailsSnapshot?)
+
+@Serializable
+internal data class PermissionDetailsSnapshot(
+    val groupName: String?,
+    val protectionLevel: String,
+    val protectionFlags: Set<String>,
+    val description: String?,
+    val declaringPackage: String,
+)
+
+internal fun Permissions.toSnapshot() = PermissionsSnapshot(
+    defined = defined.map { it.toSnapshot() }.sortedBy { it.name },
+    used = used.map { it.permissionData.toSnapshot() }.sortedBy { it.name },
+)
+
+internal fun Permission.toSnapshot() = PermissionSnapshot(
+    name = name,
+    details = details?.toSnapshot(),
+)
+
+internal fun PermissionDetails.toSnapshot() = PermissionDetailsSnapshot(
+    groupName = groupName,
+    protectionLevel = protectionLevel.name,
+    protectionFlags = protectionFlags.map { it.name }.sorted().toSet(),
+    description = description,
+    declaringPackage = declaringPackage.value,
+)

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/snapshot/ServiceSnapshot.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/snapshot/ServiceSnapshot.kt
@@ -1,0 +1,25 @@
+package sk.styk.martin.apkanalyzer.core.apphistory.capture.snapshot
+
+import kotlinx.serialization.Serializable
+import sk.styk.martin.apkanalyzer.core.apps.components.Service
+
+@Serializable
+internal data class ServiceSnapshot(
+    val name: String,
+    val permission: String?,
+    val isExported: Boolean,
+    val isStopWithTask: Boolean,
+    val isSingleUser: Boolean,
+    val isIsolatedProcess: Boolean,
+    val isExternalService: Boolean,
+)
+
+internal fun Service.toSnapshot() = ServiceSnapshot(
+    name = name,
+    permission = permission,
+    isExported = isExported,
+    isStopWithTask = isStopWithTask,
+    isSingleUser = isSingleUser,
+    isIsolatedProcess = isIsolatedProcess,
+    isExternalService = isExternalService,
+)

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/snapshot/SigningSnapshot.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/capture/snapshot/SigningSnapshot.kt
@@ -1,0 +1,60 @@
+package sk.styk.martin.apkanalyzer.core.apphistory.capture.snapshot
+
+import kotlinx.serialization.Serializable
+import sk.styk.martin.apkanalyzer.core.apps.signing.AppSigning
+import sk.styk.martin.apkanalyzer.core.apps.signing.Certificate
+import sk.styk.martin.apkanalyzer.core.apps.signing.CertificatePrincipal
+
+@Serializable
+internal data class SigningSnapshot(val currentCertificates: List<CertificateSnapshot>, val pastCertificates: List<CertificateSnapshot>)
+
+@Serializable
+internal data class CertificateSnapshot(
+    val signAlgorithm: String,
+    val certificateHashMd5: String,
+    val certificateHashSha1: String,
+    val certificateHashSha256: String,
+    val publicKeyMd5: String,
+    val publicKeySha1: String,
+    val publicKeySha256: String,
+    val validFrom: Long,
+    val validUntil: Long,
+    val serialNumber: String,
+    val issuer: CertificatePrincipalSnapshot,
+    val subject: CertificatePrincipalSnapshot,
+    val isSelfSigned: Boolean,
+)
+
+@Serializable
+internal data class CertificatePrincipalSnapshot(
+    val name: String?,
+    val organization: String?,
+    val country: String?,
+)
+
+internal fun AppSigning.toSnapshot() = SigningSnapshot(
+    currentCertificates = currentCertificates.map { it.toSnapshot() }.sortedBy { it.certificateHashSha256 },
+    pastCertificates = pastCertificates.map { it.toSnapshot() }.sortedBy { it.certificateHashSha256 },
+)
+
+internal fun Certificate.toSnapshot() = CertificateSnapshot(
+    signAlgorithm = signAlgorithm,
+    certificateHashMd5 = certificateHashMd5,
+    certificateHashSha1 = certificateHashSha1,
+    certificateHashSha256 = certificateHashSha256,
+    publicKeyMd5 = publicKeyMd5,
+    publicKeySha1 = publicKeySha1,
+    publicKeySha256 = publicKeySha256,
+    validFrom = validFrom.toEpochMilli(),
+    validUntil = validUntil.toEpochMilli(),
+    serialNumber = serialNumber,
+    issuer = issuer.toSnapshot(),
+    subject = subject.toSnapshot(),
+    isSelfSigned = isSelfSigned,
+)
+
+internal fun CertificatePrincipal.toSnapshot() = CertificatePrincipalSnapshot(
+    name = name,
+    organization = organization,
+    country = country,
+)

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/storage/AppHistoryDatabase.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/storage/AppHistoryDatabase.kt
@@ -1,0 +1,17 @@
+package sk.styk.martin.apkanalyzer.core.apphistory.storage
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import sk.styk.martin.apkanalyzer.core.apphistory.storage.entity.AppHistoryBlobEntity
+import sk.styk.martin.apkanalyzer.core.apphistory.storage.entity.AppHistorySnapshotEntity
+
+@Database(
+    entities = [AppHistorySnapshotEntity::class, AppHistoryBlobEntity::class],
+    version = 1,
+    exportSchema = false,
+)
+internal abstract class AppHistoryDatabase : RoomDatabase() {
+    abstract fun appHistoryGateDao(): AppHistoryGateDao
+    abstract fun appHistoryWriteDao(): AppHistoryWriteDao
+    abstract fun appHistoryReadDao(): AppHistoryReadDao
+}

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/storage/AppHistoryGateDao.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/storage/AppHistoryGateDao.kt
@@ -1,0 +1,26 @@
+package sk.styk.martin.apkanalyzer.core.apphistory.storage
+
+import androidx.room.Dao
+import androidx.room.Query
+
+internal data class AppHistoryGateState(
+    val packageName: String,
+    val lastUpdateTime: Long,
+    val firstInstallTime: Long,
+)
+
+@Dao
+internal interface AppHistoryGateDao {
+
+    @Query("SELECT packageName, lastUpdateTime, firstInstallTime FROM app_history_snapshot WHERE packageName = :packageName ORDER BY id DESC LIMIT 1")
+    suspend fun latestGateTimestamps(packageName: String): AppHistoryGateState?
+
+    @Query(
+        """
+        SELECT packageName, lastUpdateTime, firstInstallTime
+        FROM app_history_snapshot
+        WHERE id IN (SELECT MAX(id) FROM app_history_snapshot GROUP BY packageName)
+        """,
+    )
+    suspend fun latestGateTimestampsForAllPackages(): List<AppHistoryGateState>
+}

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/storage/AppHistoryReadDao.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/storage/AppHistoryReadDao.kt
@@ -1,0 +1,56 @@
+package sk.styk.martin.apkanalyzer.core.apphistory.storage
+
+import androidx.room.Dao
+import androidx.room.Embedded
+import androidx.room.Query
+import sk.styk.martin.apkanalyzer.core.apphistory.storage.entity.AppHistorySnapshotEntity
+
+internal data class AppHistorySnapshot(
+    @Embedded val snapshot: AppHistorySnapshotEntity,
+    val permissionsContent: String?,
+    val activitiesContent: String?,
+    val servicesContent: String?,
+    val receiversContent: String?,
+    val providersContent: String?,
+    val featuresContent: String?,
+    val signingContent: String?,
+    val intentFiltersContent: String?,
+    val nativeLibrariesContent: String?,
+    val signingSchemeContent: String?,
+    val installedSplitsContent: String?,
+)
+
+@Dao
+internal interface AppHistoryReadDao {
+
+    @Query(
+        """
+        SELECT s.*,
+            pb.content AS permissionsContent,
+            ab.content AS activitiesContent,
+            svb.content AS servicesContent,
+            rb.content AS receiversContent,
+            prb.content AS providersContent,
+            fb.content AS featuresContent,
+            sib.content AS signingContent,
+            ifb.content AS intentFiltersContent,
+            nlb.content AS nativeLibrariesContent,
+            ssb.content AS signingSchemeContent,
+            isb.content AS installedSplitsContent
+        FROM app_history_snapshot s
+        LEFT JOIN app_history_blob pb ON pb.packageName = s.packageName AND pb.hash = s.permissionsHash
+        LEFT JOIN app_history_blob ab ON ab.packageName = s.packageName AND ab.hash = s.activitiesHash
+        LEFT JOIN app_history_blob svb ON svb.packageName = s.packageName AND svb.hash = s.servicesHash
+        LEFT JOIN app_history_blob rb ON rb.packageName = s.packageName AND rb.hash = s.receiversHash
+        LEFT JOIN app_history_blob prb ON prb.packageName = s.packageName AND prb.hash = s.providersHash
+        LEFT JOIN app_history_blob fb ON fb.packageName = s.packageName AND fb.hash = s.featuresHash
+        LEFT JOIN app_history_blob sib ON sib.packageName = s.packageName AND sib.hash = s.signingHash
+        LEFT JOIN app_history_blob ifb ON ifb.packageName = s.packageName AND ifb.hash = s.intentFiltersHash
+        LEFT JOIN app_history_blob nlb ON nlb.packageName = s.packageName AND nlb.hash = s.nativeLibrariesHash
+        LEFT JOIN app_history_blob ssb ON ssb.packageName = s.packageName AND ssb.hash = s.signingSchemeHash
+        LEFT JOIN app_history_blob isb ON isb.packageName = s.packageName AND isb.hash = s.installedSplitsHash
+        WHERE s.id = :id
+        """,
+    )
+    suspend fun snapshotWithSections(id: Long): AppHistorySnapshot?
+}

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/storage/AppHistoryWriteDao.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/storage/AppHistoryWriteDao.kt
@@ -1,0 +1,24 @@
+package sk.styk.martin.apkanalyzer.core.apphistory.storage
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Transaction
+import sk.styk.martin.apkanalyzer.core.apphistory.storage.entity.AppHistoryBlobEntity
+import sk.styk.martin.apkanalyzer.core.apphistory.storage.entity.AppHistorySnapshotEntity
+
+@Dao
+internal interface AppHistoryWriteDao {
+
+    @Transaction
+    suspend fun insertSnapshotWithBlobs(snapshot: AppHistorySnapshotEntity, blobs: List<AppHistoryBlobEntity>) {
+        insertBlobs(blobs)
+        insertSnapshot(snapshot)
+    }
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertBlobs(blobs: List<AppHistoryBlobEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.ABORT)
+    suspend fun insertSnapshot(snapshot: AppHistorySnapshotEntity)
+}

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/storage/di/AppHistoryStorageModule.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/storage/di/AppHistoryStorageModule.kt
@@ -1,0 +1,34 @@
+package sk.styk.martin.apkanalyzer.core.apphistory.storage.di
+
+import android.content.Context
+import androidx.room.Room
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import sk.styk.martin.apkanalyzer.core.apphistory.storage.AppHistoryDatabase
+import sk.styk.martin.apkanalyzer.core.apphistory.storage.AppHistoryGateDao
+import sk.styk.martin.apkanalyzer.core.apphistory.storage.AppHistoryReadDao
+import sk.styk.martin.apkanalyzer.core.apphistory.storage.AppHistoryWriteDao
+import javax.inject.Singleton
+
+private const val DATABASE_NAME = "app_history.db"
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal object AppHistoryStorageModule {
+    @Provides
+    @Singleton
+    fun provideAppHistoryDatabase(@ApplicationContext context: Context): AppHistoryDatabase =
+        Room.databaseBuilder(context, AppHistoryDatabase::class.java, DATABASE_NAME).build()
+
+    @Provides
+    fun provideAppHistoryGateDao(database: AppHistoryDatabase): AppHistoryGateDao = database.appHistoryGateDao()
+
+    @Provides
+    fun provideAppHistoryWriteDao(database: AppHistoryDatabase): AppHistoryWriteDao = database.appHistoryWriteDao()
+
+    @Provides
+    fun provideAppHistoryReadDao(database: AppHistoryDatabase): AppHistoryReadDao = database.appHistoryReadDao()
+}

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/storage/entity/AppHistoryBlobEntity.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/storage/entity/AppHistoryBlobEntity.kt
@@ -9,20 +9,5 @@ import androidx.room.Entity
 internal data class AppHistoryBlobEntity(
     val packageName: String,
     val hash: String,
-    val sectionType: SectionType,
     val content: String,
 )
-
-internal enum class SectionType {
-    Permissions,
-    Activities,
-    Services,
-    Receivers,
-    Providers,
-    Features,
-    Signing,
-    IntentFilters,
-    NativeLibraries,
-    SigningScheme,
-    InstalledSplits,
-}

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/storage/entity/AppHistoryBlobEntity.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/storage/entity/AppHistoryBlobEntity.kt
@@ -1,0 +1,28 @@
+package sk.styk.martin.apkanalyzer.core.apphistory.storage.entity
+
+import androidx.room.Entity
+
+@Entity(
+    tableName = "app_history_blob",
+    primaryKeys = ["packageName", "hash"],
+)
+internal data class AppHistoryBlobEntity(
+    val packageName: String,
+    val hash: String,
+    val sectionType: SectionType,
+    val content: String,
+)
+
+internal enum class SectionType {
+    Permissions,
+    Activities,
+    Services,
+    Receivers,
+    Providers,
+    Features,
+    Signing,
+    IntentFilters,
+    NativeLibraries,
+    SigningScheme,
+    InstalledSplits,
+}

--- a/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/storage/entity/AppHistorySnapshotEntity.kt
+++ b/core/app-history/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apphistory/storage/entity/AppHistorySnapshotEntity.kt
@@ -1,0 +1,46 @@
+package sk.styk.martin.apkanalyzer.core.apphistory.storage.entity
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "app_history_snapshot",
+    indices = [Index(value = ["packageName", "lastUpdateTime", "firstInstallTime"], unique = true)],
+)
+internal data class AppHistorySnapshotEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val packageName: String,
+    val deviceId: String,
+    val firstInstallTime: Long,
+    val lastUpdateTime: Long,
+    val applicationName: String,
+    val processName: String?,
+    val versionCode: Long,
+    val versionName: String?,
+    val isSystemApp: Boolean,
+    val isDebuggable: Boolean,
+    val allowsBackup: Boolean,
+    val usesCleartextTraffic: Boolean,
+    val uid: Int?,
+    val sharedUserId: String?,
+    val description: String?,
+    val installLocation: String,
+    val installingPackage: String?,
+    val initiatingPackage: String?,
+    val originatingPackage: String?,
+    val apkSize: Long,
+    val targetSdkVersion: Int?,
+    val minSdkVersion: Int?,
+    val permissionsHash: String?,
+    val activitiesHash: String?,
+    val servicesHash: String?,
+    val receiversHash: String?,
+    val providersHash: String?,
+    val featuresHash: String?,
+    val signingHash: String?,
+    val intentFiltersHash: String?,
+    val nativeLibrariesHash: String?,
+    val signingSchemeHash: String?,
+    val installedSplitsHash: String?,
+)

--- a/core/apps/AGENTS.md
+++ b/core/apps/AGENTS.md
@@ -44,13 +44,26 @@ different lifecycles and must not be smuggled into that cache key.
 
 `PackageChangesObserverImpl.observe()` is one `BroadcastReceiver` shared across every caller
 (`shareIn(appScope, SharingStarted.WhileSubscribed(), replay = 0)`), not a fresh registration per
-subscriber — seven independent consumers each registering their own receiver for the same broadcasts
-was the previous, wasteful shape. Every current consumer subscribes permanently at construction
-(either `.launchIn(appScope + ...)` in an `init` block, or its own `shareIn(appScope, Eagerly/Lazily,
-...)`), so in practice the shared receiver stays registered for the app's lifetime either way; a
-future consumer that subscribes and later fully unsubscribes would see the receiver tear down and
-re-register around that gap, which `replay = 0` makes safe to reason about (a late subscriber only
-ever sees events after it attaches, matching the original per-consumer `callbackFlow` semantics).
+subscriber — independent consumers each registering their own receiver for the same broadcasts was
+the previous, wasteful shape. `InstalledAppsRepositoryImpl`, `AppSigningRepositoryImpl`, and
+`core:app-history`'s fast-path capture are genuine reactive consumers of the event stream and still
+subscribe via `observe()`; each subscribes permanently at construction (`shareIn(appScope,
+Eagerly/Lazily, ...)` or `.launchIn(appScope + ...)`), so in practice the shared receiver stays
+registered for the app's lifetime; a future consumer that subscribes and later fully unsubscribes
+would see the receiver tear down and re-register around that gap, which `replay = 0` makes safe to
+reason about (a late subscriber only ever sees events after it attaches).
+
+`AppDetailRepositoryImpl`, `IntentFiltersRepositoryImpl`, `NativeLibrariesRepositoryImpl`, and
+`SigningSchemeRepositoryImpl` don't need the event stream at all — they only ever clear their cache
+on any change — so they call `PackageChangesObserver.runBeforeNotifying { cache.clear() }` instead of
+subscribing to `observe()`. This isn't just a simpler call site: it fixes a real race. Their old
+`.onEach { cache.clear() }.launchIn(...)` collectors ran as independent coroutines with no ordering
+guarantee relative to any other `observe()` collector reacting to the same broadcast — including
+`core:app-history`'s fast-path capture, which could read a stale cached `AppDetail` before the
+invalidating collector got scheduled, and permanently persist it under the new install timestamp.
+`runBeforeNotifying`'s registered actions run synchronously inside `onReceive`, before `trySend`, so
+every cache is guaranteed clear before the event is observable by anyone — a structural
+happens-before, not a probabilistic one from coroutine scheduling.
 
 Expensive device-wide signing work is shared lazily. Single-app signing-scheme inspection is itself
 expensive (it reads the APK's signing block directly) and only the Certificates screen shows it, so

--- a/core/apps/AGENTS.md
+++ b/core/apps/AGENTS.md
@@ -42,6 +42,16 @@ cached `AppDetail`; consumers combine app facts with device repositories separat
 `PackageChangesObserver` invalidates installed-package data. APK-file inputs and device state have
 different lifecycles and must not be smuggled into that cache key.
 
+`PackageChangesObserverImpl.observe()` is one `BroadcastReceiver` shared across every caller
+(`shareIn(appScope, SharingStarted.WhileSubscribed(), replay = 0)`), not a fresh registration per
+subscriber — seven independent consumers each registering their own receiver for the same broadcasts
+was the previous, wasteful shape. Every current consumer subscribes permanently at construction
+(either `.launchIn(appScope + ...)` in an `init` block, or its own `shareIn(appScope, Eagerly/Lazily,
+...)`), so in practice the shared receiver stays registered for the app's lifetime either way; a
+future consumer that subscribes and later fully unsubscribes would see the receiver tear down and
+re-register around that gap, which `replay = 0` makes safe to reason about (a late subscriber only
+ever sees events after it attaches, matching the original per-consumer `callbackFlow` semantics).
+
 Expensive device-wide signing work is shared lazily. Single-app signing-scheme inspection is itself
 expensive (it reads the APK's signing block directly) and only the Certificates screen shows it, so
 it is fetched lazily and separately by `SigningSchemeRepository` rather than being collected as part

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
@@ -7,10 +7,6 @@ import android.content.pm.FeatureInfo
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.plus
 import sk.styk.martin.apkanalyzer.core.apps.components.Activity
 import sk.styk.martin.apkanalyzer.core.apps.components.BroadcastReceiver
 import sk.styk.martin.apkanalyzer.core.apps.components.ContentProvider
@@ -70,8 +66,6 @@ internal class AppDetailRepositoryImpl @Inject constructor(
     private val storageStatsRepository: StorageStatsRepository,
     private val usageStatsRepository: UsageStatsRepository,
     packageChangesObserver: PackageChangesObserver,
-    appScope: CoroutineScope,
-    private val dispatcherProvider: DispatcherProvider,
     private val performanceTracker: PerformanceTracker,
 ) : AppDetailRepository {
 
@@ -86,12 +80,10 @@ internal class AppDetailRepositoryImpl @Inject constructor(
         PackageManager.GET_CONFIGURATIONS
 
     init {
-        packageChangesObserver.observe()
-            .onEach {
-                Logger.d(TAG, "Package change detected, clearing cache")
-                cache.clear()
-            }
-            .launchIn(appScope + dispatcherProvider.default())
+        packageChangesObserver.runBeforeNotifying {
+            Logger.d(TAG, "Package change detected, clearing cache")
+            cache.clear()
+        }
     }
 
     override suspend fun details(reference: AppReference): Result<AppDetail> = performanceTracker.startCancellableTrace("app_detail_load") {

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepository.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepository.kt
@@ -2,8 +2,10 @@ package sk.styk.martin.apkanalyzer.core.apps
 
 import kotlinx.coroutines.flow.Flow
 import sk.styk.martin.apkanalyzer.core.apps.model.InstalledApp
+import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 
 interface InstalledAppsRepository {
     fun apps(): Flow<List<InstalledApp>>
     suspend fun awaitFullyEnrichedApps(): List<InstalledApp>
+    suspend fun app(packageName: PackageName): InstalledApp?
 }

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
@@ -11,10 +11,12 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.withContext
 import sk.styk.martin.apkanalyzer.core.apps.installsource.InstallSourceResolver
 import sk.styk.martin.apkanalyzer.core.apps.installsource.isSystemInstalledApp
 import sk.styk.martin.apkanalyzer.core.apps.installsource.resolveAppInstallSource
@@ -43,13 +45,14 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
     private val packageManager: PackageManager,
     private val installSourceResolver: InstallSourceResolver,
     packageChangesObserver: PackageChangesObserver,
-    dispatcherProvider: DispatcherProvider,
+    private val dispatcherProvider: DispatcherProvider,
     private val storageStatsRepository: StorageStatsRepository,
     private val usageStatsRepository: UsageStatsRepository,
     appScope: CoroutineScope,
     private val performanceTracker: PerformanceTracker,
 ) : InstalledAppsRepository {
     private val cachedApps = packageChangesObserver.observe()
+        .map { Unit }
         .onStart { emit(Unit) }
         .mapLatest { loadAllApps() }
         .onEach { apps -> storageStatsRepository.requestTotalSizes(apps.map { it.packageName }) }
@@ -87,6 +90,12 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
                 lastUsedTime = lastUsedTimes[app.packageName] ?: app.lastUsedTime,
             )
         }
+    }
+
+    override suspend fun app(packageName: PackageName): InstalledApp? = withContext(dispatcherProvider.io()) {
+        runCatchingCancellable {
+            packageManager.getPackageInfo(packageName.value, PackageManager.GET_PERMISSIONS).toInstalledApp()
+        }.getOrNull()
     }
 
     @SuppressLint("QueryPermissionsNeeded")

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/PackageChangesObserver.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/PackageChangesObserver.kt
@@ -1,7 +1,16 @@
 package sk.styk.martin.apkanalyzer.core.apps
 
 import kotlinx.coroutines.flow.Flow
+import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 
 interface PackageChangesObserver {
-    fun observe(): Flow<Unit>
+    fun observe(): Flow<PackageChangeEvent>
+}
+
+data class PackageChangeEvent(val packageName: PackageName, val action: PackageChangeAction)
+
+enum class PackageChangeAction {
+    Added,
+    Removed,
+    Replaced,
 }

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/PackageChangesObserver.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/PackageChangesObserver.kt
@@ -5,6 +5,7 @@ import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 
 interface PackageChangesObserver {
     fun observe(): Flow<PackageChangeEvent>
+    fun runBeforeNotifying(action: (PackageChangeEvent) -> Unit)
 }
 
 data class PackageChangeEvent(val packageName: PackageName, val action: PackageChangeAction)

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/PackageChangesObserverImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/PackageChangesObserverImpl.kt
@@ -13,9 +13,16 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.shareIn
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
+import java.util.concurrent.CopyOnWriteArrayList
 import javax.inject.Inject
 
-class PackageChangesObserverImpl @Inject constructor(@ApplicationContext private val context: Context, appScope: CoroutineScope) : PackageChangesObserver {
+class PackageChangesObserverImpl @Inject constructor(@ApplicationContext appContext: Context, appScope: CoroutineScope) : PackageChangesObserver {
+
+    private val actionsBeforeNotifying = CopyOnWriteArrayList<(PackageChangeEvent) -> Unit>()
+
+    override fun runBeforeNotifying(action: (PackageChangeEvent) -> Unit) {
+        actionsBeforeNotifying += action
+    }
 
     private val events = callbackFlow {
         val receiver = object : BroadcastReceiver() {
@@ -23,10 +30,11 @@ class PackageChangesObserverImpl @Inject constructor(@ApplicationContext private
                 Logger.d(INSTALLED_APPS, "Received package change event $intent")
                 val event = intent.toPackageChangeEvent()
                 if (event == null) {
-                    Logger.w(INSTALLED_APPS, "Package change broadcast with unparsable data or action: ${intent.action}")
+                    Logger.w(INSTALLED_APPS, "Package change broadcast with unparsable data or action: ${intent.action ?: "none"}")
                     return
                 }
                 Logger.i(INSTALLED_APPS, "Package change detected: $event")
+                actionsBeforeNotifying.forEach { it(event) }
                 trySend(event)
             }
         }
@@ -38,8 +46,8 @@ class PackageChangesObserverImpl @Inject constructor(@ApplicationContext private
             addDataScheme("package")
         }
 
-        context.registerReceiver(receiver, filter)
-        awaitClose { context.unregisterReceiver(receiver) }
+        appContext.registerReceiver(receiver, filter)
+        awaitClose { appContext.unregisterReceiver(receiver) }
     }.shareIn(
         scope = appScope,
         started = SharingStarted.WhileSubscribed(),

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/PackageChangesObserverImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/PackageChangesObserverImpl.kt
@@ -5,19 +5,29 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.shareIn
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
+import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import javax.inject.Inject
 
-class PackageChangesObserverImpl @Inject constructor(@ApplicationContext private val context: Context) : PackageChangesObserver {
+class PackageChangesObserverImpl @Inject constructor(@ApplicationContext private val context: Context, appScope: CoroutineScope) : PackageChangesObserver {
 
-    override fun observe(): Flow<Unit> = callbackFlow {
+    private val events = callbackFlow {
         val receiver = object : BroadcastReceiver() {
             override fun onReceive(context: Context, intent: Intent) {
-                Logger.i(INSTALLED_APPS, "Package change detected")
-                trySend(Unit)
+                Logger.d(INSTALLED_APPS, "Received package change event $intent")
+                val event = intent.toPackageChangeEvent()
+                if (event == null) {
+                    Logger.w(INSTALLED_APPS, "Package change broadcast with unparsable data or action: ${intent.action}")
+                    return
+                }
+                Logger.i(INSTALLED_APPS, "Package change detected: $event")
+                trySend(event)
             }
         }
 
@@ -30,5 +40,22 @@ class PackageChangesObserverImpl @Inject constructor(@ApplicationContext private
 
         context.registerReceiver(receiver, filter)
         awaitClose { context.unregisterReceiver(receiver) }
+    }.shareIn(
+        scope = appScope,
+        started = SharingStarted.WhileSubscribed(),
+        replay = 0,
+    )
+
+    override fun observe(): Flow<PackageChangeEvent> = events
+
+    private fun Intent.toPackageChangeEvent(): PackageChangeEvent? {
+        val packageName = data?.schemeSpecificPart ?: return null
+        val action = when (action) {
+            Intent.ACTION_PACKAGE_ADDED -> PackageChangeAction.Added
+            Intent.ACTION_PACKAGE_REMOVED -> PackageChangeAction.Removed
+            Intent.ACTION_PACKAGE_REPLACED -> PackageChangeAction.Replaced
+            else -> return null
+        }
+        return PackageChangeEvent(PackageName(packageName), action)
     }
 }

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/intentfilters/IntentFiltersRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/intentfilters/IntentFiltersRepositoryImpl.kt
@@ -1,14 +1,9 @@
 package sk.styk.martin.apkanalyzer.core.apps.intentfilters
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.plus
 import sk.styk.martin.apkanalyzer.core.apps.PackageChangesObserver
 import sk.styk.martin.apkanalyzer.core.apps.components.ComponentIntentFilter
 import sk.styk.martin.apkanalyzer.core.apps.components.ComponentIntentFilterKey
 import sk.styk.martin.apkanalyzer.core.apps.manifest.ManifestParser
-import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.model.AppReference
 import sk.styk.martin.apkanalyzer.core.common.model.AppReferenceCacheKey
@@ -31,20 +26,16 @@ private const val CACHE_HIT_ATTRIBUTE = "cache_hit"
 internal class IntentFiltersRepositoryImpl @Inject constructor(
     private val manifestParser: ManifestParser,
     packageChangesObserver: PackageChangesObserver,
-    appScope: CoroutineScope,
-    dispatcherProvider: DispatcherProvider,
     private val performanceTracker: PerformanceTracker,
 ) : IntentFiltersRepository {
 
     private val cache = ConcurrentHashMap<AppReferenceCacheKey, Map<ComponentIntentFilterKey, List<ComponentIntentFilter>>>()
 
     init {
-        packageChangesObserver.observe()
-            .onEach {
-                Logger.d(TAG, "Package change detected, clearing cache")
-                cache.clear()
-            }
-            .launchIn(appScope + dispatcherProvider.default())
+        packageChangesObserver.runBeforeNotifying {
+            Logger.d(TAG, "Package change detected, clearing cache")
+            cache.clear()
+        }
     }
 
     override suspend fun componentIntentFilters(reference: AppReference): Result<Map<ComponentIntentFilterKey, List<ComponentIntentFilter>>> =

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/packaging/NativeLibrariesRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/packaging/NativeLibrariesRepositoryImpl.kt
@@ -3,13 +3,9 @@ package sk.styk.martin.apkanalyzer.core.apps.packaging
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.plus
 import sk.styk.martin.apkanalyzer.core.apps.PackageChangesObserver
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
 import sk.styk.martin.apkanalyzer.core.common.coroutines.runCatchingCancellable
@@ -40,7 +36,6 @@ private val nativeLibraryEntryRegex = Regex("""^lib/([^/]+)/([^/]+\.so)$""")
 internal class NativeLibrariesRepositoryImpl @Inject constructor(
     private val packageManager: PackageManager,
     packageChangesObserver: PackageChangesObserver,
-    appScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     private val performanceTracker: PerformanceTracker,
 ) : NativeLibrariesRepository {
@@ -48,12 +43,10 @@ internal class NativeLibrariesRepositoryImpl @Inject constructor(
     private val cache = ConcurrentHashMap<AppReferenceCacheKey, NativeLibraries>()
 
     init {
-        packageChangesObserver.observe()
-            .onEach {
-                Logger.d(TAG, "Package change detected, clearing cache")
-                cache.clear()
-            }
-            .launchIn(appScope + dispatcherProvider.default())
+        packageChangesObserver.runBeforeNotifying {
+            Logger.d(TAG, "Package change detected, clearing cache")
+            cache.clear()
+        }
     }
 
     override suspend fun nativeLibraries(reference: AppReference): Result<NativeLibraries> = performanceTracker.startCancellableTrace("native_libraries_load") {

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/signing/AppSigningRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/signing/AppSigningRepositoryImpl.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.shareIn
@@ -33,6 +34,7 @@ internal class AppSigningRepositoryImpl @Inject constructor(
 ) : AppSigningRepository {
 
     private val cachedSigning = packageChangesObserver.observe()
+        .map { Unit }
         .onStart { emit(Unit) }
         .mapLatest { loadAllSigning() }
         .flowOn(dispatcherProvider.io())

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/signing/CertificateExtractorImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/signing/CertificateExtractorImpl.kt
@@ -15,6 +15,7 @@ import javax.security.auth.x500.X500Principal
 
 private const val TAG = "CertificateExtractorImpl"
 private val unescapedCommaRegex = Regex("""(?<!\\),""")
+private val unescapedPlusRegex = Regex("""(?<!\\)\+""")
 private val escapedCharRegex = Regex("""\\(.)""")
 
 internal class CertificateExtractorImpl @Inject constructor(private val digestManager: DigestManager) : CertificateExtractor {
@@ -89,8 +90,10 @@ internal class CertificateExtractorImpl @Inject constructor(private val digestMa
     private fun String.toDistinguishedNameFields(): Map<String, String> {
         val fields = mutableMapOf<String, String>()
         for (rdn in unescapedCommaRegex.split(this)) {
-            val (type, value) = rdn.split('=', limit = 2).takeIf { it.size == 2 } ?: continue
-            fields.putIfAbsent(type.trim().uppercase(Locale.ROOT), value.unescapeDnValue())
+            for (attributeTypeAndValue in unescapedPlusRegex.split(rdn)) {
+                val (type, value) = attributeTypeAndValue.split('=', limit = 2).takeIf { it.size == 2 } ?: continue
+                fields.putIfAbsent(type.trim().uppercase(Locale.ROOT), value.unescapeDnValue())
+            }
         }
         return fields
     }

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/signing/CertificateExtractorImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/signing/CertificateExtractorImpl.kt
@@ -12,9 +12,10 @@ import java.security.cert.X509Certificate
 import java.util.Locale
 import javax.inject.Inject
 import javax.security.auth.x500.X500Principal
-import javax.security.auth.x500.X500Principal.RFC1779
 
 private const val TAG = "CertificateExtractorImpl"
+private val unescapedCommaRegex = Regex("""(?<!\\),""")
+private val escapedCharRegex = Regex("""\\(.)""")
 
 internal class CertificateExtractorImpl @Inject constructor(private val digestManager: DigestManager) : CertificateExtractor {
 
@@ -76,15 +77,25 @@ internal class CertificateExtractorImpl @Inject constructor(private val digestMa
         }
     }
 
-    private fun X500Principal.toPrincipal() = CertificatePrincipal(
-        name = getField("CN=([^,]*)"),
-        organization = getField("O=([^,]*)"),
-        country = getField("C=([^,]*)"),
-    )
+    private fun X500Principal.toPrincipal(): CertificatePrincipal {
+        val fields = name.toDistinguishedNameFields()
+        return CertificatePrincipal(
+            name = fields["CN"],
+            organization = fields["O"],
+            country = fields["C"],
+        )
+    }
 
-    private fun X500Principal.getField(pattern: String): String? = getName(RFC1779).takeUnless {
-        it.isNullOrBlank()
-    }?.let { Regex(pattern).find(it)?.groupValues?.get(1) }
+    private fun String.toDistinguishedNameFields(): Map<String, String> {
+        val fields = mutableMapOf<String, String>()
+        for (rdn in unescapedCommaRegex.split(this)) {
+            val (type, value) = rdn.split('=', limit = 2).takeIf { it.size == 2 } ?: continue
+            fields.putIfAbsent(type.trim().uppercase(Locale.ROOT), value.unescapeDnValue())
+        }
+        return fields
+    }
+
+    private fun String.unescapeDnValue(): String = escapedCharRegex.replace(this) { it.groupValues[1] }.trim()
 
     private fun resolveTrustLevel(certificate: X509Certificate): CertificateTrustLevel {
         val issuerDn = certificate.issuerX500Principal.name

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/signing/SigningSchemeRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/signing/SigningSchemeRepositoryImpl.kt
@@ -2,10 +2,6 @@ package sk.styk.martin.apkanalyzer.core.apps.signing
 
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
 import sk.styk.martin.apkanalyzer.core.apps.PackageChangesObserver
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
@@ -33,7 +29,6 @@ internal class SigningSchemeRepositoryImpl @Inject constructor(
     private val packageManager: PackageManager,
     private val apkSigningBlockAnalyzer: ApkSigningBlockAnalyzer,
     packageChangesObserver: PackageChangesObserver,
-    appScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     private val performanceTracker: PerformanceTracker,
 ) : SigningSchemeRepository {
@@ -41,12 +36,10 @@ internal class SigningSchemeRepositoryImpl @Inject constructor(
     private val cache = ConcurrentHashMap<AppReferenceCacheKey, SigningSchemeResult>()
 
     init {
-        packageChangesObserver.observe()
-            .onEach {
-                Logger.d(TAG, "Package change detected, clearing cache")
-                cache.clear()
-            }
-            .launchIn(appScope + dispatcherProvider.default())
+        packageChangesObserver.runBeforeNotifying {
+            Logger.d(TAG, "Package change detected, clearing cache")
+            cache.clear()
+        }
     }
 
     override suspend fun signingSchemeVersions(reference: AppReference): Result<List<SigningSchemeVersion>?> =

--- a/core/common/AGENTS.md
+++ b/core/common/AGENTS.md
@@ -19,7 +19,9 @@ logic do not belong here.
 * `settings/` - generic typed DataStore persistence and preference keys.
 * `model/` - genuinely cross-module value types such as app references, source classification, and
   file sizes.
-* `resources/`, `clipboard/`, and `digest/` - shared platform adapters and focused utilities.
+* `resources/`, `clipboard/`, `digest/`, and `device/` - shared platform adapters and focused
+  utilities. `device/`'s `DeviceIdProvider` wraps `Settings.Secure.ANDROID_ID` behind an interface so
+  callers never touch `@SuppressLint("HardwareIds")` or `ContentResolver` directly.
 
 ## Durable Contracts
 

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/device/DeviceIdProvider.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/device/DeviceIdProvider.kt
@@ -1,0 +1,5 @@
+package sk.styk.martin.apkanalyzer.core.common.device
+
+interface DeviceIdProvider {
+    val deviceId: String
+}

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/device/DeviceIdProviderImpl.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/device/DeviceIdProviderImpl.kt
@@ -1,0 +1,17 @@
+package sk.styk.martin.apkanalyzer.core.common.device
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.provider.Settings
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+internal class DeviceIdProviderImpl @Inject constructor(@ApplicationContext private val context: Context) : DeviceIdProvider {
+
+    @delegate:SuppressLint("HardwareIds")
+    override val deviceId: String by lazy {
+        Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID).orEmpty()
+    }
+}

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/device/DeviceModule.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/device/DeviceModule.kt
@@ -1,0 +1,15 @@
+package sk.styk.martin.apkanalyzer.core.common.device
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal interface DeviceModule {
+    @Binds
+    @Singleton
+    fun bindDeviceIdProvider(impl: DeviceIdProviderImpl): DeviceIdProvider
+}

--- a/docs/app/technical/app-history-capture-schema.md
+++ b/docs/app/technical/app-history-capture-schema.md
@@ -191,27 +191,24 @@ matches something already stored for the same package just references the existi
 internal data class AppHistoryBlobEntity(
     val packageName: String,
     val hash: String,
-    val sectionType: SectionType,
     val content: String, // JSON
 )
-
-internal enum class SectionType {
-    Permissions,
-    Activities,
-    Services,
-    Receivers,
-    Providers,
-    Features,
-    Signing,
-    IntentFilters,
-    NativeLibraries,
-    SigningScheme,
-    InstalledSplits,
-}
 ```
 
 Insert with `OnConflictStrategy.IGNORE` against the composite `(packageName, hash)` key — no
 existence check needed first, since the hash is a deterministic function of the content.
+
+**Why no `sectionType` column.** An earlier version of this schema carried a `SectionType` enum
+column on every blob row, and hashed content alone. That's unsound: most apps have several
+genuinely empty sections (`"[]"` for `Receivers`, `Providers`, `Features`, ...), all identical
+bytes, so they'd hash identically and collide onto the same `(packageName, hash)` row — leaving that
+row's own `sectionType` correct for only whichever section won the insert race. On real captured
+data, 68% of snapshot rows already had two or more section-hash columns pointing at one shared blob.
+Forcing the section type into the hash to keep the column truthful would have turned every one of
+those legitimate, storage-saving duplicates into a separately-stored copy — trading away the actual
+point of content addressing to keep a column that nothing reads. A blob is just bytes; which
+section(s) it represents is already fully answered by whichever snapshot column points at it
+(`permissionsHash`, `activitiesHash`, ...), so the row doesn't need its own opinion.
 
 **Why per-package, not global.** A globally-shared blob (keyed by `hash` alone) can be referenced by
 any package's snapshots, so deleting one app's history can't safely delete its blobs without first
@@ -320,8 +317,7 @@ Runs once per package that the gate says changed:
    content always hashes identically) and hash it — including a successful-but-legitimately-unknown
    result (`signingScheme`'s inner `null`), so a hash column is only ever absent when extraction
    truly failed. See [Partial-Capture Marking](#partial-capture-marking).
-5. `INSERT OR IGNORE` each section's `(packageName, hash, sectionType, content)` into
-   `app_history_blob`.
+5. `INSERT OR IGNORE` each section's `(packageName, hash, content)` into `app_history_blob`.
 6. Insert one new `AppHistorySnapshotEntity` row with the scalars and the section hashes. Always a
    new row, never an update.
 
@@ -414,7 +410,14 @@ Not yet resolved — flagging rather than silently deciding:
   reuses the same proven `capture()` path, but `ACTION_PACKAGE_REPLACED` is a protected broadcast
   `adb` can't synthesize, and a real reinstall kills the process before its own receiver reacts — so
   this is reasoned, not demonstrated, confidence. Worth a real install/update test on a throwaway
-  package before relying on it.
+  package before relying on it. A real ordering bug was found (review, not on-device) and fixed on
+  this path before it ever shipped: `AppDetailRepository` and its three siblings each independently
+  subscribed to `PackageChangesObserver.observe()` to clear their caches, racing the fast path's own
+  subscription with no ordering guarantee between them — a lost race could persist stale cached
+  content under the new install timestamp, permanently, since the gate only compares timestamps and
+  would never revisit it. Fixed by moving invalidation out of `observe()`'s independent collectors
+  and into `PackageChangesObserver.runBeforeNotifying`, which runs synchronously inside `onReceive`
+  before any event is emitted — see [`core/apps/AGENTS.md`](../../../core/apps/AGENTS.md).
 
 ## Changes to the Product Design
 

--- a/docs/app/technical/app-history-capture-schema.md
+++ b/docs/app/technical/app-history-capture-schema.md
@@ -3,10 +3,24 @@
 **Roadmap:** [FR-31](../product/roadmap.md#17-invisible-infrastructure),
 [HI-01, HI-02, HI-20](../product/roadmap.md#hi--snapshot--history-pillar-1--what-changed) — see
 [app-history.md](../product/features/app-history.md) for the product design this implements.
-**Status:** Proposed. Schema and capture algorithm agreed; `core:app-history` not yet created.
+**Status:** Implemented. `core:app-history` exists; the schema, capture pipeline, and both triggers
+(reconciliation on process start, fast-path broadcast) are built and running — see
+[`core/app-history/AGENTS.md`](../../../core/app-history/AGENTS.md) for the as-built module reference.
+Still not built: the diff engine (`HI-03`), UI (`HI-08`/`HI-14`), retention (`HI-04`), backup
+(`HI-16`/`HI-17`), the `HI-10` runtime-state tier, and periodic `WorkManager` reconciliation.
 **Scope:** The on-device Room schema for full-state app history snapshots, what is and isn't
 captured, the change-detection gate, and the two capture triggers. Does not cover the diff engine
 (`HI-03`), UI (`HI-08`/`HI-14`), retention (`HI-04`), or backup (`HI-16`/`HI-17`).
+
+**Implementation note (post-agreement correction):** this doc's "Why JSON Content" section below
+still describes the *originally agreed* design — serializing the `core:apps` domain models
+(`Activity`, `Certificate`, ...) directly. That was changed during implementation: those models are
+never made `@Serializable`, because doing so would let an ordinary `core:apps` rename/retype silently
+break deserialization of historical blobs. `core:app-history` instead defines its own mirror DTOs
+(`capture/snapshot/`) and maps to them at capture time — see
+[`core/app-history/AGENTS.md`](../../../core/app-history/AGENTS.md#dto-boundary--not-a-detail) for the
+full rationale. The content-addressing, per-package scoping, and "JSON absorbs a new field for free"
+arguments below are unaffected; only *which* type gets serialized changed.
 
 ## Reconstruction Target
 
@@ -317,23 +331,18 @@ Two capture paths, sharing the same gate and pipeline above:
 
 * **Fast path** — `PackageChangesObserver`'s install/update broadcast. Only fires while the process
   is alive (a context-registered receiver can't survive process death), so it's best-effort
-  latency, not the correctness guarantee.
-
-  **Prerequisite, not yet true today:** `PackageChangesObserverImpl` currently emits `Flow<Unit>` —
-  `onReceive` reads nothing off the `Intent` before calling `trySend(Unit)`, so there's no package
-  name to key the single-package gate query on. Its only current consumer
-  (`InstalledAppsRepositoryImpl`) only ever needed "something changed, reload everything," so this
-  was never a problem before. Using this as history's fast path requires extending the observer to
-  surface the changed package from the broadcast's `Intent.getData()` (`package:<name>` URI) —
-  and ideally the action (`ACTION_PACKAGE_ADDED`/`REMOVED`/`REPLACED`) — instead of a bare `Unit`.
-  Until that lands, the fast path can only fall back to the same all-packages batched query
-  reconciliation uses, which defeats its purpose as the low-latency path.
+  latency, not the correctness guarantee. `PackageChangesObserver` now emits
+  `PackageChangeEvent(packageName, action)` (extended for this — its other consumers, which only ever
+  needed "something changed, reload everything," were adapted to the new shape) instead of the bare
+  `Flow<Unit>` this section originally described as a prerequisite.
 * **Reconciliation** — sweeps every installed app (`InstalledAppsRepository`) through the batched
   gate query above. This is what actually guarantees completeness, since install/update broadcasts
-  missed while the app was dead are otherwise lost forever. Runs once per app process start today;
-  a periodic `WorkManager` job is an agreed follow-up once this pipeline is proven, to cover long
-  stretches where the app is never opened (`androidx.work` is not yet a dependency — needs adding
-  when that follow-up starts).
+  missed while the app was dead are otherwise lost forever. Runs once per app process start today —
+  implemented by `AppHistoryCaptureScheduler`, a `DefaultLifecycleObserver` whose `onCreate` (not
+  `onStart`, which re-fires on every foreground return) calls `start()`; see
+  [`core/app-history/AGENTS.md`](../../../core/app-history/AGENTS.md#triggers). A periodic `WorkManager`
+  job is an agreed follow-up once this pipeline is proven, to cover long stretches where the app is
+  never opened (`androidx.work` is not yet a dependency — needs adding when that follow-up starts).
 
 ## Removal Handling
 
@@ -399,9 +408,13 @@ Not yet resolved — flagging rather than silently deciding:
   schema here yet — they don't fit the content-addressed snapshot model (no new version, no full
   re-capture) and need their own lightweight append-only shape.
 * **`uid` inclusion.** Flagged above as borderline; kept for now, worth revisiting.
-* **`PackageChangesObserver` needs extending before the fast path can work as designed** — see the
-  prerequisite note under [Triggers](#triggers). Not a design gap, an implementation one, but capture
-  can't ship the fast path without it.
+* **Fast-path broadcast trigger not independently verified on-device.** Reconciliation was proven
+  end-to-end on an emulator (real snapshot/blob rows, content-addressing visibly working, zero
+  partial-capture failures). The fast path's `PackageChangesObserver` wiring compiles clean and
+  reuses the same proven `capture()` path, but `ACTION_PACKAGE_REPLACED` is a protected broadcast
+  `adb` can't synthesize, and a real reinstall kills the process before its own receiver reacts — so
+  this is reasoned, not demonstrated, confidence. Worth a real install/update test on a throwaway
+  package before relying on it.
 
 ## Changes to the Product Design
 

--- a/docs/app/technical/app-history-capture-schema.md
+++ b/docs/app/technical/app-history-capture-schema.md
@@ -93,8 +93,12 @@ grouping/junction table.
   `PermissionDetails`, `ComponentIntentFilter`, `NativeLibraryFile` all live in `core:apps` and
   evolve on its schedule. `core:user-preferences/AGENTS.md` requires a `Migration` for every schema
   change — fine for one or two small, stable entities, but a real ongoing tax across nine-plus
-  actively-evolving domain models this module doesn't control. JSON absorbs a new field for free;
-  old rows simply don't have it, the same way `@Serializable` already defaults missing fields.
+  actively-evolving domain models this module doesn't control. JSON can absorb a schema change
+  without a `Migration`, but not automatically: a field added to a `capture/snapshot/` DTO must
+  declare a Kotlin default, or decoding an old blob that lacks it throws
+  `MissingFieldException` instead of defaulting; a future reader also needs
+  `Json { ignoreUnknownKeys = true }` to tolerate blobs written by a newer app version. That
+  discipline is still far cheaper than a `Migration` per section per change.
 * **Nothing here ever queries into the content with SQL.** Every read path in `app-history.md` — the
   stub label, the diff detail screen, "since you installed it" — loads one section's content for one
   snapshot (or two, to diff) and works with it as a deserialized Kotlin object. Row-level SQL

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 kotlin = "2.4.10"
 ksp = "2.3.11"
 kotlinx-collections-immutable = "0.5.2"
-kotlinx-serialization = "1.7.3"
+kotlinx-serialization = "1.11.0"
 
 # Android
 agp = "9.3.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@
 kotlin = "2.4.10"
 ksp = "2.3.11"
 kotlinx-collections-immutable = "0.5.2"
+kotlinx-serialization = "1.7.3"
 
 # Android
 agp = "9.3.2"
@@ -100,6 +101,8 @@ firebase-performance = { module = "com.google.firebase:firebase-perf" }
 
 # Kotlin
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }
+kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 
 # Persistence
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,6 +32,7 @@ include(
     ":core:app-functions",
     ":core:ai-insights",
     ":core:app-index",
+    ":core:app-history",
     ":core:common",
     ":core:user-preferences",
     ":core:ui-library",


### PR DESCRIPTION
## Summary
- New `core:app-history` module: a Room-backed, content-addressed store that captures full app state (permissions, components, signing, native libraries, signing scheme, installed splits) per install instance.
- Schema: `AppHistorySnapshotEntity` (one append-only row per captured install instance, identity enforced via a unique index on `packageName` + `lastUpdateTime` + `firstInstallTime`) and `AppHistoryBlobEntity` (content-addressed section JSON, deduplicated per package).
- Capture pipeline: `AppHistoryCaptureRepository` gates capture on install/update time change, concurrently fetches app detail, intent filters, native libraries, and signing scheme, hashes each section, and writes atomically. Own wire-format DTOs in `capture/snapshot/` decouple stored history from `core:apps` domain types, so a later rename/retype of a domain field never breaks deserialization of historical data.
- Two triggers via `AppHistoryCaptureSchedulerImpl`: a one-time reconciliation sweep at app start and a fast broadcast path. `PackageChangesObserver` (`core:apps`) is extended to carry the changed package name and action, and its `BroadcastReceiver` is now shared across all consumers via `shareIn(..., SharingStarted.WhileSubscribed())` instead of each consumer registering its own.
- `DeviceIdProvider` (`core:common/device`) extracts device-ID resolution out of the capture repository behind a small platform adapter.
- Fixed a DN-parsing regression found during review in `CertificateExtractorImpl` (escape-aware parser was replaced with a fragile per-field regex).

## Test plan
- [x] `:core:app-history:compileDebugKotlin`, `:core:apps:compileDebugKotlin`, `:app:assembleDebug` all clean
- [x] `spotlessApply` run
- [x] On-device verification (physical device): reconciliation sweep captured 498 snapshot rows across 483 packages; 15 packages show a correctly captured update (2 rows, differing timestamps)
- [x] Verified content-addressed dedup directly: two installs of an identical APK (`pl.jmpolska.clos0.mojabiedronka`, same versionCode/versionName, different install timestamps) produced 2 snapshot rows sharing all 11 section hashes, backed by exactly 11 blob rows (not 22) — confirming `OnConflictStrategy.IGNORE` dedup works as designed
- [ ] Fast-path broadcast trigger not independently exercised on-device (`ACTION_PACKAGE_REPLACED` is a protected broadcast `adb shell am broadcast` cannot send); reconciliation is the correctness backstop for this, per the design doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)